### PR TITLE
test: add missing unit tests for utility-function edge cases (#55)

### DIFF
--- a/tests/copilot_usage/test_cli.py
+++ b/tests/copilot_usage/test_cli.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import threading
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
@@ -11,6 +12,7 @@ from click.testing import CliRunner
 from rich.console import Console
 
 from copilot_usage.cli import (
+    _ensure_aware,  # pyright: ignore[reportPrivateUsage]
     _show_session_by_index,  # pyright: ignore[reportPrivateUsage]
     _start_observer,  # pyright: ignore[reportPrivateUsage]
     _stop_observer,  # pyright: ignore[reportPrivateUsage]
@@ -586,3 +588,59 @@ class TestFileChangeHandler:
         handler._last_trigger = _time.monotonic() - 3.0  # pyright: ignore[reportPrivateUsage]
         handler.dispatch(object())
         assert event.is_set()
+
+
+# ---------------------------------------------------------------------------
+# Issue #55 — _ensure_aware unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestEnsureAware:
+    """Direct tests for _ensure_aware helper."""
+
+    def test_none_passes_through(self) -> None:
+        """None input returns None."""
+        assert _ensure_aware(None) is None
+
+    def test_aware_datetime_unchanged(self) -> None:
+        """Already-aware datetime is returned as-is (identity check)."""
+        dt_aware = datetime(2026, 1, 1, tzinfo=UTC)
+        assert _ensure_aware(dt_aware) is dt_aware
+
+    def test_naive_datetime_gets_utc(self) -> None:
+        """Naïve datetime gets UTC tzinfo attached."""
+        dt_naive = datetime(2026, 1, 1)
+        result = _ensure_aware(dt_naive)
+        assert result is not None
+        assert result.tzinfo == UTC
+        assert result.replace(tzinfo=None) == dt_naive
+
+
+# ---------------------------------------------------------------------------
+# Issue #55 — uppercase interactive commands (Q, C, R)
+# ---------------------------------------------------------------------------
+
+
+def test_interactive_quit_uppercase(tmp_path: Path) -> None:
+    """Uppercase 'Q' quits the interactive loop."""
+    _write_session(tmp_path, "up-q0000-0000-0000-0000-000000000000", name="UpQ")
+    runner = CliRunner()
+    result = runner.invoke(main, ["--path", str(tmp_path)], input="Q\n")
+    assert result.exit_code == 0
+
+
+def test_interactive_cost_uppercase(tmp_path: Path) -> None:
+    """Uppercase 'C' opens cost view, then 'Q' exits."""
+    _write_session(tmp_path, "up-c0000-0000-0000-0000-000000000000", name="UpC")
+    runner = CliRunner()
+    result = runner.invoke(main, ["--path", str(tmp_path)], input="C\nQ\n")
+    assert result.exit_code == 0
+    assert "Cost" in result.output
+
+
+def test_interactive_refresh_uppercase(tmp_path: Path) -> None:
+    """Uppercase 'R' refreshes and loop continues without error."""
+    _write_session(tmp_path, "up-r0000-0000-0000-0000-000000000000", name="UpR")
+    runner = CliRunner()
+    result = runner.invoke(main, ["--path", str(tmp_path)], input="R\nQ\n")
+    assert result.exit_code == 0

--- a/tests/copilot_usage/test_parser.py
+++ b/tests/copilot_usage/test_parser.py
@@ -31,6 +31,8 @@ from copilot_usage.models import (
 )
 from copilot_usage.parser import (
     _extract_session_name,
+    _infer_model_from_metrics,
+    _read_config_model,
     build_session_summary,
     discover_sessions,
     get_all_sessions,
@@ -2035,3 +2037,81 @@ class TestGetAllSessionsOsError:
 
         assert len(results) == 1
         assert results[0].session_id == "sess-b"
+
+
+# ---------------------------------------------------------------------------
+# Issue #55 — _read_config_model OSError branch
+# ---------------------------------------------------------------------------
+
+
+class TestReadConfigModelOsError:
+    """Test that _read_config_model returns None when read_text raises OSError."""
+
+    def test_oserror_returns_none(self, tmp_path: Path) -> None:
+        """Existing file that raises OSError on read → returns None."""
+        config = tmp_path / "config.json"
+        config.write_text('{"model": "claude-sonnet-4"}', encoding="utf-8")
+
+        original_read_text = Path.read_text
+
+        def _raise_os_error(self: Path, *args: object, **kwargs: object) -> str:
+            if self == config:
+                raise OSError("permission denied")
+            return original_read_text(self, *args, **kwargs)  # type: ignore[arg-type]
+
+        with patch.object(Path, "read_text", _raise_os_error):
+            result = _read_config_model(config)
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Issue #55 — _infer_model_from_metrics tie behaviour
+# ---------------------------------------------------------------------------
+
+
+class TestInferModelFromMetricsTie:
+    """Tests for _infer_model_from_metrics when models have equal request counts."""
+
+    def test_equal_counts_returns_a_candidate(self) -> None:
+        """Two models with equal counts → returns one of them (no crash)."""
+        metrics = {
+            "model-a": ModelMetrics(
+                requests=RequestMetrics(count=5, cost=5),
+                usage=TokenUsage(outputTokens=100),
+            ),
+            "model-b": ModelMetrics(
+                requests=RequestMetrics(count=5, cost=5),
+                usage=TokenUsage(outputTokens=200),
+            ),
+        }
+        result = _infer_model_from_metrics(metrics)
+        assert result in ("model-a", "model-b")
+
+    def test_equal_counts_deterministic(self) -> None:
+        """Tied counts → result is deterministic (first in insertion order)."""
+        metrics = {
+            "model-a": ModelMetrics(
+                requests=RequestMetrics(count=5, cost=5),
+                usage=TokenUsage(outputTokens=100),
+            ),
+            "model-b": ModelMetrics(
+                requests=RequestMetrics(count=5, cost=5),
+                usage=TokenUsage(outputTokens=200),
+            ),
+        }
+        # Python dict insertion order is stable; max() returns first max key
+        assert _infer_model_from_metrics(metrics) == "model-a"
+
+    def test_strictly_higher_count_wins(self) -> None:
+        """One model with strictly higher count → always returned."""
+        metrics = {
+            "model-a": ModelMetrics(
+                requests=RequestMetrics(count=3, cost=3),
+                usage=TokenUsage(outputTokens=100),
+            ),
+            "model-b": ModelMetrics(
+                requests=RequestMetrics(count=10, cost=10),
+                usage=TokenUsage(outputTokens=200),
+            ),
+        }
+        assert _infer_model_from_metrics(metrics) == "model-b"


### PR DESCRIPTION
Closes #55

Adds dedicated unit tests for four untested utility-function edge cases identified in the test audit:

### 1. `_ensure_aware` in `cli.py`
- `None` input passes through unchanged
- Already-aware `datetime` returned as-is (identity)
- Naïve `datetime` gets UTC `tzinfo` attached

### 2. Uppercase interactive commands (`Q`, `C`, `R`)
- `Q` quits the interactive loop
- `C` opens cost view, then `Q` exits
- `R` refreshes data, loop continues without error

### 3. `_read_config_model` — `OSError` branch
- Mocks `Path.read_text` to raise `OSError` (simulating permission denied)
- Asserts the function returns `None`

### 4. `_infer_model_from_metrics` — equal-count tie behaviour
- Two models with equal `requests.count` → returns one of the candidates (no crash)
- Verifies deterministic tie-break (first in insertion order)
- One model with strictly higher count → that model is always returned

All 390 tests pass, ruff/pyright clean, coverage at 96.64%.




> Generated by [Issue Implementer](https://github.com/microsasa/cli-tools/actions/runs/23103543591) · [◷](https://github.com/search?q=repo%3Amicrosasa%2Fcli-tools+%22gh-aw-workflow-id%3A+issue-implementer%22&type=pullrequests)

> [!WARNING]
> <details>
> <summary>⚠️ Firewall blocked 1 domain</summary>
>
> The following domain was blocked by the firewall during workflow execution:
>
> - `astral.sh`
>
> To allow these domains, add them to the `network.allowed` list in your workflow frontmatter:
>
> ```yaml
> network:
>   allowed:
>     - defaults
>     - "astral.sh"
> ```
>
> See [Network Configuration](https://github.github.com/gh-aw/reference/network/) for more information.
>
> </details>


<!-- gh-aw-agentic-workflow: Issue Implementer, engine: copilot, model: claude-opus-4.6, id: 23103543591, workflow_id: issue-implementer, run: https://github.com/microsasa/cli-tools/actions/runs/23103543591 -->

<!-- gh-aw-workflow-id: issue-implementer -->