### PR TITLE
fix: default view falls back to totals for pure-active sessions (#132)

### DIFF
--- a/src/copilot_usage/report.py
+++ b/src/copilot_usage/report.py
@@ -833,12 +833,30 @@ def _render_active_section(
         model = s.model or "—"
         running = _format_session_running_time(s)
 
+        # Use active_* fields when they are populated (resumed sessions
+        # or pure-active sessions processed by the current parser).
+        # Fall back to session totals for pure-active sessions whose
+        # active_* fields were never set (issue #132).
+        has_active_stats = (
+            s.last_resume_time is not None
+            or s.active_user_messages > 0
+            or s.active_output_tokens > 0
+        )
+        if has_active_stats:
+            model_calls = str(s.active_model_calls)
+            user_msgs = str(s.active_user_messages)
+            output_tokens = format_tokens(s.active_output_tokens)
+        else:
+            model_calls = str(s.model_calls)
+            user_msgs = str(s.user_messages)
+            output_tokens = format_tokens(_estimated_output_tokens(s))
+
         table.add_row(
             name,
             model,
-            str(s.active_model_calls),
-            str(s.active_user_messages),
-            format_tokens(s.active_output_tokens),
+            model_calls,
+            user_msgs,
+            output_tokens,
             running,
         )
 
@@ -939,16 +957,27 @@ def render_cost_view(
         grand_model_calls += s.model_calls
 
         if s.is_active:
-            est = _estimate_premium_cost(s.model, s.active_model_calls)
+            has_active = (
+                s.last_resume_time is not None
+                or s.active_user_messages > 0
+                or s.active_output_tokens > 0
+            )
+            if has_active:
+                cost_calls = s.active_model_calls
+                cost_tokens = s.active_output_tokens
+            else:
+                cost_calls = s.model_calls
+                cost_tokens = _estimated_output_tokens(s)
+            est = _estimate_premium_cost(s.model, cost_calls)
             table.add_row(
                 "  ↳ Since last shutdown",
                 s.model or "—",
                 "N/A",
                 est,
-                str(s.active_model_calls),
-                format_tokens(s.active_output_tokens),
+                str(cost_calls),
+                format_tokens(cost_tokens),
             )
-            grand_output += s.active_output_tokens
+            grand_output += cost_tokens
 
     table.add_section()
     table.add_row(

--- a/tests/copilot_usage/test_report.py
+++ b/tests/copilot_usage/test_report.py
@@ -1442,6 +1442,49 @@ class TestRenderFullSummary:
             f"Output Tokens column: expected '1.5K', got '{cols[5]}'"
         )
 
+    def test_pure_active_never_shutdown_falls_back_to_totals(self) -> None:
+        """Pure-active session with active_*=0 should fall back to total fields.
+
+        Regression test for issue #132: default view shows 0s when a
+        session has never been shutdown and active_* fields are not set.
+        """
+        now = datetime.now(tz=UTC)
+        session = SessionSummary(
+            session_id="never-shutdown-abcdef",
+            name="Never Shutdown",
+            model="claude-sonnet-4",
+            start_time=now - timedelta(minutes=30),
+            is_active=True,
+            user_messages=382,
+            model_calls=58,
+            # active_* default to 0 — simulating old parser or direct construction
+            active_model_calls=0,
+            active_user_messages=0,
+            active_output_tokens=0,
+            model_metrics={
+                "claude-sonnet-4": ModelMetrics(
+                    usage=TokenUsage(outputTokens=204_000),
+                )
+            },
+        )
+        output = _capture_full_summary([session])
+        assert "Active Sessions" in output
+        # Strip ANSI codes and locate the session row
+        clean = re.sub(r"\x1b\[[0-9;]*m", "", output)
+        lines = clean.splitlines()
+        row = next(line for line in lines if "Never Shutdown" in line)
+        cols = [c.strip() for c in row.split("│")]
+        # Columns: Name | Model | Model Calls | User Msgs | Output Tokens | Running Time
+        assert cols[3] == "58", (
+            f"Model Calls should fall back to total (58), got '{cols[3]}'"
+        )
+        assert cols[4] == "382", (
+            f"User Msgs should fall back to total (382), got '{cols[4]}'"
+        )
+        assert cols[5] == "204.0K", (
+            f"Output Tokens should fall back to total (204.0K), got '{cols[5]}'"
+        )
+
 
 # ---------------------------------------------------------------------------
 # render_cost_view capture helper
@@ -1725,6 +1768,43 @@ class TestRenderCostView:
         output = _capture_cost_view([session])
         # 3 calls × 3.0 multiplier = ~9
         assert "~9" in output
+
+    def test_pure_active_never_shutdown_cost_falls_back(self) -> None:
+        """Cost view: pure-active session with active_*=0 uses totals for the active row.
+
+        Regression test for issue #132.
+        """
+        session = SessionSummary(
+            session_id="cost-never-shut",
+            name="Cost No Shutdown",
+            model="claude-sonnet-4",
+            start_time=datetime(2025, 1, 15, 10, 0, tzinfo=UTC),
+            is_active=True,
+            model_calls=10,
+            user_messages=8,
+            active_model_calls=0,
+            active_user_messages=0,
+            active_output_tokens=0,
+            model_metrics={
+                "claude-sonnet-4": ModelMetrics(
+                    requests=RequestMetrics(count=10, cost=10),
+                    usage=TokenUsage(outputTokens=50_000),
+                )
+            },
+        )
+        output = _capture_cost_view([session])
+        assert "Since last shutdown" in output
+        clean = re.sub(r"\x1b\[[0-9;]*m", "", output)
+        lines = clean.splitlines()
+        shutdown_row = next(line for line in lines if "Since last shutdown" in line)
+        cols = [c.strip() for c in shutdown_row.split("│")]
+        # Should show model_calls (10) and model_metrics tokens (50.0K), not 0
+        assert "10" in cols[5], (
+            f"Model Calls in active row should be 10, got '{cols[5]}'"
+        )
+        assert "50.0K" in cols[6], (
+            f"Output Tokens in active row should be 50.0K, got '{cols[6]}'"
+        )
 
 
 class TestRenderFullSummaryHelperReuse:


### PR DESCRIPTION
## Summary

Fixes #132 — the default view (`copilot-usage`) showed all 0s for the "Active Sessions (Since Last Shutdown)" section when a session had never been shutdown.

## Root cause

`_render_active_section` and `render_cost_view` always used the `active_*` fields directly (`active_model_calls`, `active_user_messages`, `active_output_tokens`). For pure-active sessions where these fields are 0 (e.g. older parser output or direct `SessionSummary` construction), the display showed zeros while the total counters and `model_metrics` held the real data.

Meanwhile, `render_live_sessions` already had a `has_active_stats` fallback that correctly displayed totals in this scenario.

## Fix

Added the same `has_active_stats` fallback to both `_render_active_section` and `render_cost_view`:

- When `active_*` fields are all zero **and** `last_resume_time` is `None`, fall back to `model_calls`, `user_messages`, and `_estimated_output_tokens()`
- When any `active_*` field is non-zero or `last_resume_time` is set (resumed sessions), use the `active_*` fields as before

This makes all three views (`render_live_sessions`, `_render_active_section`, `render_cost_view`) consistent.

## Tests

- `test_pure_active_never_shutdown_falls_back_to_totals` — verifies the default full-summary view shows totals (58 model calls, 382 user msgs, 204.0K tokens) when `active_*` are 0
- `test_pure_active_never_shutdown_cost_falls_back` — verifies the cost view's "↳ Since last shutdown" row shows totals when `active_*` are 0

All 430 tests pass. Coverage: 98%.




> Generated by [Issue Implementer](https://github.com/microsasa/cli-tools/actions/runs/23370720472) · [◷](https://github.com/search?q=repo%3Amicrosasa%2Fcli-tools+%22gh-aw-workflow-id%3A+issue-implementer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Issue Implementer, engine: copilot, model: claude-opus-4.6, id: 23370720472, workflow_id: issue-implementer, run: https://github.com/microsasa/cli-tools/actions/runs/23370720472 -->

<!-- gh-aw-workflow-id: issue-implementer -->