### PR TITLE
fix: use _total_output_tokens in _render_aggregate_stats for resumed sessions (#290)

### DIFF
--- a/src/copilot_usage/report.py
+++ b/src/copilot_usage/report.py
@@ -458,7 +458,7 @@ def _render_aggregate_stats(
     """Print aggregate stats panel (model calls, user msgs, tokens, premium)."""
     out = target_console or Console()
 
-    total_output = sum(mm.usage.outputTokens for mm in summary.model_metrics.values())
+    total_output = _total_output_tokens(summary)
 
     lines = [
         f"[green]{summary.model_calls}[/green] model calls   "

--- a/tests/copilot_usage/test_report.py
+++ b/tests/copilot_usage/test_report.py
@@ -3243,6 +3243,43 @@ class TestTotalOutputTokens:
         assert _total_output_tokens(session) == 600  # 200 + 300 + 100
 
 
+class TestRenderAggregateStatsResumedTokens:
+    """Issue #290 — _render_aggregate_stats includes active tokens for resumed sessions."""
+
+    def test_aggregate_stats_shows_total_output_tokens_for_resumed_session(
+        self,
+    ) -> None:
+        """Output tokens in Aggregate Stats panel include active_output_tokens for resumed sessions."""
+        from copilot_usage.report import _render_aggregate_stats
+
+        session = SessionSummary(
+            session_id="agg-resumed-1234",
+            model_calls=5,
+            user_messages=3,
+            total_premium_requests=2,
+            total_api_duration_ms=1500,
+            is_active=True,
+            last_resume_time=datetime.now(tz=UTC),
+            active_output_tokens=250,
+            model_metrics={
+                "gpt-4": ModelMetrics(
+                    requests=RequestMetrics(count=5, cost=10),
+                    usage=TokenUsage(outputTokens=350),
+                ),
+            },
+        )
+
+        expected_total = _total_output_tokens(session)  # 350 + 250 = 600
+        assert expected_total == 600
+
+        output = _capture_console(_render_aggregate_stats, session)
+        assert format_tokens(expected_total) in output
+        # Ensure the shutdown-only baseline is NOT shown
+        shutdown_only = format_tokens(350)
+        if shutdown_only != format_tokens(expected_total):
+            assert shutdown_only not in output
+
+
 class TestComputeSessionTotalsResumed:
     """Issue #276 — _compute_session_totals includes active tokens for resumed sessions."""
 


### PR DESCRIPTION
## Problem

`_render_aggregate_stats` computed output token count by summing directly from `session.model_metrics`:

```python
total_output = sum(mm.usage.outputTokens for mm in summary.model_metrics.values())
```

This only reflected the shutdown baseline. For resumed sessions, post-shutdown tokens in `active_output_tokens` were excluded, understating the count in the "Aggregate Stats" panel.

## Fix

Replace the direct sum with `_total_output_tokens(summary)`, which correctly includes both the shutdown baseline and post-resume active tokens. Every other call site already uses this helper.

## Testing

Added `TestRenderAggregateStatsResumedTokens` regression test that:
1. Builds a `SessionSummary` representing a resumed session with `model_metrics` (requests.count > 0) **and** `active_output_tokens > 0`
2. Captures Rich console output from `_render_aggregate_stats`
3. Asserts the rendered token figure equals `_total_output_tokens(session)` (shutdown + active), not just the shutdown baseline

All 562 tests pass, 99.27% coverage.

Closes #290




> Generated by [Issue Implementer](https://github.com/microsasa/cli-tools/actions/runs/23429005793) · [◷](https://github.com/search?q=repo%3Amicrosasa%2Fcli-tools+%22gh-aw-workflow-id%3A+issue-implementer%22&type=pullrequests)

> [!WARNING]
> <details>
> <summary>⚠️ Firewall blocked 1 domain</summary>
>
> The following domain was blocked by the firewall during workflow execution:
>
> - `astral.sh`
>
> To allow these domains, add them to the `network.allowed` list in your workflow frontmatter:
>
> ```yaml
> network:
>   allowed:
>     - defaults
>     - "astral.sh"
> ```
>
> See [Network Configuration](https://github.github.com/gh-aw/reference/network/) for more information.
>
> </details>


<!-- gh-aw-agentic-workflow: Issue Implementer, engine: copilot, model: claude-opus-4.6, id: 23429005793, workflow_id: issue-implementer, run: https://github.com/microsasa/cli-tools/actions/runs/23429005793 -->

<!-- gh-aw-workflow-id: issue-implementer -->