### PR TITLE
fix: code quality cleanups in report.py and models.py (#66)

### DIFF
--- a/src/copilot_usage/models.py
+++ b/src/copilot_usage/models.py
@@ -123,9 +123,7 @@ class AssistantMessageData(BaseModel):
     interactionId: str = ""
     reasoningText: str | None = None
     reasoningOpaque: str | None = None
-    toolRequests: list[dict[str, object]] = Field(
-        default_factory=lambda: list[dict[str, object]]()
-    )
+    toolRequests: list[dict[str, object]] = Field(default_factory=lambda: [])
 
 
 class SessionShutdownData(BaseModel):

--- a/src/copilot_usage/report.py
+++ b/src/copilot_usage/report.py
@@ -111,6 +111,17 @@ def _estimated_output_tokens(session: SessionSummary) -> int:
     return sum(m.usage.outputTokens for m in session.model_metrics.values())
 
 
+def _format_session_running_time(session: SessionSummary) -> str:
+    """Return a human-readable running time for *session*.
+
+    Uses ``last_resume_time`` if available, otherwise ``start_time``.
+    Returns ``"—"`` when the session has no start time.
+    """
+    if session.start_time:
+        return _format_elapsed_since(session.last_resume_time or session.start_time)
+    return "—"
+
+
 def render_live_sessions(sessions: list[SessionSummary]) -> None:
     """Render overview of active sessions only.
 
@@ -144,11 +155,7 @@ def render_live_sessions(sessions: list[SessionSummary]) -> None:
         short_id = s.session_id[:8] if s.session_id else "—"
         name = s.name or "—"
         model = s.model or "—"
-        running = (
-            _format_elapsed_since(s.last_resume_time or s.start_time)
-            if s.start_time
-            else "—"
-        )
+        running = _format_session_running_time(s)
         messages = str(s.user_messages)
         tokens = f"{_estimated_output_tokens(s):,}"
         cwd = s.cwd or "—"
@@ -580,10 +587,9 @@ def _render_totals(console: Console, sessions: list[SessionSummary]) -> None:
     total_duration = sum(s.total_api_duration_ms for s in sessions)
     total_sessions = len(sessions)
 
-    total_output = 0
-    for s in sessions:
-        for mm in s.model_metrics.values():
-            total_output += mm.usage.outputTokens
+    total_output = sum(
+        mm.usage.outputTokens for s in sessions for mm in s.model_metrics.values()
+    )
 
     pr_label = "premium request" if total_premium == 1 else "premium requests"
     session_label = "session" if total_sessions == 1 else "sessions"
@@ -788,11 +794,7 @@ def _render_active_section(
     for s in active:
         name = s.name or s.session_id[:12]
         model = s.model or "—"
-        running = (
-            _format_elapsed_since(s.last_resume_time or s.start_time)
-            if s.start_time
-            else "—"
-        )
+        running = _format_session_running_time(s)
 
         table.add_row(
             name,
@@ -847,9 +849,9 @@ def render_cost_view(
     for premium and the active model calls / output tokens.
     """
     console = target_console or Console()
-    sessions = _filter_sessions(sessions, since, until)
+    filtered = _filter_sessions(sessions, since, until)
 
-    if not sessions:
+    if not filtered:
         console.print("[yellow]No sessions found.[/yellow]")
         return
 
@@ -866,7 +868,7 @@ def render_cost_view(
     grand_model_calls = 0
     grand_output = 0
 
-    for s in sessions:
+    for s in filtered:
         name = s.name or s.session_id[:12]
         model_calls_display = str(s.model_calls)
 

--- a/tests/copilot_usage/test_report.py
+++ b/tests/copilot_usage/test_report.py
@@ -26,7 +26,9 @@ from copilot_usage.report import (
     _event_type_label,
     _filter_sessions,
     _format_detail_duration,
+    _format_elapsed_since,
     _format_relative_time,
+    _format_session_running_time,
     format_duration,
     format_tokens,
     render_cost_view,
@@ -1661,3 +1663,31 @@ class TestRenderTotalsSingularLabels:
         # "session" appears without trailing 's'
         stripped = output.replace("sessions", "")
         assert "session" in stripped
+
+
+# ---------------------------------------------------------------------------
+# Issue #66 — _format_session_running_time helper
+# ---------------------------------------------------------------------------
+
+
+class TestFormatSessionRunningTime:
+    """Tests for the extracted _format_session_running_time helper."""
+
+    def test_returns_dash_when_start_time_is_none(self) -> None:
+        session = SessionSummary(session_id="no-start")
+        assert _format_session_running_time(session) == "—"
+
+    def test_uses_start_time_when_no_last_resume(self) -> None:
+        start = datetime.now(tz=UTC) - timedelta(minutes=5, seconds=30)
+        session = SessionSummary(session_id="with-start", start_time=start)
+        result = _format_session_running_time(session)
+        assert result == _format_elapsed_since(start)
+
+    def test_uses_last_resume_time_when_present(self) -> None:
+        start = datetime.now(tz=UTC) - timedelta(hours=2)
+        resume = datetime.now(tz=UTC) - timedelta(minutes=10)
+        session = SessionSummary(
+            session_id="with-resume", start_time=start, last_resume_time=resume
+        )
+        result = _format_session_running_time(session)
+        assert result == _format_elapsed_since(resume)


### PR DESCRIPTION
Closes #66

## Changes

### 1. Extract `_format_session_running_time` helper (`report.py`)
The 4-line running-time expression was duplicated in `render_live_sessions` and `_render_active_section`. Extracted into a private helper `_format_session_running_time(session)` called from both sites.

### 2. Fix parameter shadowing in `render_cost_view` (`report.py`)
Renamed the reassignment `sessions = _filter_sessions(...)` to `filtered = _filter_sessions(...)` and updated all internal references, consistent with other filtering functions.

### 3. Standardize output-token summation in `_render_totals` (`report.py`)
Replaced the nested `for` loop with the same comprehension form used by `_render_historical_section`.

### 4. Simplify `default_factory` in `AssistantMessageData.toolRequests` (`models.py`)
Changed `default_factory=lambda: list[dict[str, object]]()` to `default_factory=lambda: []` — the generic subscript was erased at runtime and was misleading.

## Tests
- Added `TestFormatSessionRunningTime` with 3 test cases covering: `start_time is None` → returns `"—"`, `start_time` without `last_resume_time`, and `last_resume_time` present.
- All 383 existing tests pass, 97% coverage.




> Generated by [Issue Implementer](https://github.com/microsasa/cli-tools/actions/runs/23111477801) · [◷](https://github.com/search?q=repo%3Amicrosasa%2Fcli-tools+%22gh-aw-workflow-id%3A+issue-implementer%22&type=pullrequests)

> [!WARNING]
> <details>
> <summary>⚠️ Firewall blocked 1 domain</summary>
>
> The following domain was blocked by the firewall during workflow execution:
>
> - `astral.sh`
>
> To allow these domains, add them to the `network.allowed` list in your workflow frontmatter:
>
> ```yaml
> network:
>   allowed:
>     - defaults
>     - "astral.sh"
> ```
>
> See [Network Configuration](https://github.github.com/gh-aw/reference/network/) for more information.
>
> </details>


<!-- gh-aw-agentic-workflow: Issue Implementer, engine: copilot, model: claude-opus-4.6, id: 23111477801, workflow_id: issue-implementer, run: https://github.com/microsasa/cli-tools/actions/runs/23111477801 -->

<!-- gh-aw-workflow-id: issue-implementer -->