### PR TITLE
fix: authenticate orchestrator bash with PAT for GraphQL queries

### DIFF
--- a/.github/workflows/pipeline-orchestrator.lock.yml
+++ b/.github/workflows/pipeline-orchestrator.lock.yml
@@ -22,7 +22,7 @@
 # For more information: https://github.github.com/gh-aw/introduction/overview/
 #
 #
-# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"96df3a1d2d30a46810a72c84054becda8307a741c21cdb7751bef8f9d3f4d180","compiler_version":"v0.58.1","strict":true}
+# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"b1e08727895c4b68dc7fac58a3f2e8d95462ce5ff547d2ea0be0f8e5f9a97c23","compiler_version":"v0.58.1","strict":true}
 
 name: "Pipeline Orchestrator"
 "on":
@@ -305,6 +305,7 @@ jobs:
         env:
           GH_AW_GITHUB_TOKEN: ${{ secrets.GH_AW_GITHUB_TOKEN }}
           GH_AW_GITHUB_MCP_SERVER_TOKEN: ${{ secrets.GH_AW_GITHUB_MCP_SERVER_TOKEN }}
+          CUSTOM_GITHUB_TOKEN: ${{ secrets.GH_AW_WRITE_TOKEN }}
         with:
           script: |
             const determineAutomaticLockdown = require('/opt/gh-aw/actions/determine_automatic_lockdown.cjs');
@@ -802,7 +803,7 @@ jobs:
           GH_AW_SAFE_OUTPUTS_API_KEY: ${{ steps.safe-outputs-start.outputs.api_key }}
           GH_AW_SAFE_OUTPUTS_PORT: ${{ steps.safe-outputs-start.outputs.port }}
           GITHUB_MCP_LOCKDOWN: ${{ steps.determine-automatic-lockdown.outputs.lockdown == 'true' && '1' || '0' }}
-          GITHUB_MCP_SERVER_TOKEN: ${{ secrets.GH_AW_GITHUB_MCP_SERVER_TOKEN || secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
+          GITHUB_MCP_SERVER_TOKEN: ${{ secrets.GH_AW_WRITE_TOKEN }}
         run: |
           set -eo pipefail
           mkdir -p /tmp/gh-aw/mcp-config
@@ -896,7 +897,7 @@ jobs:
           GITHUB_API_URL: ${{ github.api_url }}
           GITHUB_AW: true
           GITHUB_HEAD_REF: ${{ github.head_ref }}
-          GITHUB_MCP_SERVER_TOKEN: ${{ secrets.GH_AW_GITHUB_MCP_SERVER_TOKEN || secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
+          GITHUB_MCP_SERVER_TOKEN: ${{ secrets.GH_AW_WRITE_TOKEN }}
           GITHUB_REF_NAME: ${{ github.ref_name }}
           GITHUB_SERVER_URL: ${{ github.server_url }}
           GITHUB_STEP_SUMMARY: /tmp/gh-aw/agent-step-summary.md
@@ -959,10 +960,11 @@ jobs:
             const { main } = require('/opt/gh-aw/actions/redact_secrets.cjs');
             await main();
         env:
-          GH_AW_SECRET_NAMES: 'COPILOT_GITHUB_TOKEN,GH_AW_GITHUB_MCP_SERVER_TOKEN,GH_AW_GITHUB_TOKEN,GITHUB_TOKEN'
+          GH_AW_SECRET_NAMES: 'COPILOT_GITHUB_TOKEN,GH_AW_GITHUB_MCP_SERVER_TOKEN,GH_AW_GITHUB_TOKEN,GH_AW_WRITE_TOKEN,GITHUB_TOKEN'
           SECRET_COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
           SECRET_GH_AW_GITHUB_MCP_SERVER_TOKEN: ${{ secrets.GH_AW_GITHUB_MCP_SERVER_TOKEN }}
           SECRET_GH_AW_GITHUB_TOKEN: ${{ secrets.GH_AW_GITHUB_TOKEN }}
+          SECRET_GH_AW_WRITE_TOKEN: ${{ secrets.GH_AW_WRITE_TOKEN }}
           SECRET_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Append agent step summary
         if: always()

--- a/.github/workflows/pipeline-orchestrator.md
+++ b/.github/workflows/pipeline-orchestrator.md
@@ -23,6 +23,7 @@ engine:
 tools:
   github:
     toolsets: [default, actions]
+    github-token: ${{ secrets.GH_AW_WRITE_TOKEN }}
   bash:
     - "gh:api:graphql"
 
@@ -110,9 +111,9 @@ If Copilot has not reviewed this PR yet, request a review from `@copilot` using 
 
 #### Action 2: Resolve unresolved threads
 
-Query the PR's review threads using bash:
+Query the PR's review threads using bash. Use `$GITHUB_MCP_SERVER_TOKEN` for authentication:
 ```
-gh api graphql -f query='query($owner: String!, $name: String!, $pr: Int!) {
+GH_TOKEN="$GITHUB_MCP_SERVER_TOKEN" gh api graphql -f query='query($owner: String!, $name: String!, $pr: Int!) {
   repository(owner: $owner, name: $name) {
     pullRequest(number: $pr) {
       reviewThreads(first: 100) {


### PR DESCRIPTION
The orchestrator's bash `gh api graphql` failed overnight on every run (22 runs, all reporting `missing_data`) because `GH_TOKEN` defaults to the installation token which can't query GraphQL.

**Fix:**
- Added `github-token: ${{ secrets.GH_AW_WRITE_TOKEN }}` to the GitHub tools config
- Instruct agent to use `GH_TOKEN=GITHUB_MCP_SERVER_TOKEN` prefix for auth

This unblocks thread resolution (Action 2) which has been noop'ing since the orchestrator went live.