### PR TITLE
feat: deterministic safe admin merge scripts and documentation

### DIFF
--- a/docs/agentic-workflows.md
+++ b/docs/agentic-workflows.md
@@ -335,7 +335,7 @@ Settings required for the autonomous pipeline:
 |---|---|---|
 | Auto-merge | `gh api repos/OWNER/REPO -X PATCH -f allow_auto_merge=true` | `true` |
 | Branch protection: required reviews | API (see below) | 1 approving review |
-| Branch protection: dismiss stale | API | `false` (disabled for PR rescue rebase flow) |
+| Branch protection: dismiss stale | API | `true` (new pushes invalidate old approvals) |
 | Branch protection: required status | API | `check` (strict: must be up to date) |
 | Branch protection: enforce admins | API | `true` |
 | Branch protection: conversation resolution | API | `true` (all review threads must be resolved) |

--- a/scripts/hold-for-merge.sh
+++ b/scripts/hold-for-merge.sh
@@ -41,6 +41,9 @@ echo ""
 echo "=== Disabling enforce_admins ==="
 gh api "repos/${REPO}/branches/main/protection/enforce_admins" -X DELETE > /dev/null
 
+# Re-enable enforce_admins if anything below fails
+trap 'echo "ERROR: re-enabling enforce_admins after failure"; gh api "repos/${REPO}/branches/main/protection/enforce_admins" -X POST > /dev/null 2>&1; exit 1' ERR
+
 AFTER=$(get_protection)
 echo ""
 echo "${BEFORE}" | AFTER_JSON="${AFTER}" python3 -c "
@@ -48,7 +51,7 @@ import json, os, sys
 before = json.load(sys.stdin)
 after = json.loads(os.environ['AFTER_JSON'])
 changing = {'enforce_admins'}
-R, G, Y, NC = '\033[0;31m', '\033[0;32m', '\033[0;33m', '\033[0m'
+R, G, NC = '\033[0;31m', '\033[0;32m', '\033[0m'
 h = ('Setting', 'Before', 'After', 'Status')
 print(f'{h[0]:<35} {h[1]:<15} {h[2]:<15} {h[3]}')
 print(f'{chr(45)*35} {chr(45)*15} {chr(45)*15} {chr(45)*20}')

--- a/scripts/release-from-merge.sh
+++ b/scripts/release-from-merge.sh
@@ -82,4 +82,4 @@ if not ok:
 print(f'\n{G}All settings restored correctly.{NC}')
 "
 
-rm "${STASH}"
+rm -f "${STASH}"


### PR DESCRIPTION
## Summary

Replaces the manual safe admin merge protocol with two deterministic bash scripts. The old protocol relied on Copilot CLI manually reconstructing branch protection settings from memory, which caused three separate incidents of broken protection (see bug #261).

Fixes #262
Related: #261

## What changed

### New scripts

**`scripts/hold-for-merge.sh <owner/repo>`**
- Reads all 15 branch protection settings from API (BEFORE snapshot)
- Lists all open PRs with auto-merge enabled, saves to temp file
- Disables auto-merge on each
- Disables `enforce_admins` (the only setting that changes)
- Reads all settings again (AFTER snapshot)
- Displays single color-coded table: Before → After → Status
- Exits with code 1 if any setting is wrong

**`scripts/release-from-merge.sh <owner/repo>`**
- Reads all 15 settings from API (BEFORE snapshot)
- Re-enables `enforce_admins`
- Re-enables auto-merge on exact PRs saved by hold script
- Reads all settings again (AFTER snapshot)
- Displays single color-coded table: Before → After → Status
- Exits with code 1 if any setting is wrong

### Key design decisions

- **Only toggles `enforce_admins`**: No other setting is touched. This eliminates the entire class of bugs from incidents in #261.
- **Verifies via live API**: Before and After columns both come from fresh API calls, never from memory.
- **Saves/restores exact PR list**: No guessing which PRs had auto-merge.

### Documentation added to `docs/agentic-workflows.md`

New section "Branch Protection & Safe Admin Merge" covering:
- Steady-state branch protection table (all 15 settings with rationale)
- Why `require_last_push_approval` cannot be enabled (implementer and quality gate are same bot identity `github-actions[bot]`, database ID 41898282)
- Why the required status check is `check` not `CI` (GitHub matches job names, not workflow names)
- Safe admin merge procedure using the scripts
- Full incident writeup for 2026-03-22 (wrong check name → 9-hour loop → 3 PRs merged without review → reverted)

## Usage

```bash
scripts/hold-for-merge.sh microsasa/cli-tools
gh pr merge <number> --squash   # or --merge
scripts/release-from-merge.sh microsasa/cli-tools
```