### PR TITLE
fix: allow Copilot reviewer bot to trigger review-responder and quality-gate

### DIFF
--- a/.github/workflows/quality-gate.lock.yml
+++ b/.github/workflows/quality-gate.lock.yml
@@ -22,7 +22,7 @@
 # For more information: https://github.github.com/gh-aw/introduction/overview/
 #
 #
-# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"dc166a6992cc5ffedd8f50bf687351344ccea3cb0cafe99f3b86ccd6534a2264","compiler_version":"v0.58.1","strict":true}
+# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"ddc05091f49326139f57d76d51f5e1ffe03bb0a8641f3429620707b82986dede","compiler_version":"v0.58.1","strict":true}
 
 name: "Quality Gate"
 "on":

--- a/.github/workflows/quality-gate.md
+++ b/.github/workflows/quality-gate.md
@@ -3,6 +3,8 @@ on:
   pull_request_review:
     types: [submitted]
 
+bots: [copilot-pull-request-reviewer]
+
 permissions:
   contents: read
   issues: read

--- a/.github/workflows/review-responder.lock.yml
+++ b/.github/workflows/review-responder.lock.yml
@@ -22,7 +22,7 @@
 # For more information: https://github.github.com/gh-aw/introduction/overview/
 #
 #
-# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"73fd3124dd5f5623cfc4b6273a3cdc0f1cd113a836c9543b0fa8bf1f9d92067d","compiler_version":"v0.58.1","strict":true}
+# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"f329f5594237e4fd0f76a7084061068ff2df6b6b4f8923e1c36854073ae4af63","compiler_version":"v0.58.1","strict":true}
 
 name: "Review Responder"
 "on":

--- a/.github/workflows/review-responder.md
+++ b/.github/workflows/review-responder.md
@@ -3,6 +3,8 @@ on:
   pull_request_review:
     types: [submitted]
 
+bots: [copilot-pull-request-reviewer]
+
 permissions:
   contents: read
   issues: read


### PR DESCRIPTION
The pre_activation gate checks github.actor role (admin/maintainer/write). When Copilot reviewer submits a review, it's the actor but not a repo collaborator, so activation fails with action_required.

Fix: add `bots: [copilot-pull-request-reviewer]` to both workflows so the Copilot bot bypasses the role check.