### PR TITLE
fix: pipe gh output to jq for Copilot review check

### DIFF
--- a/.github/workflows/pipeline-orchestrator.yml
+++ b/.github/workflows/pipeline-orchestrator.yml
@@ -17,7 +17,7 @@ name: "Pipeline Orchestrator"
 on:
   # Event-driven triggers (immediate response)
   workflow_run:
-    workflows: ["Review Responder", "CI Fixer", "CI", "Quality Gate"]
+    workflows: ["Review Responder", "CI Fixer", "CI", "Quality Gate", "Copilot code review"]
     types: [completed]
   pull_request_review:
     types: [submitted]


### PR DESCRIPTION
The `--jq` flag on `gh run list` doesn't support `--arg`. The command was silently failing and the `|| echo "1"` fallback permanently blocked quality gate dispatch (always reported 'Copilot review in progress').

Fix: pipe `gh run list --json` output to `jq` separately, which supports `--arg`.