### PR TITLE
fix: minor cleanup bundle — redundant factory, dead branch, naming, stale docs (#277)

### DIFF
--- a/src/copilot_usage/docs/architecture.md
+++ b/src/copilot_usage/docs/architecture.md
@@ -78,11 +78,11 @@ tests/
 │   ├── test_report.py          Rich output formatting, rendering functions
 │   └── test_cli.py             Click command invocation via CliRunner
 └── e2e/                        E2e tests — real CLI commands against fixture data
-    ├── fixtures/               Anonymized events from real Copilot sessions (8 fixtures)
+    ├── fixtures/               Anonymized events from real Copilot sessions (9 fixtures)
     └── test_e2e.py             Full pipeline: CLI → parser → models → report → output
 ```
 
-- **327 total tests**: 272 unit tests + 55 e2e tests
 - **Unit tests**: 96% coverage, test individual functions with synthetic data
-- **E2e tests**: Run actual CLI commands against 8 anonymized fixture sessions, assert on output content
+- **E2e tests**: Run actual CLI commands against 9 anonymized fixture sessions, assert on output content
+- Test counts grow regularly — run `make test` to see the current numbers
 - Coverage is measured on unit tests only (e2e coverage would be misleading)

--- a/src/copilot_usage/models.py
+++ b/src/copilot_usage/models.py
@@ -131,11 +131,6 @@ class SessionStartData(BaseModel):
     context: SessionContext = Field(default_factory=SessionContext)
 
 
-def empty_tool_requests() -> list[dict[str, object]]:
-    """Factory for an empty list of tool request dicts."""
-    return []
-
-
 class AssistantMessageData(BaseModel):
     """Payload for ``assistant.message`` events."""
 
@@ -145,7 +140,9 @@ class AssistantMessageData(BaseModel):
     interactionId: str = ""
     reasoningText: str | None = None
     reasoningOpaque: str | None = None
-    toolRequests: list[dict[str, object]] = Field(default_factory=empty_tool_requests)
+    toolRequests: list[dict[str, object]] = Field(
+        default_factory=lambda: list[dict[str, object]]()
+    )
 
 
 class SessionShutdownData(BaseModel):

--- a/src/copilot_usage/report.py
+++ b/src/copilot_usage/report.py
@@ -319,8 +319,6 @@ def _truncate(text: str, max_len: int = _MAX_CONTENT_LEN) -> str:
         return ""
     if len(text) <= max_len:
         return text
-    if max_len == 1:
-        return "…"
     return text[: max_len - 1] + "…"
 
 
@@ -396,14 +394,14 @@ def _build_event_details(ev: SessionEvent) -> str:
         case EventType.TOOL_EXECUTION_COMPLETE:
             if (data := _safe_event_data(ev, ev.as_tool_execution)) is None:
                 return ""
-            parts_t: list[str] = []
+            parts: list[str] = []
             tool_name = _extract_tool_name(data)
             if tool_name:
-                parts_t.append(tool_name)
-            parts_t.append("✓" if data.success else "✗")
+                parts.append(tool_name)
+            parts.append("✓" if data.success else "✗")
             if data.model:
-                parts_t.append(f"model={data.model}")
-            return "  ".join(parts_t)
+                parts.append(f"model={data.model}")
+            return "  ".join(parts)
 
         case EventType.SESSION_SHUTDOWN:
             if (data := _safe_event_data(ev, ev.as_session_shutdown)) is None:


### PR DESCRIPTION
Closes #277

### Changes

1. **Remove `empty_tool_requests()` redundant factory** (`models.py`) — replaced `default_factory=empty_tool_requests` with an inline typed lambda `lambda: list[dict[str, object]]()`, consistent with how every other list/dict field uses inline factories. Deleted the module-level function.

2. **Remove dead `if max_len == 1` branch** (`report.py:_truncate`) — the general case `text[:max_len - 1] + "…"` already produces `"…"` when `max_len == 1`. Existing test `test_max_len_one_returns_ellipsis` covers this edge case.

3. **Rename `parts_t` → `parts`** (`report.py:_build_event_details`) — the `_t` suffix only existed to avoid a same-scope reuse warning, but the `match`/`case` arms are mutually exclusive. Now uses `parts` consistently.

4. **Update stale counts in `architecture.md`** — fixture count 8 → 9, replaced hardcoded test counts with a pointer to `make test` to prevent future drift.

### Testing

- All 561 tests pass (502 unit + 59 e2e)
- Coverage: 99.27% (≥80% threshold)
- `ruff check`, `ruff format`, and `pyright` all clean




> Generated by [Issue Implementer](https://github.com/microsasa/cli-tools/actions/runs/23422883566) · [◷](https://github.com/search?q=repo%3Amicrosasa%2Fcli-tools+%22gh-aw-workflow-id%3A+issue-implementer%22&type=pullrequests)

> [!WARNING]
> <details>
> <summary>⚠️ Firewall blocked 1 domain</summary>
>
> The following domain was blocked by the firewall during workflow execution:
>
> - `astral.sh`
>
> To allow these domains, add them to the `network.allowed` list in your workflow frontmatter:
>
> ```yaml
> network:
>   allowed:
>     - defaults
>     - "astral.sh"
> ```
>
> See [Network Configuration](https://github.github.com/gh-aw/reference/network/) for more information.
>
> </details>


<!-- gh-aw-agentic-workflow: Issue Implementer, engine: copilot, model: claude-opus-4.6, id: 23422883566, workflow_id: issue-implementer, run: https://github.com/microsasa/cli-tools/actions/runs/23422883566 -->

<!-- gh-aw-workflow-id: issue-implementer -->