### PR TITLE
fix: correct bots: placement under on: for agent activation

### DIFF
--- a/.github/workflows/quality-gate.lock.yml
+++ b/.github/workflows/quality-gate.lock.yml
@@ -22,10 +22,12 @@
 # For more information: https://github.github.com/gh-aw/introduction/overview/
 #
 #
-# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"ddc05091f49326139f57d76d51f5e1ffe03bb0a8641f3429620707b82986dede","compiler_version":"v0.58.1","strict":true}
+# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"647d1032017ffb27629b128c73d927ea4e89450a4076e7f85b72d1209d2ff086","compiler_version":"v0.58.1","strict":true}
 
 name: "Quality Gate"
 "on":
+  # bots: # Bots processed as bot check in pre-activation job
+  # - copilot-pull-request-reviewer # Bots processed as bot check in pre-activation job
   pull_request_review:
     types:
     - submitted
@@ -109,6 +111,8 @@ jobs:
       - name: Compute current body text
         id: sanitized
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        env:
+          GH_AW_ALLOWED_BOTS: copilot-pull-request-reviewer
         with:
           script: |
             const { setupGlobals } = require('/opt/gh-aw/actions/setup_globals.cjs');
@@ -1109,6 +1113,7 @@ jobs:
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         env:
           GH_AW_REQUIRED_ROLES: admin,maintainer,write
+          GH_AW_ALLOWED_BOTS: copilot-pull-request-reviewer
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/quality-gate.md
+++ b/.github/workflows/quality-gate.md
@@ -2,8 +2,7 @@
 on:
   pull_request_review:
     types: [submitted]
-
-bots: [copilot-pull-request-reviewer]
+  bots: [copilot-pull-request-reviewer]
 
 permissions:
   contents: read

--- a/.github/workflows/review-responder.lock.yml
+++ b/.github/workflows/review-responder.lock.yml
@@ -22,10 +22,12 @@
 # For more information: https://github.github.com/gh-aw/introduction/overview/
 #
 #
-# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"f329f5594237e4fd0f76a7084061068ff2df6b6b4f8923e1c36854073ae4af63","compiler_version":"v0.58.1","strict":true}
+# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"2e65899aae74e70bf5713c338461409a657ef2cb0e8a398496baa554fa51d636","compiler_version":"v0.58.1","strict":true}
 
 name: "Review Responder"
 "on":
+  # bots: # Bots processed as bot check in pre-activation job
+  # - copilot-pull-request-reviewer # Bots processed as bot check in pre-activation job
   pull_request_review:
     types:
     - submitted
@@ -109,6 +111,8 @@ jobs:
       - name: Compute current body text
         id: sanitized
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        env:
+          GH_AW_ALLOWED_BOTS: copilot-pull-request-reviewer
         with:
           script: |
             const { setupGlobals } = require('/opt/gh-aw/actions/setup_globals.cjs');
@@ -1209,6 +1213,7 @@ jobs:
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         env:
           GH_AW_REQUIRED_ROLES: admin,maintainer,write
+          GH_AW_ALLOWED_BOTS: copilot-pull-request-reviewer
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/review-responder.md
+++ b/.github/workflows/review-responder.md
@@ -2,8 +2,7 @@
 on:
   pull_request_review:
     types: [submitted]
-
-bots: [copilot-pull-request-reviewer]
+  bots: [copilot-pull-request-reviewer]
 
 permissions:
   contents: read


### PR DESCRIPTION
Closes #70
Related: #53

## Problem

PR #64 added `bots: [copilot-pull-request-reviewer]` at the **top level** of the frontmatter in `review-responder.md` and `quality-gate.md`. The gh-aw compiler accepted this silently but **did not emit** `GH_AW_ALLOWED_BOTS` into the compiled lock files. Result: the `pre_activation` gate still checked only `GH_AW_REQUIRED_ROLES: admin,maintainer,write`, and the Copilot reviewer bot (which has no repo role) was blocked.

## How check_membership.cjs works

From the gh-aw source (`check_membership.test.cjs`):
1. Role check runs first — checks actor's repo permission against `GH_AW_REQUIRED_ROLES`
2. If role check fails, falls back to `GH_AW_ALLOWED_BOTS`
3. If actor is in the allowed bots list AND the bot is active/installed on the repo → `authorized_bot`

So `GH_AW_ALLOWED_BOTS` in the lock file is sufficient — no `roles: all` needed.

## What this PR does

Moves `bots:` from top-level to under `on:` in both workflows:

### Before (PR #64 — no effect):
```yaml
on:
  pull_request_review:
    types: [submitted]

bots: [copilot-pull-request-reviewer]  # top-level — compiler ignores
```
Lock file: `GH_AW_REQUIRED_ROLES: admin,maintainer,write` only.

### After (this PR):
```yaml
on:
  pull_request_review:
    types: [submitted]
  bots: [copilot-pull-request-reviewer]  # under on: — compiles correctly
```
Lock file: `GH_AW_REQUIRED_ROLES: admin,maintainer,write` + `GH_AW_ALLOWED_BOTS: copilot-pull-request-reviewer`.

## Companion repo setting change

This PR alone is not sufficient. GitHub Actions also has its own approval gate (`action_required`) for outside contributors that blocks workflow runs before any jobs execute. The repo setting "Approval for running fork pull request workflows" was changed to "Require approval for first-time contributors who are new to GitHub" (least restrictive option that still blocks suspicious new accounts). Additionally, "Allow GitHub Actions to create and approve pull requests" was enabled for the quality-gate agent to submit approval reviews.