### PR TITLE
test: assert resumed-session output tokens and summary date range (#127)

### DIFF
--- a/tests/copilot_usage/test_report.py
+++ b/tests/copilot_usage/test_report.py
@@ -953,6 +953,38 @@ class TestReportCoverageGaps:
         # Code Changes section should NOT appear
         assert "Code Changes" not in output
 
+    def test_summary_header_shows_date_range(self) -> None:
+        """_render_summary_header date range: earliest date → latest date."""
+        s1 = _make_summary_session(
+            session_id="early",
+            start_time=datetime(2025, 3, 1, tzinfo=UTC),
+        )
+        s2 = _make_summary_session(
+            session_id="late",
+            start_time=datetime(2025, 11, 30, tzinfo=UTC),
+        )
+        output = _capture_summary([s1, s2])
+        assert "2025-03-01  →  2025-11-30" in output
+
+    def test_summary_header_date_range_order_is_min_max(self) -> None:
+        """Date range shows min date first even when sessions are not in order."""
+        sessions = [
+            _make_summary_session(
+                session_id="mid",
+                start_time=datetime(2025, 6, 15, tzinfo=UTC),
+            ),
+            _make_summary_session(
+                session_id="early",
+                start_time=datetime(2025, 1, 1, tzinfo=UTC),
+            ),
+            _make_summary_session(
+                session_id="late",
+                start_time=datetime(2025, 12, 31, tzinfo=UTC),
+            ),
+        ]
+        output = _capture_summary(sessions)
+        assert "2025-01-01  →  2025-12-31" in output
+
     def test_summary_header_no_start_times(self) -> None:
         """Sessions with no start_time → 'no sessions' subtitle (line 533)."""
         session = SessionSummary(session_id="no-time", start_time=None)
@@ -1324,6 +1356,8 @@ class TestRenderCostView:
         )
         assert grand_match is not None, "Grand Total row not found"
         assert grand_match.group(1) == "10"
+        # Output Tokens must include active_output_tokens: 1000 + 200 = 1200 → "1.2K"
+        assert "1.2K" in output
 
     def test_pure_active_session_no_metrics_shows_both_rows(self) -> None:
         """Active session with no model_metrics shows placeholder row AND Since-last-shutdown row."""


### PR DESCRIPTION
Closes #127

## Changes

Fills two assertion gaps in `tests/copilot_usage/test_report.py`:

### Gap 1 — Output Tokens in `test_resumed_session_no_double_count`

The existing test only asserted the **Model Calls** column in the Grand Total row. Now it also asserts that `"1.2K"` appears in the output, verifying that `grand_output` correctly sums `outputTokens` (1000) and `active_output_tokens` (200) for resumed sessions.

### Gap 2 — `_render_summary_header` date range

Two new tests in `TestRenderSummary`:

- **`test_summary_header_shows_date_range`** — two sessions with different `start_time` values → output contains `"2025-03-01  →  2025-11-30"`
- **`test_summary_header_date_range_order_is_min_max`** — three out-of-order sessions → output contains `"2025-01-01  →  2025-12-31"` (min first, max second)

### CI

All checks pass locally:
- `ruff check` ✅
- `ruff format` ✅
- `pyright` ✅ (0 errors)
- `pytest --cov --cov-fail-under=80` ✅ (400 passed, 97.97% coverage)




> Generated by [Issue Implementer](https://github.com/microsasa/cli-tools/actions/runs/23128078909) · [◷](https://github.com/search?q=repo%3Amicrosasa%2Fcli-tools+%22gh-aw-workflow-id%3A+issue-implementer%22&type=pullrequests)

> [!WARNING]
> <details>
> <summary>⚠️ Firewall blocked 1 domain</summary>
>
> The following domain was blocked by the firewall during workflow execution:
>
> - `astral.sh`
>
> To allow these domains, add them to the `network.allowed` list in your workflow frontmatter:
>
> ```yaml
> network:
>   allowed:
>     - defaults
>     - "astral.sh"
> ```
>
> See [Network Configuration](https://github.github.com/gh-aw/reference/network/) for more information.
>
> </details>


<!-- gh-aw-agentic-workflow: Issue Implementer, engine: copilot, model: claude-opus-4.6, id: 23128078909, workflow_id: issue-implementer, run: https://github.com/microsasa/cli-tools/actions/runs/23128078909 -->

<!-- gh-aw-workflow-id: issue-implementer -->