### PR TITLE
test: add coverage for pure active session with no model_metrics (#78)

### DIFF
--- a/tests/copilot_usage/test_report.py
+++ b/tests/copilot_usage/test_report.py
@@ -1325,6 +1325,44 @@ class TestRenderCostView:
         assert grand_match is not None, "Grand Total row not found"
         assert grand_match.group(1) == "10"
 
+    def test_pure_active_session_no_metrics_shows_both_rows(self) -> None:
+        """Active session with no model_metrics shows placeholder row AND Since-last-shutdown row."""
+        session = SessionSummary(
+            session_id="pure-active-1234",
+            name="Just Started",
+            model="claude-sonnet-4",
+            start_time=datetime(2025, 1, 15, 10, 0, tzinfo=UTC),
+            is_active=True,
+            model_calls=2,
+            user_messages=1,
+            active_model_calls=2,
+            active_output_tokens=300,
+            # model_metrics intentionally empty
+        )
+        output = _capture_cost_view([session])
+        assert "Just Started" in output
+        assert "—" in output  # placeholder row (no metrics)
+        assert "Since last shutdown" in output  # active row
+        assert "N/A" in output
+
+    def test_pure_active_no_metrics_grand_total_includes_active_tokens(self) -> None:
+        """Grand total output tokens includes active_output_tokens for no-metrics active session."""
+        session = SessionSummary(
+            session_id="pure-active-5678",
+            name="Token Check",
+            model="claude-sonnet-4",
+            start_time=datetime(2025, 1, 15, 10, 0, tzinfo=UTC),
+            is_active=True,
+            model_calls=1,
+            user_messages=1,
+            active_model_calls=1,
+            active_output_tokens=1500,
+        )
+        output = _capture_cost_view([session])
+        assert "Grand Total" in output
+        # 1500 output tokens → formatted as "1.5K"
+        assert "1.5K" in output
+
 
 class TestRenderFullSummaryHelperReuse:
     """Verify _render_historical_section delegates to shared table helpers."""


### PR DESCRIPTION
Closes #78

## What

Adds two tests to `TestRenderCostView` in `tests/copilot_usage/test_report.py` that exercise the previously untested branch combination where `model_metrics={}` **and** `is_active=True` (branch A + branch B).

## Tests added

| Test | Asserts |
|------|---------|
| `test_pure_active_session_no_metrics_shows_both_rows` | Placeholder row with "—" appears (branch A) **and** "↳ Since last shutdown" row appears (branch B), including "N/A" for premium columns |
| `test_pure_active_no_metrics_grand_total_includes_active_tokens` | Grand total output tokens includes `active_output_tokens` — 1500 tokens formatted as "1.5K" |

## Verification

- All 383 tests pass
- Coverage: 96.65% (well above the 80% threshold)
- `ruff check`, `ruff format`, `pyright` all clean




> Generated by [Issue Implementer](https://github.com/microsasa/cli-tools/actions/runs/23116463531) · [◷](https://github.com/search?q=repo%3Amicrosasa%2Fcli-tools+%22gh-aw-workflow-id%3A+issue-implementer%22&type=pullrequests)

> [!WARNING]
> <details>
> <summary>⚠️ Firewall blocked 1 domain</summary>
>
> The following domain was blocked by the firewall during workflow execution:
>
> - `astral.sh`
>
> To allow these domains, add them to the `network.allowed` list in your workflow frontmatter:
>
> ```yaml
> network:
>   allowed:
>     - defaults
>     - "astral.sh"
> ```
>
> See [Network Configuration](https://github.github.com/gh-aw/reference/network/) for more information.
>
> </details>


<!-- gh-aw-agentic-workflow: Issue Implementer, engine: copilot, model: claude-opus-4.6, id: 23116463531, workflow_id: issue-implementer, run: https://github.com/microsasa/cli-tools/actions/runs/23116463531 -->

<!-- gh-aw-workflow-id: issue-implementer -->