### PR TITLE
fix: resolve code inconsistencies in models, report (#240)

### DIFF
--- a/src/copilot_usage/models.py
+++ b/src/copilot_usage/models.py
@@ -140,9 +140,7 @@ class AssistantMessageData(BaseModel):
     interactionId: str = ""
     reasoningText: str | None = None
     reasoningOpaque: str | None = None
-    toolRequests: list[dict[str, object]] = Field(
-        default_factory=list[dict[str, object]]
-    )
+    toolRequests: list[dict[str, object]] = Field(default_factory=lambda: [])
 
 
 class SessionShutdownData(BaseModel):

--- a/src/copilot_usage/report.py
+++ b/src/copilot_usage/report.py
@@ -634,9 +634,10 @@ def _filter_sessions(
     for s in sessions:
         if s.start_time is None:
             continue
-        if since is not None and s.start_time < since:
+        aware_start = ensure_aware(s.start_time)
+        if since is not None and aware_start < since:
             continue
-        if until is not None and s.start_time > until:
+        if until is not None and aware_start > until:
             continue
         filtered.append(s)
     return filtered

--- a/tests/copilot_usage/test_report.py
+++ b/tests/copilot_usage/test_report.py
@@ -2818,3 +2818,52 @@ class TestFormatDetailDurationBoundaries:
         """None end should return em-dash."""
         start = datetime(2025, 1, 1, tzinfo=UTC)
         assert _format_detail_duration(start, None) == "—"
+
+
+# ---------------------------------------------------------------------------
+# Issue #240 — _filter_sessions with naive start_time vs aware since/until
+# ---------------------------------------------------------------------------
+
+
+class TestFilterSessionsNaiveStartTime:
+    def test_naive_start_time_with_aware_since(self) -> None:
+        """Naive start_time must not raise TypeError when since is aware."""
+        naive_session = SessionSummary(
+            session_id="naive",
+            start_time=datetime(2026, 6, 15),  # naive — no tzinfo
+        )
+        since = datetime(2026, 1, 1, tzinfo=UTC)
+        result = _filter_sessions([naive_session], since=since, until=None)
+        assert len(result) == 1
+        assert result[0].session_id == "naive"
+
+    def test_naive_start_time_with_aware_until(self) -> None:
+        """Naive start_time must not raise TypeError when until is aware."""
+        naive_session = SessionSummary(
+            session_id="naive",
+            start_time=datetime(2026, 6, 15),  # naive — no tzinfo
+        )
+        until = datetime(2026, 12, 31, tzinfo=UTC)
+        result = _filter_sessions([naive_session], since=None, until=until)
+        assert len(result) == 1
+        assert result[0].session_id == "naive"
+
+    def test_naive_start_time_filtered_out_by_since(self) -> None:
+        """Naive start_time before since is correctly excluded."""
+        naive_session = SessionSummary(
+            session_id="old",
+            start_time=datetime(2025, 1, 1),  # naive
+        )
+        since = datetime(2026, 1, 1, tzinfo=UTC)
+        result = _filter_sessions([naive_session], since=since, until=None)
+        assert result == []
+
+    def test_naive_start_time_filtered_out_by_until(self) -> None:
+        """Naive start_time after until is correctly excluded."""
+        naive_session = SessionSummary(
+            session_id="future",
+            start_time=datetime(2027, 1, 1),  # naive
+        )
+        until = datetime(2026, 12, 31, tzinfo=UTC)
+        result = _filter_sessions([naive_session], since=None, until=until)
+        assert result == []


### PR DESCRIPTION
Fixes #240

## Changes

### 1. Non-idiomatic `default_factory` in `AssistantMessageData.toolRequests` (models.py)

Replaced `default_factory=list[dict[str, object]]` (a `GenericAlias` callable) with the idiomatic `default_factory=lambda: []`. Uses a lambda to satisfy pyright strict mode's `reportUnknownVariableType` check (bare `list` would produce `list[Unknown]` for nested generic types).

### 2. Logger format mismatch (parser.py)

Already fixed in the current codebase — all `logger` calls already use loguru's `{}` format. No change needed.

### 3. Missing `ensure_aware` in `_filter_sessions` (report.py)

Wrapped `s.start_time` with `ensure_aware()` before comparing against aware `since`/`until` bounds. This prevents `TypeError: can't compare offset-naive and offset-aware datetimes` when a `SessionSummary` has a naive `start_time`.

## Testing

Added 4 regression tests in `TestFilterSessionsNaiveStartTime`:
- Naive `start_time` with aware `since` — no TypeError, correctly included
- Naive `start_time` with aware `until` — no TypeError, correctly included
- Naive `start_time` before `since` — correctly excluded
- Naive `start_time` after `until` — correctly excluded

All 510 tests pass, 98.77% coverage, pyright strict clean.




> Generated by [Issue Implementer](https://github.com/microsasa/cli-tools/actions/runs/23408922417) · [◷](https://github.com/search?q=repo%3Amicrosasa%2Fcli-tools+%22gh-aw-workflow-id%3A+issue-implementer%22&type=pullrequests)

> [!WARNING]
> <details>
> <summary>⚠️ Firewall blocked 1 domain</summary>
>
> The following domain was blocked by the firewall during workflow execution:
>
> - `astral.sh`
>
> To allow these domains, add them to the `network.allowed` list in your workflow frontmatter:
>
> ```yaml
> network:
>   allowed:
>     - defaults
>     - "astral.sh"
> ```
>
> See [Network Configuration](https://github.github.com/gh-aw/reference/network/) for more information.
>
> </details>


<!-- gh-aw-agentic-workflow: Issue Implementer, engine: copilot, model: claude-opus-4.6, id: 23408922417, workflow_id: issue-implementer, run: https://github.com/microsasa/cli-tools/actions/runs/23408922417 -->

<!-- gh-aw-workflow-id: issue-implementer -->