### PR TITLE
test: add direct unit tests for `_infer_model_from_metrics` (#238)

### DIFF
--- a/tests/copilot_usage/test_parser.py
+++ b/tests/copilot_usage/test_parser.py
@@ -2143,19 +2143,25 @@ class TestInferModelFromMetrics:
         assert _infer_model_from_metrics(metrics) == "claude-opus-4.6"
 
     def test_tie_returns_a_model_deterministically(self) -> None:
-        """When counts are equal, a specific model must always win.
+        """When counts are equal, tie-breaking must be stable and by insertion order.
 
-        This test documents (and locks in) the current tie-breaking behaviour.
+        This test documents (and locks in) the current tie-breaking behaviour:
+        the first key by insertion order wins when counts are equal.
         If the behaviour changes, the test should be updated intentionally.
         """
+        # First insertion order: model-a, then model-b
         metrics = {
             "model-a": ModelMetrics(requests=RequestMetrics(count=5)),
             "model-b": ModelMetrics(requests=RequestMetrics(count=5)),
         }
-        result = _infer_model_from_metrics(metrics)
-        assert result in ("model-a", "model-b")
-        # Run again to confirm stability within a single process
-        assert _infer_model_from_metrics(metrics) == result
+        assert _infer_model_from_metrics(metrics) == "model-a"
+
+        # Reversed insertion order: model-b, then model-a
+        metrics_reversed = {
+            "model-b": ModelMetrics(requests=RequestMetrics(count=5)),
+            "model-a": ModelMetrics(requests=RequestMetrics(count=5)),
+        }
+        assert _infer_model_from_metrics(metrics_reversed) == "model-b"
 
 
 # ---------------------------------------------------------------------------
@@ -2163,7 +2169,7 @@ class TestInferModelFromMetrics:
 # ---------------------------------------------------------------------------
 
 
-class TestBuildSummaryInfersModelWhenCurrentModelAbsent:
+class TestBuildSessionSummaryInfersModelWhenCurrentModelAbsent:
     """Shutdown event with no currentModel → _infer_model_from_metrics is used."""
 
     def test_completed_session_infers_model_from_metrics(self, tmp_path: Path) -> None:


### PR DESCRIPTION
Closes #238

## Changes

Adds direct unit tests for `_infer_model_from_metrics` covering all four branches:

| Test | Branch |
|------|--------|
| `test_empty_returns_none` | Empty dict → `None` |
| `test_single_key_returns_it` | Single model key → returns it |
| `test_multi_key_returns_highest_count` | Multiple models → highest `requests.count` wins |
| `test_tie_returns_a_model_deterministically` | Equal counts → documents and locks in tie-breaking behaviour |

Adds an integration test (`TestBuildSummaryInfersModelWhenCurrentModelAbsent`) verifying that `build_session_summary` correctly infers the model via `_infer_model_from_metrics` when a **completed** session has multi-model `modelMetrics` but no `currentModel` at either the top level or in `data`.

## Validation

All checks pass locally:
- `ruff check` ✅
- `ruff format` ✅
- `pyright` — 0 errors ✅
- `pytest --cov --cov-fail-under=80` — 506 passed, 98.91% coverage ✅




> Generated by [Issue Implementer](https://github.com/microsasa/cli-tools/actions/runs/23398685487) · [◷](https://github.com/search?q=repo%3Amicrosasa%2Fcli-tools+%22gh-aw-workflow-id%3A+issue-implementer%22&type=pullrequests)

> [!WARNING]
> <details>
> <summary>⚠️ Firewall blocked 1 domain</summary>
>
> The following domain was blocked by the firewall during workflow execution:
>
> - `astral.sh`
>
> To allow these domains, add them to the `network.allowed` list in your workflow frontmatter:
>
> ```yaml
> network:
>   allowed:
>     - defaults
>     - "astral.sh"
> ```
>
> See [Network Configuration](https://github.github.com/gh-aw/reference/network/) for more information.
>
> </details>


<!-- gh-aw-agentic-workflow: Issue Implementer, engine: copilot, model: claude-opus-4.6, id: 23398685487, workflow_id: issue-implementer, run: https://github.com/microsasa/cli-tools/actions/runs/23398685487 -->

<!-- gh-aw-workflow-id: issue-implementer -->