### PR TITLE
fix: emit warning for malformed config.json in _read_config_model (#322)

### DIFF
--- a/src/copilot_usage/parser.py
+++ b/src/copilot_usage/parser.py
@@ -59,7 +59,14 @@ def _read_config_model(config_path: Path | None = None) -> str | None:
         data = json.loads(path.read_text(encoding="utf-8"))
         model = data.get("model")
         return model if isinstance(model, str) and model else None
-    except (json.JSONDecodeError, OSError):
+    except json.JSONDecodeError as exc:
+        logger.warning(
+            "Config file {} contains malformed JSON; model will be unavailable: {}",
+            path,
+            exc,
+        )
+        return None
+    except OSError:
         return None
 
 

--- a/tests/copilot_usage/test_parser.py
+++ b/tests/copilot_usage/test_parser.py
@@ -2252,6 +2252,29 @@ class TestConfigModelReading:
         summary = build_session_summary(events, config_path=config)
         assert summary.model is None
 
+    def test_invalid_config_json_emits_warning(self, tmp_path: Path) -> None:
+        """Malformed config.json → returns None AND emits a WARNING log."""
+        from loguru import logger
+
+        config = tmp_path / "config.json"
+        config.write_text("NOT JSON{{{", encoding="utf-8")
+
+        warnings: list[str] = []
+        handler_id = logger.add(
+            lambda msg: warnings.append(str(msg)),
+            level="WARNING",
+            format="{message}",
+        )
+        try:
+            result = _read_config_model(config)
+        finally:
+            logger.remove(handler_id)
+
+        assert result is None
+        assert len(warnings) == 1
+        assert "malformed JSON" in warnings[0]
+        assert str(config) in warnings[0]
+
     def test_config_without_model_key(self, tmp_path: Path) -> None:
         """config.json without 'model' key → model stays None."""
         config = tmp_path / "config.json"


### PR DESCRIPTION
Closes #322

## Problem

`_read_config_model()` caught both `json.JSONDecodeError` and `OSError` in a single bare clause and returned `None` silently. This conflated two fundamentally different failure modes:

- **`OSError`** — expected/benign (config file doesn't exist yet)
- **`json.JSONDecodeError`** — unexpected/user-impacting (corrupt config file)

Users with a corrupted `~/.copilot/config.json` saw `model: —` with no diagnostic output.

## Fix

Split the exception handling into separate branches:

- `json.JSONDecodeError` → emits `logger.warning(...)` with the file path and error details
- `OSError` → stays silent (expected case)

This is consistent with how the rest of the parser handles unexpected data quality issues (e.g., `parse_events()` line 120, `get_all_sessions()` line 377).

## Testing

Added `test_invalid_config_json_emits_warning` which:
1. Writes malformed JSON to a temp `config.json`
2. Calls `_read_config_model()` with that path
3. Asserts the return value is `None` **and** that exactly one `WARNING`-level log entry was emitted containing `"malformed JSON"` and the config file path

Uses loguru's test sink pattern (`logger.add(sink)`) consistent with existing test patterns.

All 609 tests pass. Coverage at 99%.




> Generated by [Issue Implementer](https://github.com/microsasa/cli-tools/actions/runs/23474876236) · [◷](https://github.com/search?q=repo%3Amicrosasa%2Fcli-tools+%22gh-aw-workflow-id%3A+issue-implementer%22&type=pullrequests)

> [!WARNING]
> <details>
> <summary>⚠️ Firewall blocked 1 domain</summary>
>
> The following domain was blocked by the firewall during workflow execution:
>
> - `astral.sh`
>
> To allow these domains, add them to the `network.allowed` list in your workflow frontmatter:
>
> ```yaml
> network:
>   allowed:
>     - defaults
>     - "astral.sh"
> ```
>
> See [Network Configuration](https://github.github.com/gh-aw/reference/network/) for more information.
>
> </details>


<!-- gh-aw-agentic-workflow: Issue Implementer, engine: copilot, model: claude-opus-4.6, id: 23474876236, workflow_id: issue-implementer, run: https://github.com/microsasa/cli-tools/actions/runs/23474876236 -->

<!-- gh-aw-workflow-id: issue-implementer -->