### PR TITLE
test: add coverage for pure active session with no model_metrics (#78)

### DIFF
--- a/tests/copilot_usage/test_report.py
+++ b/tests/copilot_usage/test_report.py
@@ -1347,6 +1347,8 @@ class TestRenderCostView:
 
     def test_pure_active_no_metrics_grand_total_includes_active_tokens(self) -> None:
         """Grand total output tokens includes active_output_tokens for no-metrics active session."""
+        import re
+
         session = SessionSummary(
             session_id="pure-active-5678",
             name="Token Check",
@@ -1359,9 +1361,13 @@ class TestRenderCostView:
             active_output_tokens=1500,
         )
         output = _capture_cost_view([session])
-        assert "Grand Total" in output
-        # 1500 output tokens → formatted as "1.5K"
-        assert "1.5K" in output
+        clean = re.sub(r"\x1b\[[0-9;]*m", "", output)
+        # Extract Grand Total row's last column (output tokens)
+        grand_match = re.search(
+            r"Grand Total\s*│[^│]*│\s*\d+\s*│\s*\d+\s*│\s*\d+\s*│\s*(\S+)\s*│", clean
+        )
+        assert grand_match is not None, "Grand Total row not found"
+        assert grand_match.group(1) == "1.5K"
 
 
 class TestRenderFullSummaryHelperReuse:


### PR DESCRIPTION
## Summary

Adds two missing tests to `TestRenderCostView` that exercise the **branch A + branch B** combination in `render_cost_view` — a session where `model_metrics={}` (no shutdown data) **and** `is_active=True` (just started).

### Tests added

| Test | Assertion |
|------|-----------|
| `test_pure_active_session_no_metrics_shows_both_rows` | Placeholder row (`—`) AND `↳ Since last shutdown` row both appear |
| `test_pure_active_no_metrics_grand_total_includes_active_tokens` | Grand total output tokens includes `active_output_tokens` (formatted as `1.5K`) |

### Regression coverage

These tests guard against:
- Accidentally nesting `if s.is_active:` inside `if s.model_metrics:`, which would silently lose the "Since last shutdown" row for pure-active sessions
- Removing `grand_output += s.active_output_tokens` from the active block, which would under-count output tokens

### CI

All 382 tests pass. Coverage: 96.64% (threshold: 80%).

Closes #78




> Generated by [Issue Implementer](https://github.com/microsasa/cli-tools/actions/runs/23115799412) · [◷](https://github.com/search?q=repo%3Amicrosasa%2Fcli-tools+%22gh-aw-workflow-id%3A+issue-implementer%22&type=pullrequests)

> [!WARNING]
> <details>
> <summary>⚠️ Firewall blocked 1 domain</summary>
>
> The following domain was blocked by the firewall during workflow execution:
>
> - `astral.sh`
>
> To allow these domains, add them to the `network.allowed` list in your workflow frontmatter:
>
> ```yaml
> network:
>   allowed:
>     - defaults
>     - "astral.sh"
> ```
>
> See [Network Configuration](https://github.github.com/gh-aw/reference/network/) for more information.
>
> </details>


<!-- gh-aw-agentic-workflow: Issue Implementer, engine: copilot, model: claude-opus-4.6, id: 23115799412, workflow_id: issue-implementer, run: https://github.com/microsasa/cli-tools/actions/runs/23115799412 -->

<!-- gh-aw-workflow-id: issue-implementer -->