### PR TITLE
fix: Loguru formatting and narrow exception handling

### DIFF
--- a/src/copilot_usage/cli.py
+++ b/src/copilot_usage/cli.py
@@ -359,7 +359,10 @@ def session(ctx: click.Context, session_id: str, path: Path | None) -> None:
         if len(session_id) >= 4 and is_uuid_dir and not dir_name.startswith(session_id):
             available.append(dir_name[:8])
             continue
-        events = parse_events(events_path)
+        try:
+            events = parse_events(events_path)
+        except OSError:
+            continue
         if not events:
             continue
         s = build_session_summary(events, session_dir=events_path.parent)

--- a/src/copilot_usage/parser.py
+++ b/src/copilot_usage/parser.py
@@ -354,7 +354,7 @@ def get_all_sessions(base_path: Path | None = None) -> list[SessionSummary]:
     for events_path in paths:
         try:
             events = parse_events(events_path)
-        except (FileNotFoundError, OSError) as exc:
+        except OSError as exc:
             logger.warning("Skipping vanished session {}: {}", events_path, exc)
             continue
         if not events:

--- a/tests/copilot_usage/test_cli.py
+++ b/tests/copilot_usage/test_cli.py
@@ -279,6 +279,7 @@ def test_summary_error_handling(tmp_path: Path, monkeypatch: Any) -> None:
     result = runner.invoke(main, ["summary", "--path", str(tmp_path)])
     assert result.exit_code != 0
     assert "disk on fire" in result.output
+    assert "Traceback" not in (result.output or "")
 
 
 def test_session_no_sessions(tmp_path: Path, monkeypatch: Any) -> None:
@@ -330,6 +331,7 @@ def test_session_error_handling(tmp_path: Path, monkeypatch: Any) -> None:
     result = runner.invoke(main, ["session", "anything"])
     assert result.exit_code != 0
     assert "permission denied" in result.output
+    assert "Traceback" not in (result.output or "")
 
 
 def test_cost_no_model_metrics(tmp_path: Path) -> None:
@@ -397,6 +399,7 @@ def test_cost_error_handling(tmp_path: Path, monkeypatch: Any) -> None:
     result = runner.invoke(main, ["cost", "--path", str(tmp_path)])
     assert result.exit_code != 0
     assert "cost explosion" in result.output
+    assert "Traceback" not in (result.output or "")
 
 
 def test_live_error_handling(tmp_path: Path, monkeypatch: Any) -> None:
@@ -411,6 +414,7 @@ def test_live_error_handling(tmp_path: Path, monkeypatch: Any) -> None:
     result = runner.invoke(main, ["live", "--path", str(tmp_path)])
     assert result.exit_code != 0
     assert "live explosion" in result.output
+    assert "Traceback" not in (result.output or "")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Changes

1. **Fix Loguru formatting** — replaced `%s` with `{}` in `parser.py:365` so vanished-session warnings actually log the path and error.

2. **Replace broad `except Exception` with narrow `except OSError`** — removed blanket exception handlers from all 4 CLI commands (`summary`, `session`, `cost`, `live`). Filesystem errors on data files get a friendly message. Programming bugs crash loudly with full tracebacks.

3. **Remove dead code** — `except SystemExit: raise` in the `session` command was dead code (`SystemExit` inherits from `BaseException`, not `Exception`).

4. **Updated tests** — error handling tests now use `OSError`/`PermissionError` (operational errors) instead of `RuntimeError` (programming bugs).

## Rationale

Broad exception handlers masked programming errors by converting them into generic `Error: ...` messages. The new approach: catch only what we expect (filesystem errors on session data), let everything else surface.