### PR TITLE
test: add ValidationError path tests for SessionEvent accessors (#337)

### DIFF
--- a/tests/copilot_usage/test_models.py
+++ b/tests/copilot_usage/test_models.py
@@ -4,6 +4,7 @@ import json
 from datetime import UTC, datetime
 
 import pytest
+from pydantic import ValidationError
 
 from copilot_usage.models import (
     EPOCH,
@@ -387,6 +388,12 @@ class TestAsSessionStart:
         with pytest.raises(ValueError, match="session.start"):
             ev.as_session_start()
 
+    def test_invalid_data_raises_validation_error(self) -> None:
+        ev = SessionEvent(type=EventType.SESSION_START, data={})
+        with pytest.raises(ValidationError) as exc_info:
+            ev.as_session_start()
+        assert type(exc_info.value) is not ValueError
+
 
 class TestAsSessionShutdown:
     """Tests for SessionEvent.as_session_shutdown()."""
@@ -401,6 +408,15 @@ class TestAsSessionShutdown:
         ev = SessionEvent.model_validate(RAW_SESSION_START)
         with pytest.raises(ValueError, match="session.shutdown"):
             ev.as_session_shutdown()
+
+    def test_invalid_data_raises_validation_error(self) -> None:
+        ev = SessionEvent(
+            type=EventType.SESSION_SHUTDOWN,
+            data={"totalPremiumRequests": "not-an-int"},
+        )
+        with pytest.raises(ValidationError) as exc_info:
+            ev.as_session_shutdown()
+        assert type(exc_info.value) is not ValueError
 
 
 class TestAsAssistantMessage:
@@ -417,6 +433,15 @@ class TestAsAssistantMessage:
         with pytest.raises(ValueError, match="assistant.message"):
             ev.as_assistant_message()
 
+    def test_invalid_data_raises_validation_error(self) -> None:
+        ev = SessionEvent(
+            type=EventType.ASSISTANT_MESSAGE,
+            data={"outputTokens": [1, 2, 3]},
+        )
+        with pytest.raises(ValidationError) as exc_info:
+            ev.as_assistant_message()
+        assert type(exc_info.value) is not ValueError
+
 
 class TestAsUserMessage:
     """Tests for SessionEvent.as_user_message()."""
@@ -431,6 +456,15 @@ class TestAsUserMessage:
         ev = SessionEvent.model_validate(RAW_ASSISTANT_MESSAGE)
         with pytest.raises(ValueError, match="user.message"):
             ev.as_user_message()
+
+    def test_invalid_data_raises_validation_error(self) -> None:
+        ev = SessionEvent(
+            type=EventType.USER_MESSAGE,
+            data={"attachments": 99},
+        )
+        with pytest.raises(ValidationError) as exc_info:
+            ev.as_user_message()
+        assert type(exc_info.value) is not ValueError
 
 
 class TestAsToolExecution:
@@ -447,6 +481,15 @@ class TestAsToolExecution:
         ev = SessionEvent.model_validate(RAW_SESSION_START)
         with pytest.raises(ValueError, match="tool.execution_complete"):
             ev.as_tool_execution()
+
+    def test_invalid_data_raises_validation_error(self) -> None:
+        ev = SessionEvent(
+            type=EventType.TOOL_EXECUTION_COMPLETE,
+            data={"success": "maybe"},
+        )
+        with pytest.raises(ValidationError) as exc_info:
+            ev.as_tool_execution()
+        assert type(exc_info.value) is not ValueError
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #337

## Changes

Adds `test_invalid_data_raises_validation_error` to each of the five accessor test classes in `tests/copilot_usage/test_models.py`:

| Accessor | Test class | Invalid data |
|---|---|---|
| `as_session_start()` | `TestAsSessionStart` | `data={}` (missing required `sessionId`) |
| `as_session_shutdown()` | `TestAsSessionShutdown` | `data={"totalPremiumRequests": "not-an-int"}` |
| `as_assistant_message()` | `TestAsAssistantMessage` | `data={"outputTokens": [1, 2, 3]}` |
| `as_user_message()` | `TestAsUserMessage` | `data={"attachments": 99}` |
| `as_tool_execution()` | `TestAsToolExecution` | `data={"success": "maybe"}` |

Each test:
- Constructs a `SessionEvent` with the correct event type but malformed `data`
- Asserts `pytest.raises(ValidationError)`
- Confirms the exception type is specifically `ValidationError`, not a plain `ValueError`

## Verification

All checks pass locally:
- `ruff check` — ✅
- `ruff format` — ✅
- `pyright` — ✅ (0 errors)
- `pytest --cov --cov-fail-under=80` — ✅ (637 passed, 99.13% coverage)




> Generated by [Issue Implementer](https://github.com/microsasa/cli-tools/actions/runs/23496121583) · [◷](https://github.com/search?q=repo%3Amicrosasa%2Fcli-tools+%22gh-aw-workflow-id%3A+issue-implementer%22&type=pullrequests)

> [!WARNING]
> <details>
> <summary>⚠️ Firewall blocked 1 domain</summary>
>
> The following domain was blocked by the firewall during workflow execution:
>
> - `astral.sh`
>
> To allow these domains, add them to the `network.allowed` list in your workflow frontmatter:
>
> ```yaml
> network:
>   allowed:
>     - defaults
>     - "astral.sh"
> ```
>
> See [Network Configuration](https://github.github.com/gh-aw/reference/network/) for more information.
>
> </details>


<!-- gh-aw-agentic-workflow: Issue Implementer, engine: copilot, model: claude-opus-4.6, id: 23496121583, workflow_id: issue-implementer, run: https://github.com/microsasa/cli-tools/actions/runs/23496121583 -->

<!-- gh-aw-workflow-id: issue-implementer -->