### PR TITLE
fix: parser.py / pricing.py housekeeping (#182)

### DIFF
--- a/src/copilot_usage/parser.py
+++ b/src/copilot_usage/parser.py
@@ -8,6 +8,7 @@ aggregates.
 from __future__ import annotations
 
 import json
+from datetime import UTC, datetime
 from pathlib import Path
 
 from loguru import logger
@@ -28,6 +29,16 @@ from copilot_usage.models import (
 
 _DEFAULT_BASE: Path = Path.home() / ".copilot" / "session-state"
 _CONFIG_PATH: Path = Path.home() / ".copilot" / "config.json"
+
+_RESUME_INDICATOR_TYPES: frozenset[str] = frozenset(
+    {
+        EventType.SESSION_RESUME,
+        EventType.USER_MESSAGE,
+        EventType.ASSISTANT_MESSAGE,
+    }
+)
+
+_EPOCH: datetime = datetime.min.replace(tzinfo=UTC)
 
 
 def _infer_model_from_metrics(metrics: dict[str, ModelMetrics]) -> str | None:
@@ -234,12 +245,6 @@ def build_session_summary(
     name = _extract_session_name(session_dir) if session_dir else None
 
     # --- Detect resumed session (events after last shutdown) --------------
-    _RESUME_INDICATOR_TYPES: set[str] = {
-        EventType.SESSION_RESUME,
-        EventType.USER_MESSAGE,
-        EventType.ASSISTANT_MESSAGE,
-    }
-
     session_resumed = False
     post_shutdown_output_tokens = 0
     post_shutdown_turn_starts = 0
@@ -365,10 +370,8 @@ def get_all_sessions(base_path: Path | None = None) -> list[SessionSummary]:
         summary.events_path = events_path
         summaries.append(summary)
 
-    def _sort_key(s: SessionSummary) -> str:
-        if s.start_time is None:
-            return ""
-        return s.start_time.isoformat()
+    def _sort_key(s: SessionSummary) -> datetime:
+        return s.start_time if s.start_time is not None else _EPOCH
 
     summaries.sort(key=_sort_key, reverse=True)
     return summaries

--- a/src/copilot_usage/pricing.py
+++ b/src/copilot_usage/pricing.py
@@ -83,6 +83,7 @@ _RAW_MULTIPLIERS: Final[dict[str, float]] = {
     "gpt-5.3-codex": 1.0,
     "gpt-5.1-codex-max": 1.0,
     "gpt-5.1-codex-mini": 0.33,
+    "gpt-5.4-mini": 0.0,
     "gpt-5-mini": 0.0,
     "gpt-4.1": 0.0,
     # Gemini -----------------------------------------------------------------

--- a/tests/copilot_usage/test_pricing.py
+++ b/tests/copilot_usage/test_pricing.py
@@ -51,6 +51,7 @@ class TestKnownPricing:
             ("gpt-5.1-codex-max", 1.0),
             ("gpt-4.1", 0.0),
             ("gpt-5-mini", 0.0),
+            ("gpt-5.4-mini", 0.0),
             ("gemini-3-pro-preview", 1.0),
         ],
     )
@@ -64,6 +65,7 @@ class TestKnownPricing:
             ("claude-sonnet-4.6", PricingTier.STANDARD),
             ("claude-haiku-4.5", PricingTier.LIGHT),
             ("gpt-5-mini", PricingTier.LIGHT),
+            ("gpt-5.4-mini", PricingTier.LIGHT),
         ],
     )
     def test_known_tiers(self, model: str, expected_tier: PricingTier) -> None:


### PR DESCRIPTION
Closes #182

Three small housekeeping fixes:

### 1. `_RESUME_INDICATOR_TYPES` → module-level `frozenset`
Moved the set literal from inside `build_session_summary()` to a module-level `frozenset` constant, avoiding recreation on every call and signaling immutability.

### 2. `_sort_key` uses datetime sentinel instead of ISO strings
Replaced the ISO string comparison sort key with a `datetime` sentinel (`_EPOCH = datetime.min.replace(tzinfo=UTC)`). Sessions with `start_time=None` sort to `_EPOCH` (effectively last when sorted descending), avoiding reliance on implicit string ordering.

### 3. Added `gpt-5.4-mini` to `_RAW_MULTIPLIERS`
Added at `0.0×` multiplier (tier `LIGHT`), consistent with `gpt-5-mini` and `gpt-4.1`.

### Tests
- **Item 1:** No new test needed — existing coverage validates unchanged behavior.
- **Item 2:** Existing `test_sessions_without_start_time_sort_last` validates the sort behavior.
- **Item 3:** Added parametrized entries to `test_known_multipliers` (`gpt-5.4-mini`, `0.0`) and `test_known_tiers` (`gpt-5.4-mini`, `LIGHT`).

All 422 tests pass, coverage 98%, ruff/pyright clean.




> Generated by [Issue Implementer](https://github.com/microsasa/cli-tools/actions/runs/23369788585) · [◷](https://github.com/search?q=repo%3Amicrosasa%2Fcli-tools+%22gh-aw-workflow-id%3A+issue-implementer%22&type=pullrequests)

> [!WARNING]
> <details>
> <summary>⚠️ Firewall blocked 1 domain</summary>
>
> The following domain was blocked by the firewall during workflow execution:
>
> - `astral.sh`
>
> To allow these domains, add them to the `network.allowed` list in your workflow frontmatter:
>
> ```yaml
> network:
>   allowed:
>     - defaults
>     - "astral.sh"
> ```
>
> See [Network Configuration](https://github.github.com/gh-aw/reference/network/) for more information.
>
> </details>


<!-- gh-aw-agentic-workflow: Issue Implementer, engine: copilot, model: claude-opus-4.6, id: 23369788585, workflow_id: issue-implementer, run: https://github.com/microsasa/cli-tools/actions/runs/23369788585 -->

<!-- gh-aw-workflow-id: issue-implementer -->