### PR TITLE
fix: widen `_safe_mtime` to catch `OSError`, not just `FileNotFoundError` (#249)

### DIFF
--- a/src/copilot_usage/parser.py
+++ b/src/copilot_usage/parser.py
@@ -68,10 +68,10 @@ def _read_config_model(config_path: Path | None = None) -> str | None:
 
 
 def _safe_mtime(path: Path) -> float:
-    """Return *path*'s mtime, or ``0`` if the file no longer exists."""
+    """Return *path*'s mtime, or ``0`` on any OS-level error (deleted, permission denied, etc.)."""
     try:
         return path.stat().st_mtime
-    except FileNotFoundError:
+    except OSError:
         return 0.0
 
 

--- a/tests/copilot_usage/test_parser.py
+++ b/tests/copilot_usage/test_parser.py
@@ -28,6 +28,7 @@ from copilot_usage.models import (
 from copilot_usage.parser import (
     _extract_session_name,
     _infer_model_from_metrics,
+    _safe_mtime,
     build_session_summary,
     discover_sessions,
     get_all_sessions,
@@ -298,6 +299,45 @@ def _active_events(
 
 
 # ---------------------------------------------------------------------------
+# _safe_mtime
+# ---------------------------------------------------------------------------
+
+
+class TestSafeMtime:
+    def test_returns_mtime_for_existing_file(self, tmp_path: Path) -> None:
+        f = tmp_path / "events.jsonl"
+        f.write_text("")
+        assert _safe_mtime(f) > 0
+
+    def test_returns_zero_for_missing_file(self, tmp_path: Path) -> None:
+        assert _safe_mtime(tmp_path / "ghost.jsonl") == 0.0
+
+    def test_returns_zero_for_permission_error(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        f = tmp_path / "events.jsonl"
+        f.write_text("")
+
+        def _raise_perm(self: Path, **kwargs: object) -> object:
+            raise PermissionError("denied")
+
+        monkeypatch.setattr(Path, "stat", _raise_perm)
+        assert _safe_mtime(f) == 0.0
+
+    def test_returns_zero_for_generic_oserror(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        f = tmp_path / "events.jsonl"
+        f.write_text("")
+
+        def _raise_os(self: Path, **kwargs: object) -> object:
+            raise OSError("I/O error")
+
+        monkeypatch.setattr(Path, "stat", _raise_os)
+        assert _safe_mtime(f) == 0.0
+
+
+# ---------------------------------------------------------------------------
 # discover_sessions
 # ---------------------------------------------------------------------------
 
@@ -354,6 +394,24 @@ class TestDiscoverSessions:
         assert any(p == s2 for p in result)
         # The call must not raise
         assert isinstance(result, list)
+
+    def test_stat_race_permission_error(self, tmp_path: Path) -> None:
+        """discover_sessions should not crash when stat() raises PermissionError."""
+        s1 = tmp_path / "sess-a" / "events.jsonl"
+        _write_events(s1, _START_EVENT)
+
+        original_stat = Path.stat
+
+        def _flaky_stat(self: Path, **kwargs: object) -> object:
+            if self.name == "events.jsonl":
+                raise PermissionError("denied")
+            return original_stat(self)
+
+        with patch.object(Path, "stat", _flaky_stat):
+            result = discover_sessions(tmp_path)
+
+        # Should return the path (with mtime=0), not crash
+        assert result == [s1]
 
     def test_get_all_sessions_skips_vanished_session(self, tmp_path: Path) -> None:
         """TOCTOU: events.jsonl deleted after discover but before parse."""


### PR DESCRIPTION
Closes #249

## Problem

`_safe_mtime` in `parser.py` only caught `FileNotFoundError`, so any other `OSError` subclass (e.g. `PermissionError` from unreadable session files) would propagate out of `sorted()` in `discover_sessions` and crash every CLI command.

## Fix

Widened the `except` clause from `FileNotFoundError` to `OSError`. Since `FileNotFoundError` is a subclass of `OSError`, existing behavior is preserved while now also handling `PermissionError`, I/O errors, etc.

## Tests added

- **`TestSafeMtime`** — 4 unit tests covering existing file, missing file, `PermissionError`, and generic `OSError`
- **`test_stat_race_permission_error`** — integration test verifying `discover_sessions` doesn't crash when `stat()` raises `PermissionError`

## Verification

All 521 tests pass, coverage at 98.74%, ruff/pyright clean.




> Generated by [Issue Implementer](https://github.com/microsasa/cli-tools/actions/runs/23415214478) · [◷](https://github.com/search?q=repo%3Amicrosasa%2Fcli-tools+%22gh-aw-workflow-id%3A+issue-implementer%22&type=pullrequests)

> [!WARNING]
> <details>
> <summary>⚠️ Firewall blocked 1 domain</summary>
>
> The following domain was blocked by the firewall during workflow execution:
>
> - `astral.sh`
>
> To allow these domains, add them to the `network.allowed` list in your workflow frontmatter:
>
> ```yaml
> network:
>   allowed:
>     - defaults
>     - "astral.sh"
> ```
>
> See [Network Configuration](https://github.github.com/gh-aw/reference/network/) for more information.
>
> </details>


<!-- gh-aw-agentic-workflow: Issue Implementer, engine: copilot, model: claude-opus-4.6, id: 23415214478, workflow_id: issue-implementer, run: https://github.com/microsasa/cli-tools/actions/runs/23415214478 -->

<!-- gh-aw-workflow-id: issue-implementer -->