### PR TITLE
test: add group-level --path propagation tests (#60)

### DIFF
--- a/tests/copilot_usage/test_cli.py
+++ b/tests/copilot_usage/test_cli.py
@@ -748,6 +748,41 @@ def test_group_path_propagates_to_live(tmp_path: Path) -> None:
     assert result.exit_code == 0
 
 
+def test_summary_group_path_propagation(tmp_path: Path) -> None:
+    """summary reads --path from group level when not provided at subcommand level."""
+    _write_session(tmp_path, "grp10000-0000-0000-0000-000000000000", name="GroupPath")
+    runner = CliRunner()
+    # --path before subcommand name → stored in ctx.obj, not subcommand
+    result = runner.invoke(main, ["--path", str(tmp_path), "summary"])
+    assert result.exit_code == 0
+    assert "GroupPath" in result.output
+
+
+def test_cost_group_path_propagation(tmp_path: Path) -> None:
+    _write_session(tmp_path, "grp20000-0000-0000-0000-000000000000", name="CostGroup")
+    runner = CliRunner()
+    result = runner.invoke(main, ["--path", str(tmp_path), "cost"])
+    assert result.exit_code == 0
+
+
+def test_live_group_path_propagation(tmp_path: Path) -> None:
+    _write_session(
+        tmp_path, "grp30000-0000-0000-0000-000000000000", name="LiveGroup", active=True
+    )
+    runner = CliRunner()
+    result = runner.invoke(main, ["--path", str(tmp_path), "live"])
+    assert result.exit_code == 0
+
+
+def test_session_group_path_propagation(tmp_path: Path) -> None:
+    sid = "grp40000-0000-0000-0000-000000000000"
+    _write_session(tmp_path, sid, name="SessGroup")
+    runner = CliRunner()
+    # session needs the session_id positional argument
+    result = runner.invoke(main, ["--path", str(tmp_path), "session", sid[:8]])
+    assert result.exit_code == 0
+
+
 # 5. Auto-refresh branches in _interactive_loop -------------------------------
 
 


### PR DESCRIPTION
Closes #60

## What

Adds four tests verifying that the group-level `--path` option propagates correctly to all four subcommands (`summary`, `cost`, `live`, `session`) via `ctx.obj["path"]`.

## Why

Each subcommand contains `path = path or ctx.obj.get("path")` to support `copilot-usage --path /dir summary` syntax, but this specific fallback path was untested with the exact session IDs and assertions specified in the issue. If the propagation line or `ctx.obj["path"] = path` in `main` were accidentally removed, no existing test would catch the regression.

## Tests added

| Test | Subcommand | Session ID |
|------|-----------|------------|
| `test_summary_group_path_propagation` | `summary` | `grp10000-…` |
| `test_cost_group_path_propagation` | `cost` | `grp20000-…` |
| `test_live_group_path_propagation` | `live` | `grp30000-…` |
| `test_session_group_path_propagation` | `session` | `grp40000-…` |

## Verification

All 408 tests pass, coverage at 98% (well above the 80% threshold). Full CI suite (`ruff check`, `ruff format`, `pyright`, `pytest --cov`) passes cleanly.




> Generated by [Issue Implementer](https://github.com/microsasa/cli-tools/actions/runs/23214025036) · [◷](https://github.com/search?q=repo%3Amicrosasa%2Fcli-tools+%22gh-aw-workflow-id%3A+issue-implementer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Issue Implementer, engine: copilot, model: claude-opus-4.6, id: 23214025036, workflow_id: issue-implementer, run: https://github.com/microsasa/cli-tools/actions/runs/23214025036 -->

<!-- gh-aw-workflow-id: issue-implementer -->