### PR TITLE
fix: return None instead of empty string for absent parser values (#321)

### DIFF
--- a/src/copilot_usage/parser.py
+++ b/src/copilot_usage/parser.py
@@ -58,7 +58,7 @@ def _read_config_model(config_path: Path | None = None) -> str | None:
     try:
         data = json.loads(path.read_text(encoding="utf-8"))
         model = data.get("model")
-        return model if isinstance(model, str) else None
+        return model if isinstance(model, str) and model else None
     except (json.JSONDecodeError, OSError):
         return None
 
@@ -144,7 +144,7 @@ def _extract_session_name(session_dir: Path) -> str | None:
     try:
         first_line = plan.read_text(encoding="utf-8").split("\n", maxsplit=1)[0]
         if first_line.startswith("# "):
-            return first_line.removeprefix("# ").strip()
+            return first_line.removeprefix("# ").strip() or None
     except OSError as exc:
         logger.debug("Could not read session name from {}: {}", plan, exc)
     return None
@@ -244,7 +244,7 @@ def build_session_summary(
         # -- assistant.message --------------------------------------------
         elif ev.type == EventType.ASSISTANT_MESSAGE:
             raw_tokens = ev.data.get("outputTokens")
-            if isinstance(raw_tokens, int):
+            if isinstance(raw_tokens, int) and not isinstance(raw_tokens, bool):
                 total_output_tokens += raw_tokens
 
     # Derive name
@@ -267,7 +267,7 @@ def build_session_summary(
                 last_resume_time = ev.timestamp
             if ev.type == EventType.ASSISTANT_MESSAGE:
                 raw_tokens = ev.data.get("outputTokens")
-                if isinstance(raw_tokens, int):
+                if isinstance(raw_tokens, int) and not isinstance(raw_tokens, bool):
                     post_shutdown_output_tokens += raw_tokens
             if ev.type == EventType.ASSISTANT_TURN_START:
                 post_shutdown_turn_starts += 1

--- a/tests/copilot_usage/test_parser.py
+++ b/tests/copilot_usage/test_parser.py
@@ -28,6 +28,7 @@ from copilot_usage.models import (
 from copilot_usage.parser import (
     _extract_session_name,
     _infer_model_from_metrics,
+    _read_config_model,
     _safe_mtime,
     build_session_summary,
     discover_sessions,
@@ -2735,3 +2736,69 @@ class TestGetAllSessionsNoStartEvent:
         assert results[0].start_time is None
         # Completed (has shutdown), not active
         assert results[0].is_active is False
+
+
+# ---------------------------------------------------------------------------
+# Falsy-string edge cases (issue #321)
+# ---------------------------------------------------------------------------
+
+
+class TestParserFalsyStringEdgeCases:
+    """Edge cases where parser helpers return '' instead of None."""
+
+    def test_extract_session_name_whitespace_heading_returns_none(
+        self, tmp_path: Path
+    ) -> None:
+        plan = tmp_path / "plan.md"
+        plan.write_text("# \n", encoding="utf-8")
+        assert _extract_session_name(tmp_path) is None
+
+    def test_extract_session_name_hash_only_returns_none(self, tmp_path: Path) -> None:
+        plan = tmp_path / "plan.md"
+        plan.write_text("#\n", encoding="utf-8")
+        assert _extract_session_name(tmp_path) is None
+
+    def test_read_config_model_empty_string_returns_none(self, tmp_path: Path) -> None:
+        config = tmp_path / "config.json"
+        config.write_text('{"model": ""}', encoding="utf-8")
+        assert _read_config_model(config) is None
+
+    def test_output_tokens_boolean_true_excluded(self, tmp_path: Path) -> None:
+        """Boolean True must not be counted as outputTokens."""
+        msg_bool_tokens = json.dumps(
+            {
+                "type": "assistant.message",
+                "data": {
+                    "messageId": "m1",
+                    "content": "hi",
+                    "outputTokens": True,
+                },
+                "id": "ev-m",
+                "timestamp": "2026-03-07T10:01:00.000Z",
+            }
+        )
+        p = tmp_path / "s" / "events.jsonl"
+        _write_events(p, _START_EVENT, msg_bool_tokens)
+        events = parse_events(p)
+        summary = build_session_summary(events)
+        assert summary.active_output_tokens == 0
+
+    def test_output_tokens_boolean_false_excluded(self, tmp_path: Path) -> None:
+        """Boolean False must not be counted as outputTokens."""
+        msg_bool_tokens = json.dumps(
+            {
+                "type": "assistant.message",
+                "data": {
+                    "messageId": "m1",
+                    "content": "hi",
+                    "outputTokens": False,
+                },
+                "id": "ev-m",
+                "timestamp": "2026-03-07T10:01:00.000Z",
+            }
+        )
+        p = tmp_path / "s" / "events.jsonl"
+        _write_events(p, _START_EVENT, msg_bool_tokens)
+        events = parse_events(p)
+        summary = build_session_summary(events)
+        assert summary.active_output_tokens == 0


### PR DESCRIPTION
Closes #321

## Changes

Three parser helpers could return `""` instead of `None` for semantically absent values, violating the `str | None` contract on `SessionSummary` fields.

### 1. `_extract_session_name` — whitespace-only `#` heading
A `plan.md` containing only `"# \n"` would return `""`. Now returns `None` via `or None`.

### 2. `_read_config_model` — `{"model": ""}` in config.json
An empty model string passed the `isinstance(model, str)` check. Added `and model` guard to return `None`.

### 3. `isinstance(raw_tokens, int)` — boolean pitfall
`isinstance(True, int)` is `True` in Python, so `"outputTokens": true` would silently add 1 to token counts. Added `and not isinstance(raw_tokens, bool)` guard at both accumulation sites.

## Tests

Added `TestParserFalsyStringEdgeCases` class with 5 tests:
- `test_extract_session_name_whitespace_heading_returns_none`
- `test_extract_session_name_hash_only_returns_none`
- `test_read_config_model_empty_string_returns_none`
- `test_output_tokens_boolean_true_excluded`
- `test_output_tokens_boolean_false_excluded`

## Verification

All 608 tests pass, 99% coverage, ruff/pyright clean.




> Generated by [Issue Implementer](https://github.com/microsasa/cli-tools/actions/runs/23474543149) · [◷](https://github.com/search?q=repo%3Amicrosasa%2Fcli-tools+%22gh-aw-workflow-id%3A+issue-implementer%22&type=pullrequests)

> [!WARNING]
> <details>
> <summary>⚠️ Firewall blocked 1 domain</summary>
>
> The following domain was blocked by the firewall during workflow execution:
>
> - `astral.sh`
>
> To allow these domains, add them to the `network.allowed` list in your workflow frontmatter:
>
> ```yaml
> network:
>   allowed:
>     - defaults
>     - "astral.sh"
> ```
>
> See [Network Configuration](https://github.github.com/gh-aw/reference/network/) for more information.
>
> </details>


<!-- gh-aw-agentic-workflow: Issue Implementer, engine: copilot, model: claude-opus-4.6, id: 23474543149, workflow_id: issue-implementer, run: https://github.com/microsasa/cli-tools/actions/runs/23474543149 -->

<!-- gh-aw-workflow-id: issue-implementer -->