### PR TITLE
fix: pre-fetch review comments and allow astral.sh in responder

### DIFF
--- a/.github/workflows/review-responder.lock.yml
+++ b/.github/workflows/review-responder.lock.yml
@@ -22,7 +22,11 @@
 # For more information: https://github.github.com/gh-aw/introduction/overview/
 #
 #
-# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"e9dedf9ee2f5a6beffd74f5c1ac40c9263eda4f41e3db146c13a4d8576fd3970","compiler_version":"v0.60.0","strict":true}
+# Resolved workflow manifest:
+#   Imports:
+#     - shared/fetch-review-comments.md
+#
+# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"99594989482cadf66785af7f0d8a7a3f7ca7c7826a814c07734bb8942a84eae0","compiler_version":"v0.60.0","strict":true}
 
 name: "Review Responder"
 "on":
@@ -170,6 +174,9 @@ jobs:
           </system>
           GH_AW_PROMPT_EOF
           cat << 'GH_AW_PROMPT_EOF'
+          {{#runtime-import .github/workflows/shared/fetch-review-comments.md}}
+          GH_AW_PROMPT_EOF
+          cat << 'GH_AW_PROMPT_EOF'
           {{#runtime-import .github/workflows/review-responder.md}}
           GH_AW_PROMPT_EOF
           } > "$GH_AW_PROMPT"
@@ -281,6 +288,13 @@ jobs:
           git -c "http.extraheader=Authorization: Basic ${header}" fetch origin '+refs/heads/*:refs/remotes/origin/*'
       - name: Create gh-aw temp directory
         run: bash /opt/gh-aw/actions/create_gh_aw_tmp_dir.sh
+      - env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ inputs.pr_number }}
+        name: Fetch PR review comments
+        run: "mkdir -p /tmp/gh-aw/review-data\n\nOWNER=\"${GITHUB_REPOSITORY_OWNER}\"\nREPO=\"${GITHUB_REPOSITORY#*/}\"\n\necho \"Fetching review comments for PR #${PR_NUMBER}...\"\n\n# Fetch review comment threads via GraphQL (includes resolution status)\ngh api graphql -f query='\n  query($owner: String!, $repo: String!, $pr: Int!) {\n    repository(owner: $owner, name: $repo) {\n      pullRequest(number: $pr) {\n        title\n        body\n        reviewThreads(first: 100) {\n          nodes {\n            id\n            isResolved\n            isOutdated\n            comments(first: 100) {\n              nodes {\n                id\n                databaseId\n                body\n                path\n                line\n                author { login }\n                createdAt\n              }\n            }\n          }\n        }\n      }\n    }\n  }' -f owner=\"$OWNER\" -f repo=\"$REPO\" -F pr=\"$PR_NUMBER\" \\\n  > /tmp/gh-aw/review-data/threads.json\n\n# Extract unresolved threads for easy agent consumption\nif ! jq '[.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false) | .comments = .comments.nodes]' \\\n  /tmp/gh-aw/review-data/threads.json \\\n  > /tmp/gh-aw/review-data/unresolved-threads.json; then\n  echo \"Error: Failed to extract unresolved review threads from GraphQL response\" >&2\n  exit 1\nfi\n\nUNRESOLVED=$(jq 'length' /tmp/gh-aw/review-data/unresolved-threads.json)\necho \"Found ${UNRESOLVED} unresolved thread(s)\"\necho \"Data saved to /tmp/gh-aw/review-data/\""
+
       - name: Configure Git credentials
         env:
           REPO_NAME: ${{ github.repository }}

--- a/.github/workflows/review-responder.md
+++ b/.github/workflows/review-responder.md
@@ -12,6 +12,9 @@ permissions:
   issues: read
   pull-requests: read
 
+imports:
+  - shared/fetch-review-comments.md
+
 checkout:
   fetch: ["*"]
   fetch-depth: 0
@@ -57,13 +60,13 @@ This workflow addresses unresolved review comments on a pull request.
 
 2. Add the label `aw-review-response-attempted` to the PR.
 
-3. Read the unresolved review comment threads on the PR using the GitHub REST API: fetch `https://api.github.com/repos/$OWNER/$REPO/pulls/$PR_NUMBER/comments` and `https://api.github.com/repos/$OWNER/$REPO/pulls/$PR_NUMBER/reviews`. If there are more than 10 unresolved threads, address the first 10 and leave a summary comment on the PR noting how many remain for manual follow-up.
+3. Read the pre-fetched unresolved review threads from the file `/tmp/gh-aw/review-data/unresolved-threads.json`. This file was populated before you started by a workflow step that queried the GitHub GraphQL API. Each thread contains an `id`, `comments` array (with `databaseId`, `body`, `path`, `line`, `author`), and resolution status. If the file is empty or contains `[]`, there are no unresolved threads — stop and report via noop. If there are more than 10 unresolved threads, address the first 10 and leave a summary comment on the PR noting how many remain for manual follow-up.
 
 4. For each unresolved review comment thread (up to 10):
    a. Read the comment and understand what change is being requested
    b. Read the relevant file and surrounding code context
    c. Make the requested fix in the code
-   d. Reply to the comment thread explaining what you changed
+   d. Reply to the comment thread using `reply_to_pull_request_review_comment` with the comment's `databaseId` as the `comment_id`
 
 5. After addressing all comments, run the CI checks locally to make sure your fixes don't break anything: `uv sync && uv run ruff check --fix . && uv run ruff format . && uv run pyright && uv run pytest --cov --cov-fail-under=80 -v`
 

--- a/.github/workflows/shared/fetch-review-comments.md
+++ b/.github/workflows/shared/fetch-review-comments.md
@@ -1,0 +1,91 @@
+---
+steps:
+  - name: Fetch PR review comments
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      PR_NUMBER: ${{ inputs.pr_number }}
+    run: |
+      mkdir -p /tmp/gh-aw/review-data
+
+      OWNER="${GITHUB_REPOSITORY_OWNER}"
+      REPO="${GITHUB_REPOSITORY#*/}"
+
+      echo "Fetching review comments for PR #${PR_NUMBER}..."
+
+      # Fetch review comment threads via GraphQL (includes resolution status)
+      gh api graphql -f query='
+        query($owner: String!, $repo: String!, $pr: Int!) {
+          repository(owner: $owner, name: $repo) {
+            pullRequest(number: $pr) {
+              title
+              body
+              reviewThreads(first: 100) {
+                nodes {
+                  id
+                  isResolved
+                  isOutdated
+                  comments(first: 100) {
+                    nodes {
+                      id
+                      databaseId
+                      body
+                      path
+                      line
+                      author { login }
+                      createdAt
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }' -f owner="$OWNER" -f repo="$REPO" -F pr="$PR_NUMBER" \
+        > /tmp/gh-aw/review-data/threads.json
+
+      # Extract unresolved threads for easy agent consumption
+      if ! jq '[.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false) | .comments = .comments.nodes]' \
+        /tmp/gh-aw/review-data/threads.json \
+        > /tmp/gh-aw/review-data/unresolved-threads.json; then
+        echo "Error: Failed to extract unresolved review threads from GraphQL response" >&2
+        exit 1
+      fi
+
+      UNRESOLVED=$(jq 'length' /tmp/gh-aw/review-data/unresolved-threads.json)
+      echo "Found ${UNRESOLVED} unresolved thread(s)"
+      echo "Data saved to /tmp/gh-aw/review-data/"
+---
+
+<!--
+## Fetch PR Review Comments
+
+Shared component that pre-fetches PR review comment threads before the agent runs.
+The agent reads `/tmp/gh-aw/review-data/unresolved-threads.json` instead of using MCP tools.
+
+### Why
+
+The GitHub MCP `pull_request_read` tool intermittently returns empty arrays `[]` inside
+the gh-aw agent sandbox. This has been observed consistently in our repo — the tool
+never reliably returns review comment data. Pre-fetching via `gh api` in a workflow step
+(which has GITHUB_TOKEN) bypasses the MCP entirely.
+
+### Output Files
+
+- `/tmp/gh-aw/review-data/threads.json` — Full GraphQL response with all review threads
+- `/tmp/gh-aw/review-data/unresolved-threads.json` — Filtered to unresolved threads only
+
+### Usage
+
+Import in your workflow:
+
+```yaml
+imports:
+  - shared/fetch-review-comments.md
+```
+
+Then tell the agent to read the pre-fetched data:
+
+```markdown
+Read the unresolved review threads from `/tmp/gh-aw/review-data/unresolved-threads.json`.
+```
+-->


### PR DESCRIPTION
## Summary

Fixes #180 (MCP returns empty review comments), #183 (astral.sh blocked by firewall), and #184 (audit all workflows for missing network domains).

## Problem

Three issues prevented the gh-aw agents from working correctly:

1. **MCP read failure**: The GitHub MCP `pull_request_read` tool returns empty `[]` for review comments inside the gh-aw agent sandbox. This is a known issue confirmed by the gh-aw team. The responder could never find comments to address.

2. **Cannot run lint**: `astral.sh` (where `uv` and `ruff` binaries are hosted) was blocked by the firewall. All three code-writing workflows (responder, ci-fixer, implementer) were instructed to run `uv run ruff check` but could not. The agents skipped validation and pushed unverified code. PR body claims like "All 416 tests pass" were written without actually running tests — confirmed by checking agent logs (zero matches for uv/ruff/pytest).

3. **Audit**: All 6 workflows audited. The 3 that write code (responder, ci-fixer, implementer) now have `astral.sh`. The other 3 (code-health, quality-gate, test-analysis) only review/file issues and do not need it.

## Solution

### Pre-fetch pattern (fixes #180)

Created a shared import (`.github/workflows/shared/fetch-review-comments.md`) that runs **before** the agent starts:
- Uses `gh api graphql` to fetch all review threads with resolution status
- Flattens GraphQL `comments.nodes` wrapper into clean arrays
- Writes filtered unresolved threads to `/tmp/gh-aw/review-data/unresolved-threads.json`
- The agent reads from the file instead of calling MCP

This mirrors the pattern used in `github/gh-aw` own `copilot-pr-data-fetch.md`.

### Network fix (fixes #183, #184)

Added `"astral.sh"` to `network.allowed` in all three code-writing workflows:
- `review-responder.md`
- `ci-fixer.md`
- `issue-implementer.md`

## Changes

- **NEW** `.github/workflows/shared/fetch-review-comments.md` — pre-fetch shared import
- **MODIFIED** `.github/workflows/review-responder.md` — added `imports:`, `astral.sh`, updated step 3
- **MODIFIED** `.github/workflows/ci-fixer.md` — added `astral.sh` to network
- **MODIFIED** `.github/workflows/issue-implementer.md` — added `astral.sh` to network
- **MODIFIED** lock files recompiled for all three

## Testing

Tested pre-fetch on two PRs (before jq/pagination fixes, both successful):
- **PR #177**: Responder found all 4 unresolved threads, addressed them, pushed fixes, replied to all comments ✅
- **PR #172**: Responder found 1 unresolved thread, addressed it, CI passed ✅

## Known limitations

- GraphQL query fetches first 100 review threads without cursor pagination. Tracked in #185.

## Related issues

- Closes #180
- Closes #183
- Closes #184
- Related: #185 (pagination)
