### PR TITLE
fix: include zero-metrics completed sessions in historical section (#323)

### DIFF
--- a/src/copilot_usage/report.py
+++ b/src/copilot_usage/report.py
@@ -888,11 +888,11 @@ def _render_historical_section(
     sessions: list[SessionSummary],
 ) -> None:
     """Render Section 1: Historical Data from shutdown cycles."""
-    # Filter to sessions that have shutdown data
+    # Include all completed (non-active) sessions so they are never silently
+    # invisible.  Previously, zero-metrics completed sessions were excluded,
+    # causing a count mismatch with ``render_summary()``.
     historical = [
-        s
-        for s in sessions
-        if s.total_premium_requests > 0 or (s.model_metrics and not s.is_active)
+        s for s in sessions if s.total_premium_requests > 0 or not s.is_active
     ]
 
     if not historical:

--- a/tests/copilot_usage/test_report.py
+++ b/tests/copilot_usage/test_report.py
@@ -1622,6 +1622,31 @@ class TestRenderFullSummary:
             "Row should not display historical total output tokens '100.0K'"
         )
 
+    def test_completed_zero_metrics_session_visible(self) -> None:
+        """Completed session with zero metrics must appear in historical section.
+
+        Regression test for issue #323: a completed (is_active=False) session
+        with total_premium_requests=0 and model_metrics={} was silently
+        excluded from both the historical and active sections in interactive
+        mode, making it completely invisible.
+        """
+        session = SessionSummary(
+            session_id="zero-met-1111-aaaaaa",
+            name="Zero Metrics Done",
+            start_time=datetime(2025, 1, 15, 10, 0, tzinfo=UTC),
+            end_time=datetime(2025, 1, 15, 10, 5, tzinfo=UTC),
+            is_active=False,
+            total_premium_requests=0,
+            model_metrics={},
+        )
+        output = _capture_full_summary([session])
+        # The session must NOT be invisible — it should appear in the
+        # historical section (either by name or session ID prefix).
+        assert "Zero Metrics Done" in output
+        # The historical section must be rendered (not "No historical shutdown
+        # data"), since there IS a completed session.
+        assert "No historical shutdown data" not in output
+
 
 # ---------------------------------------------------------------------------
 # render_cost_view capture helper


### PR DESCRIPTION
Closes #323

## Problem

`_render_historical_section()` in `report.py` filtered sessions with:

```python
historical = [
    s for s in sessions
    if s.total_premium_requests > 0 or (s.model_metrics and not s.is_active)
]
```

A **completed** session (`is_active=False`) with `total_premium_requests=0` and `model_metrics={}` was excluded because `{}` is falsy in Python. Such sessions were invisible in interactive mode while still appearing in `copilot-usage summary`.

## Fix

Replaced the filter with:

```python
historical = [
    s for s in sessions if s.total_premium_requests > 0 or not s.is_active
]
```

This includes **all** completed sessions in the historical section regardless of whether they have model metrics, while still keeping resumed sessions (active with prior shutdown data) in the historical view.

## Testing

Added `test_completed_zero_metrics_session_visible` regression test that:
1. Creates a `SessionSummary` with `is_active=False`, `total_premium_requests=0`, `model_metrics={}`
2. Calls `render_full_summary([session])`
3. Asserts the session name appears in the output and "No historical shutdown data" is **not** shown

All 610 tests pass, ruff/pyright clean.




> Generated by [Issue Implementer](https://github.com/microsasa/cli-tools/actions/runs/23475202020) · [◷](https://github.com/search?q=repo%3Amicrosasa%2Fcli-tools+%22gh-aw-workflow-id%3A+issue-implementer%22&type=pullrequests)

> [!WARNING]
> <details>
> <summary>⚠️ Firewall blocked 1 domain</summary>
>
> The following domain was blocked by the firewall during workflow execution:
>
> - `astral.sh`
>
> To allow these domains, add them to the `network.allowed` list in your workflow frontmatter:
>
> ```yaml
> network:
>   allowed:
>     - defaults
>     - "astral.sh"
> ```
>
> See [Network Configuration](https://github.github.com/gh-aw/reference/network/) for more information.
>
> </details>


<!-- gh-aw-agentic-workflow: Issue Implementer, engine: copilot, model: claude-opus-4.6, id: 23475202020, workflow_id: issue-implementer, run: https://github.com/microsasa/cli-tools/actions/runs/23475202020 -->

<!-- gh-aw-workflow-id: issue-implementer -->