### PR TITLE
test: cover three untested parser edge cases (#248)

### DIFF
--- a/tests/copilot_usage/test_parser.py
+++ b/tests/copilot_usage/test_parser.py
@@ -759,6 +759,62 @@ class TestBuildSessionSummaryResumed:
         # 100 post-resume goes to active
         assert summary.active_output_tokens == 100
 
+    def test_user_message_alone_marks_resumed(self, tmp_path: Path) -> None:
+        """Shutdown → USER_MESSAGE (no session.resume) → is_active=True."""
+        post_user = json.dumps(
+            {
+                "type": "user.message",
+                "data": {"content": "continue", "attachments": []},
+                "id": "ev-u-noresume",
+                "timestamp": "2026-03-07T12:01:00.000Z",
+                "parentId": "ev-shutdown",
+            }
+        )
+        p = tmp_path / "s" / "events.jsonl"
+        _write_events(
+            p,
+            _START_EVENT,
+            _USER_MSG,
+            _ASSISTANT_MSG,
+            _SHUTDOWN_EVENT,
+            post_user,
+        )
+        events = parse_events(p)
+        summary = build_session_summary(events)
+        assert summary.is_active is True
+        assert summary.active_user_messages == 1
+
+    def test_assistant_message_alone_marks_resumed(self, tmp_path: Path) -> None:
+        """Shutdown → ASSISTANT_MESSAGE (no session.resume) → is_active=True."""
+        post_asst = json.dumps(
+            {
+                "type": "assistant.message",
+                "data": {
+                    "messageId": "m-noresume",
+                    "content": "continuing",
+                    "toolRequests": [],
+                    "interactionId": "int-nr",
+                    "outputTokens": 120,
+                },
+                "id": "ev-a-noresume",
+                "timestamp": "2026-03-07T12:01:05.000Z",
+                "parentId": "ev-shutdown",
+            }
+        )
+        p = tmp_path / "s" / "events.jsonl"
+        _write_events(
+            p,
+            _START_EVENT,
+            _USER_MSG,
+            _ASSISTANT_MSG,
+            _SHUTDOWN_EVENT,
+            post_asst,
+        )
+        events = parse_events(p)
+        summary = build_session_summary(events)
+        assert summary.is_active is True
+        assert summary.active_output_tokens == 120
+
     def test_model_inferred_from_highest_request_count(self, tmp_path: Path) -> None:
         """Shutdown with multiple models, no currentModel → picks highest requests.count."""
         shutdown_multi = json.dumps(
@@ -1785,6 +1841,34 @@ class TestConfigModelReading:
         events = parse_events(p)
         summary = build_session_summary(events, config_path=config)
         assert summary.model is None
+
+    def test_active_session_model_none_with_output_tokens_has_empty_metrics(
+        self, tmp_path: Path
+    ) -> None:
+        """model=None + output tokens → model_metrics empty, active_output_tokens set."""
+        config = tmp_path / "nonexistent" / "config.json"
+        asst_250 = json.dumps(
+            {
+                "type": "assistant.message",
+                "data": {
+                    "messageId": "msg-250",
+                    "content": "hello",
+                    "toolRequests": [],
+                    "interactionId": "int-1",
+                    "outputTokens": 250,
+                },
+                "id": "ev-asst-250",
+                "timestamp": "2026-03-07T10:01:05.000Z",
+                "parentId": "ev-user1",
+            }
+        )
+        p = tmp_path / "s" / "events.jsonl"
+        _write_events(p, _START_EVENT, _USER_MSG, asst_250)
+        events = parse_events(p)
+        summary = build_session_summary(events, config_path=config)
+        assert summary.model is None
+        assert summary.model_metrics == {}
+        assert summary.active_output_tokens == 250
 
     def test_invalid_config_json(self, tmp_path: Path) -> None:
         """Malformed config.json → model stays None."""


### PR DESCRIPTION
Adds tests for three untested code paths in `build_session_summary` identified in #248:

### 1. `USER_MESSAGE` alone marks session as resumed
After a shutdown, a `user.message` event (without any `session.resume`) correctly sets `is_active=True` and increments `active_user_messages`.

### 2. `ASSISTANT_MESSAGE` alone marks session as resumed
After a shutdown, an `assistant.message` event (without any `session.resume`) correctly sets `is_active=True` and accumulates `active_output_tokens`.

### 3. Active session with `model=None` and positive output tokens
When no model can be determined (no `tool.execution_complete`, no `config.json`) but `assistant.message` events contribute output tokens, `model_metrics` is empty `{}` while `active_output_tokens` still reflects the token count.

> Note: The `_infer_model_from_metrics` unit tests (empty dict, single key, highest count, tie-break by insertion order) already existed in the test suite.

### Verification
- All 516 tests pass
- Coverage: 98.74% (threshold: 80%)
- ruff, pyright clean

Closes #248




> Generated by [Issue Implementer](https://github.com/microsasa/cli-tools/actions/runs/23414968102) · [◷](https://github.com/search?q=repo%3Amicrosasa%2Fcli-tools+%22gh-aw-workflow-id%3A+issue-implementer%22&type=pullrequests)

> [!WARNING]
> <details>
> <summary>⚠️ Firewall blocked 1 domain</summary>
>
> The following domain was blocked by the firewall during workflow execution:
>
> - `astral.sh`
>
> To allow these domains, add them to the `network.allowed` list in your workflow frontmatter:
>
> ```yaml
> network:
>   allowed:
>     - defaults
>     - "astral.sh"
> ```
>
> See [Network Configuration](https://github.github.com/gh-aw/reference/network/) for more information.
>
> </details>


<!-- gh-aw-agentic-workflow: Issue Implementer, engine: copilot, model: claude-opus-4.6, id: 23414968102, workflow_id: issue-implementer, run: https://github.com/microsasa/cli-tools/actions/runs/23414968102 -->

<!-- gh-aw-workflow-id: issue-implementer -->