### PR TITLE
fix: inherit _FileChangeHandler from FileSystemEventHandler (#67)

### DIFF
--- a/src/copilot_usage/cli.py
+++ b/src/copilot_usage/cli.py
@@ -16,6 +16,7 @@ from pathlib import Path
 import click
 from rich.console import Console
 from rich.table import Table
+from watchdog.events import FileSystemEventHandler  # type: ignore[import-untyped]
 from watchdog.observers import Observer  # type: ignore[import-untyped]
 
 from copilot_usage.models import SessionSummary
@@ -114,14 +115,15 @@ def _read_line_nonblocking(timeout: float = 0.5) -> str | None:
     return None
 
 
-class _FileChangeHandler:
+class _FileChangeHandler(FileSystemEventHandler):  # type: ignore[misc]
     """Watchdog handler that triggers refresh on any session-state change."""
 
     def __init__(self, change_event: threading.Event) -> None:
+        super().__init__()
         self._change_event = change_event
         self._last_trigger = 0.0
 
-    def dispatch(self, event: object) -> None:  # noqa: ANN001
+    def dispatch(self, event: object) -> None:
         now = time.monotonic()
         if now - self._last_trigger > 2.0:  # debounce 2s
             self._last_trigger = now
@@ -132,7 +134,7 @@ def _start_observer(session_path: Path, change_event: threading.Event) -> object
     """Start a watchdog observer monitoring *session_path* for changes."""
     handler = _FileChangeHandler(change_event)
     observer = Observer()
-    observer.schedule(handler, str(session_path), recursive=True)  # type: ignore[arg-type]
+    observer.schedule(handler, str(session_path), recursive=True)
     observer.daemon = True
     observer.start()
     return observer

--- a/tests/copilot_usage/test_cli.py
+++ b/tests/copilot_usage/test_cli.py
@@ -586,3 +586,19 @@ class TestFileChangeHandler:
         handler._last_trigger = _time.monotonic() - 3.0  # pyright: ignore[reportPrivateUsage]
         handler.dispatch(object())
         assert event.is_set()
+
+    def test_inherits_from_filesystemeventhandler(self) -> None:
+        """_FileChangeHandler inherits from watchdog FileSystemEventHandler."""
+        from watchdog.events import (
+            FileSystemEventHandler,  # type: ignore[import-untyped]
+        )
+
+        from copilot_usage.cli import (
+            _FileChangeHandler,  # pyright: ignore[reportPrivateUsage]
+        )
+
+        event = threading.Event()
+        handler = _FileChangeHandler(event)
+        assert isinstance(handler, FileSystemEventHandler)
+        handler.dispatch(object())
+        assert event.is_set()


### PR DESCRIPTION
## Summary

`_FileChangeHandler` now properly inherits from `watchdog.events.FileSystemEventHandler` instead of relying on duck typing.

## Changes

- **`src/copilot_usage/cli.py`**:
  - Import `FileSystemEventHandler` from `watchdog.events`
  - `_FileChangeHandler` inherits from `FileSystemEventHandler`
  - Added `super().__init__()` call
  - Removed `# noqa: ANN001` from `dispatch`
  - Removed `# type: ignore[arg-type]` from `observer.schedule()`

- **`tests/copilot_usage/test_cli.py`**:
  - Added `test_inherits_from_filesystemeventhandler` verifying `isinstance` check and dispatch behavior

## Verification

All CI checks pass locally:
- `ruff check` ✅
- `ruff format` ✅
- `pyright` — 0 errors ✅
- `pytest` — 381 passed, 96.65% coverage ✅

Closes #67




> Generated by [Issue Implementer](https://github.com/microsasa/cli-tools/actions/runs/23111479400) · [◷](https://github.com/search?q=repo%3Amicrosasa%2Fcli-tools+%22gh-aw-workflow-id%3A+issue-implementer%22&type=pullrequests)

> [!WARNING]
> <details>
> <summary>⚠️ Firewall blocked 1 domain</summary>
>
> The following domain was blocked by the firewall during workflow execution:
>
> - `astral.sh`
>
> To allow these domains, add them to the `network.allowed` list in your workflow frontmatter:
>
> ```yaml
> network:
>   allowed:
>     - defaults
>     - "astral.sh"
> ```
>
> See [Network Configuration](https://github.github.com/gh-aw/reference/network/) for more information.
>
> </details>


<!-- gh-aw-agentic-workflow: Issue Implementer, engine: copilot, model: claude-opus-4.6, id: 23111479400, workflow_id: issue-implementer, run: https://github.com/microsasa/cli-tools/actions/runs/23111479400 -->

<!-- gh-aw-workflow-id: issue-implementer -->