### PR TITLE
fix: use format_tokens() in render_live_sessions (#133)

### DIFF
--- a/src/copilot_usage/report.py
+++ b/src/copilot_usage/report.py
@@ -156,7 +156,7 @@ def render_live_sessions(sessions: list[SessionSummary]) -> None:
         model = s.model or "—"
         running = _format_session_running_time(s)
         messages = str(s.user_messages)
-        tokens = f"{_estimated_output_tokens(s):,}"
+        tokens = format_tokens(_estimated_output_tokens(s))
         cwd = s.cwd or "—"
 
         table.add_row(

--- a/tests/copilot_usage/test_report.py
+++ b/tests/copilot_usage/test_report.py
@@ -190,7 +190,15 @@ class TestRenderLiveSessions:
             output_tokens=15000, start_time=now - timedelta(minutes=5)
         )
         output = _capture_output([session])
-        assert "15,000" in output
+        assert "15.0K" in output
+
+    def test_active_session_shows_output_tokens_m_suffix(self) -> None:
+        now = datetime.now(tz=UTC)
+        session = _make_session(
+            output_tokens=1_500_000, start_time=now - timedelta(minutes=5)
+        )
+        output = _capture_output([session])
+        assert "1.5M" in output
 
     def test_active_session_shows_cwd(self) -> None:
         now = datetime.now(tz=UTC)


### PR DESCRIPTION
Fixes #133

## Changes

**`src/copilot_usage/report.py`** — `render_live_sessions` now calls `format_tokens()` instead of raw `:,` f-string formatting for output tokens, matching every other token-displaying call site.

**`tests/copilot_usage/test_report.py`**:
- Updated `test_active_session_shows_output_tokens` assertion from `"15,000"` → `"15.0K"`
- Added `test_active_session_shows_output_tokens_m_suffix` verifying values ≥1,000,000 render with `M` suffix (e.g. `1.5M`)

## Verification

All 405 tests pass. Coverage at 97.97% (≥80% required). Ruff, pyright, and bandit all clean.




> Generated by [Issue Implementer](https://github.com/microsasa/cli-tools/actions/runs/23305950974) · [◷](https://github.com/search?q=repo%3Amicrosasa%2Fcli-tools+%22gh-aw-workflow-id%3A+issue-implementer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Issue Implementer, engine: copilot, model: claude-opus-4.6, id: 23305950974, workflow_id: issue-implementer, run: https://github.com/microsasa/cli-tools/actions/runs/23305950974 -->

<!-- gh-aw-workflow-id: issue-implementer -->