### PR TITLE
fix: disable all automatic orchestrator triggers

### DIFF
--- a/.github/workflows/pipeline-orchestrator.yml
+++ b/.github/workflows/pipeline-orchestrator.yml
@@ -15,12 +15,13 @@ name: "Pipeline Orchestrator"
 
 on:
   schedule:
-    - cron: "*/15 * * * *"
-  workflow_run:
-    workflows: ["Review Responder"]
-    types: [completed]
-  push:
-    branches: [main]
+  # schedule:
+  #   - cron: "*/15 * * * *"
+  # workflow_run:
+  #   workflows: ["Review Responder"]
+  #   types: [completed]
+  # push:
+  #   branches: [main]
   workflow_dispatch:
     inputs:
       pr_number:


### PR DESCRIPTION
Disabling cron, workflow_run, and push triggers until the responder and orchestrator loop issues are resolved. Only manual workflow_dispatch remains.

Part of #135