### PR TITLE
docs: fix stale changelog and plan.md (#260)

### DIFF
--- a/src/copilot_usage/docs/changelog.md
+++ b/src/copilot_usage/docs/changelog.md
@@ -36,16 +36,17 @@ Append-only history of what was planned and delivered, PR by PR. Newest entries 
 
 ---
 
-## refactor: remove multiplier estimation, report raw event counts — 2026-03-13
+## refactor: remove multiplier estimation from summary/cost, report raw event counts — 2026-03-13
 
-**Plan**: Strip out all multiplier-based premium request estimation. Report raw facts: model calls (assistant.turn_start count), user messages, output tokens, and exact premium requests from shutdown data only.
+**Plan**: Strip out multiplier-based premium request estimation from `SessionSummary` and the `cost`/`summary` commands. Report raw facts: model calls (assistant.turn_start count), user messages, output tokens, and exact premium requests from shutdown data only.
 
 **Done**:
 - Removed estimated_premium_requests from SessionSummary
 - Added model_calls and user_messages fields
 - Simplified cost command to raw data only
-- Removed ~ prefix estimation display
 - Updated all tests and fixtures
+
+**Note**: Active/live sessions still show estimated costs with a `~` prefix via `_estimate_premium_cost` in the `live` command's "Est. Cost" column. This estimation was intentionally kept for live sessions where exact premium data is not yet available from a shutdown event.
 
 ---
 

--- a/src/copilot_usage/docs/plan.md
+++ b/src/copilot_usage/docs/plan.md
@@ -23,9 +23,6 @@ Standards: follows `microsasa/project-standards`
   - `session.shutdown` — `totalPremiumRequests`, `totalApiDurationMs`, `modelMetrics` (per-model `inputTokens`, `outputTokens`, `cacheReadTokens`, `cacheWriteTokens`, request count & cost), `codeChanges`, `currentModel`
   - `tool.execution_complete` — model used per tool call
   - `user.message` — user prompts
-- **`workspace.yaml`** — session workspace/cwd info
-- **`~/.copilot/logs/process-*.log`** — CompactionProcessor lines show real-time token utilization
-
 **Commands**:
 - `copilot-usage` — launches Rich interactive mode with numbered session list, cost view, and watchdog-based auto-refresh (2-second debounce)
 - `copilot-usage session <id>` — per-turn token breakdown, tools used, API call timeline, code changes (static CLI output)


### PR DESCRIPTION
Fixes #260

### Changes

**`src/copilot_usage/docs/changelog.md`** — The "refactor: remove multiplier estimation" entry incorrectly claimed all estimation was removed (including `~ prefix estimation display`). In reality, `_estimate_premium_cost()` and `_estimated_output_tokens()` are still actively used for the `live` command. Updated the entry to:
- Scope the removal to `SessionSummary` and the `cost`/`summary` commands
- Remove the inaccurate "Removed ~ prefix estimation display" bullet
- Add a note clarifying that live sessions still show `~`-prefixed estimated costs

**`src/copilot_usage/docs/plan.md`** — Removed two data source entries (`workspace.yaml` and `process-*.log`) that are not implemented anywhere in the codebase. CWD is already read from `session.start` event data.

### Testing

Documentation-only changes. Full CI suite passes (540 tests, 99% coverage, ruff/pyright clean).




> Generated by [Issue Implementer](https://github.com/microsasa/cli-tools/actions/runs/23420815322) · [◷](https://github.com/search?q=repo%3Amicrosasa%2Fcli-tools+%22gh-aw-workflow-id%3A+issue-implementer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Issue Implementer, engine: copilot, model: claude-opus-4.6, id: 23420815322, workflow_id: issue-implementer, run: https://github.com/microsasa/cli-tools/actions/runs/23420815322 -->

<!-- gh-aw-workflow-id: issue-implementer -->