### PR TITLE
fix: address code health issues from #161

### DIFF
--- a/src/copilot_usage/parser.py
+++ b/src/copilot_usage/parser.py
@@ -149,8 +149,8 @@ def _extract_session_name(session_dir: Path) -> str | None:
         first_line = plan.read_text(encoding="utf-8").split("\n", maxsplit=1)[0]
         if first_line.startswith("# "):
             return first_line.removeprefix("# ").strip()
-    except OSError:
-        pass
+    except OSError as exc:
+        logger.debug("Could not read session name from {}: {}", plan, exc)
     return None
 
 

--- a/src/copilot_usage/pricing.py
+++ b/src/copilot_usage/pricing.py
@@ -37,6 +37,7 @@ class PricingTier(StrEnum):
     PREMIUM = "premium"
     STANDARD = "standard"
     LIGHT = "light"
+    FREE = "free"
 
 
 # ---------------------------------------------------------------------------
@@ -60,6 +61,8 @@ class ModelPricing(BaseModel):
 def _tier_from_multiplier(m: float) -> PricingTier:
     if m >= 3.0:
         return PricingTier.PREMIUM
+    if m == 0.0:
+        return PricingTier.FREE
     if m < 1.0:
         return PricingTier.LIGHT
     return PricingTier.STANDARD

--- a/src/copilot_usage/report.py
+++ b/src/copilot_usage/report.py
@@ -6,6 +6,7 @@ the terminal.
 
 from __future__ import annotations
 
+import warnings
 from datetime import UTC, datetime, timedelta
 
 from rich.console import Console
@@ -569,6 +570,14 @@ def _filter_sessions(
     until: datetime | None,
 ) -> list[SessionSummary]:
     """Return sessions whose start_time falls within [since, until]."""
+    if since is not None and until is not None and since > until:
+        warnings.warn(
+            f"--since ({since.date()}) is after --until ({until.date()}); "
+            "no sessions will match.",
+            UserWarning,
+            stacklevel=3,
+        )
+
     if since is None and until is None:
         return sessions
 

--- a/tests/copilot_usage/test_parser.py
+++ b/tests/copilot_usage/test_parser.py
@@ -1999,7 +1999,7 @@ class TestExtractSessionName:
         plan.write_text("", encoding="utf-8")
         assert _extract_session_name(tmp_path) is None
 
-    def test_oserror_returns_none(self, tmp_path: Path) -> None:
+    def test_oserror_returns_none_and_logs(self, tmp_path: Path) -> None:
         plan = tmp_path / "plan.md"
         plan.write_text("# Title\n", encoding="utf-8")
 
@@ -2010,8 +2010,16 @@ class TestExtractSessionName:
                 raise OSError("denied")
             return original_read_text(self, *args, **kwargs)  # type: ignore[arg-type]
 
-        with patch.object(Path, "read_text", _raise_os_error):
-            assert _extract_session_name(tmp_path) is None
+        from loguru import logger
+
+        log_messages: list[str] = []
+        handler_id = logger.add(lambda m: log_messages.append(str(m)), level="DEBUG")
+        try:
+            with patch.object(Path, "read_text", _raise_os_error):
+                assert _extract_session_name(tmp_path) is None
+        finally:
+            logger.remove(handler_id)
+        assert any("Could not read session name" in msg for msg in log_messages)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/copilot_usage/test_pricing.py
+++ b/tests/copilot_usage/test_pricing.py
@@ -64,8 +64,9 @@ class TestKnownPricing:
             ("claude-opus-4.5", PricingTier.PREMIUM),
             ("claude-sonnet-4.6", PricingTier.STANDARD),
             ("claude-haiku-4.5", PricingTier.LIGHT),
-            ("gpt-5-mini", PricingTier.LIGHT),
-            ("gpt-5.4-mini", PricingTier.LIGHT),
+            ("gpt-5-mini", PricingTier.FREE),
+            ("gpt-5.4-mini", PricingTier.FREE),
+            ("gpt-4.1", PricingTier.FREE),
         ],
     )
     def test_known_tiers(self, model: str, expected_tier: PricingTier) -> None:
@@ -123,3 +124,9 @@ class TestCategorizeModel:
 
     def test_light(self) -> None:
         assert categorize_model("claude-haiku-4.5") == PricingTier.LIGHT
+
+    def test_free(self) -> None:
+        assert categorize_model("gpt-5-mini") == PricingTier.FREE
+
+    def test_free_gpt_4_1(self) -> None:
+        assert categorize_model("gpt-4.1") == PricingTier.FREE

--- a/tests/copilot_usage/test_report.py
+++ b/tests/copilot_usage/test_report.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import re
+import warnings
 from datetime import UTC, datetime, timedelta
 from io import StringIO
 from unittest.mock import patch
@@ -2142,3 +2143,40 @@ class TestRenderTotalsSingularLabels:
         # "session" appears without trailing 's'
         stripped = output.replace("sessions", "")
         assert "session" in stripped
+
+
+# ---------------------------------------------------------------------------
+# Issue #161 — _filter_sessions reversed date range warning
+# ---------------------------------------------------------------------------
+
+
+class TestFilterSessionsReversedDateRange:
+    def test_reversed_since_until_warns(self) -> None:
+        """Passing since > until emits a UserWarning."""
+        session = SessionSummary(
+            session_id="s1",
+            start_time=datetime(2026, 6, 15, tzinfo=UTC),
+        )
+        since = datetime(2026, 12, 31, tzinfo=UTC)
+        until = datetime(2026, 1, 1, tzinfo=UTC)
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            result = _filter_sessions([session], since=since, until=until)
+        assert result == []
+        assert len(caught) == 1
+        assert "--since" in str(caught[0].message)
+        assert "after" in str(caught[0].message)
+
+    def test_normal_range_no_warning(self) -> None:
+        """Passing since < until does NOT emit a warning."""
+        session = SessionSummary(
+            session_id="s1",
+            start_time=datetime(2026, 6, 15, tzinfo=UTC),
+        )
+        since = datetime(2026, 1, 1, tzinfo=UTC)
+        until = datetime(2026, 12, 31, tzinfo=UTC)
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            result = _filter_sessions([session], since=since, until=until)
+        assert len(result) == 1
+        assert len(caught) == 0


### PR DESCRIPTION
Fixes #161 — four code health items bundled in a single cleanup PR.

### Changes

1. **`_extract_session_name` OSError logging** (`parser.py`): Replaced silent `except OSError: pass` with `logger.debug(...)` so unreadable `plan.md` files produce a diagnostic message instead of being silently swallowed.

2. **`_filter_sessions` reversed date range warning** (`report.py`): Added a guard that emits a `UserWarning` when `--since` is after `--until`, making it immediately obvious when dates are accidentally swapped.

3. **`PricingTier.FREE` tier** (`pricing.py`): Added a `FREE` enum member for 0× multiplier models (`gpt-5-mini`, `gpt-5.4-mini`, `gpt-4.1`). Updated `_tier_from_multiplier` to classify `m == 0.0` as `FREE` instead of `LIGHT`.

4. **`_RESUME_INDICATOR_TYPES` module-level constant** — already at module level as `frozenset` in current code; no changes needed.

### Tests

- Updated `test_oserror_returns_none` → `test_oserror_returns_none_and_logs` to verify `logger.debug` is emitted on `OSError`.
- Added `TestFilterSessionsReversedDateRange` with tests for warning emission and no-warning on valid range.
- Updated `test_known_tiers` to expect `PricingTier.FREE` for `gpt-5-mini`, `gpt-5.4-mini`, `gpt-4.1`.
- Added `test_free` and `test_free_gpt_4_1` to `TestCategorizeModel`.

All CI checks pass locally (ruff, pyright, pytest 435 passed, 98% coverage).




> Generated by [Issue Implementer](https://github.com/microsasa/cli-tools/actions/runs/23370993807) · [◷](https://github.com/search?q=repo%3Amicrosasa%2Fcli-tools+%22gh-aw-workflow-id%3A+issue-implementer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Issue Implementer, engine: copilot, model: claude-opus-4.6, id: 23370993807, workflow_id: issue-implementer, run: https://github.com/microsasa/cli-tools/actions/runs/23370993807 -->

<!-- gh-aw-workflow-id: issue-implementer -->