### PR TITLE
fix: orchestrator rebase fetch creates proper remote ref

### DIFF
--- a/.github/workflows/pipeline-orchestrator.yml
+++ b/.github/workflows/pipeline-orchestrator.yml
@@ -218,13 +218,13 @@ jobs:
 
             echo "  Attempting rebase of $BRANCH onto main..."
 
-            # Fetch latest and attempt rebase
-            git fetch origin main "$BRANCH" || {
+            # Fetch latest refs for main and the PR branch
+            git fetch origin main "$BRANCH":"refs/remotes/origin/$BRANCH" || {
               echo "  ⚠️  PR #${PR}: Failed to fetch branch. Skipping."
               echo "::endgroup::"
               continue
             }
-            git checkout -B "$BRANCH" -- "origin/$BRANCH"
+            git checkout -B "$BRANCH" "origin/$BRANCH"
 
             if git rebase origin/main; then
               # Rebase succeeded — force push


### PR DESCRIPTION
Fixes the orchestrator rebase step failing with `fatal: 'origin/BRANCH' is not a commit`.

`git fetch origin BRANCH` fetches to FETCH_HEAD but doesn't create a tracking ref. Fixed by explicitly mapping: `git fetch origin BRANCH:refs/remotes/origin/BRANCH`.

Discovered during first live test of v2 on PR #113.

Part of #135