### PR TITLE
fix: gate agent workflows on aw label

### DIFF
--- a/.github/workflows/quality-gate.lock.yml
+++ b/.github/workflows/quality-gate.lock.yml
@@ -22,7 +22,7 @@
 # For more information: https://github.github.com/gh-aw/introduction/overview/
 #
 #
-# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"51b7c0f46336464fcff657fb3d3e63ff0c9f9b4a578b0d86b63f251df8bd6434","compiler_version":"v0.58.1","strict":true}
+# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"15df3ac9ea802b32be49f9486f73a665c2e27c493cb502a1c8f1e1aac1d9b8a9","compiler_version":"v0.58.1","strict":true}
 
 name: "Quality Gate"
 "on":
@@ -44,6 +44,7 @@ run-name: "Quality Gate"
 
 jobs:
   activation:
+    if: contains(github.event.pull_request.labels.*.name, 'aw')
     runs-on: ubuntu-slim
     permissions:
       contents: read

--- a/.github/workflows/quality-gate.md
+++ b/.github/workflows/quality-gate.md
@@ -1,4 +1,5 @@
 ---
+if: "contains(github.event.pull_request.labels.*.name, 'aw')"
 on:
   pull_request_review:
     types: [submitted]

--- a/.github/workflows/review-responder.lock.yml
+++ b/.github/workflows/review-responder.lock.yml
@@ -22,7 +22,7 @@
 # For more information: https://github.github.com/gh-aw/introduction/overview/
 #
 #
-# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"e1defa99f6997703c92f43de1a3dcd3fcc7661ead5eb63b2ac8f1023f3db57be","compiler_version":"v0.58.1","strict":true}
+# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"35ba5d1e915453dfb8bb36f204c8e88294a212d8699ccd2b25513ce1bcece680","compiler_version":"v0.58.1","strict":true}
 
 name: "Review Responder"
 "on":
@@ -44,6 +44,7 @@ run-name: "Review Responder"
 
 jobs:
   activation:
+    if: contains(github.event.pull_request.labels.*.name, 'aw')
     runs-on: ubuntu-slim
     permissions:
       contents: read

--- a/.github/workflows/review-responder.md
+++ b/.github/workflows/review-responder.md
@@ -1,4 +1,5 @@
 ---
+if: "contains(github.event.pull_request.labels.*.name, 'aw')"
 on:
   pull_request_review:
     types: [submitted]


### PR DESCRIPTION
## Problem

Agent workflows (review-responder, quality-gate) fire on **every** `pull_request_review` event — including human-authored PRs without the `aw` label. The `aw` label check was only in the agent prompt instructions (soft guard), so the agent still activated, burned compute + inference tokens, then noop'd.

Discovered on PR #118 — both agents ran on a manually-created PR.

## Fix

Added `if: contains(github.event.pull_request.labels.*.name, 'aw')` to both workflow frontmatters. This compiles to a job-level `if:` on the activation job via gh-aw, so the workflow skips entirely at the GitHub Actions level — zero tokens burned.

## Files changed

- `.github/workflows/review-responder.md` — added `if:` condition
- `.github/workflows/quality-gate.md` — added `if:` condition  
- Both `.lock.yml` files — recompiled

## Note

Since `pull_request_review` uses workflow files from the **base branch** (main), this gate won't be active until after merge. The agents will still fire on this PR itself (but will noop on the label check in their prompt).

Refs #119