### PR TITLE
fix: stale docstring, short-circuit return, missing helper docstrings (#340)

### DIFF
--- a/src/copilot_usage/logging_config.py
+++ b/src/copilot_usage/logging_config.py
@@ -24,6 +24,7 @@ CONSOLE_FORMAT = (
 
 
 def _emoji_patcher(record: "loguru.Record") -> None:
+    """Inject a level-specific emoji into the log record's extras."""
     record["extra"]["emoji"] = LEVEL_EMOJI.get(record["level"].name, "  ")
 
 

--- a/src/copilot_usage/models.py
+++ b/src/copilot_usage/models.py
@@ -213,8 +213,7 @@ class SessionEvent(BaseModel):
     """A single event from an ``events.jsonl`` file.
 
     ``data`` is kept as a generic dict-like object; callers can use the
-    helper ``parsed_data`` property (or ``parse_data()``) to get a typed
-    payload when needed.
+    helper ``parse_data()`` method to get a typed payload when needed.
     """
 
     type: str

--- a/src/copilot_usage/parser.py
+++ b/src/copilot_usage/parser.py
@@ -399,6 +399,7 @@ def get_all_sessions(base_path: Path | None = None) -> list[SessionSummary]:
         summaries.append(summary)
 
     def _sort_key(s: SessionSummary) -> datetime:
+        """Return an aware start_time for sorting, falling back to EPOCH."""
         return ensure_aware(s.start_time) if s.start_time is not None else EPOCH
 
     summaries.sort(key=_sort_key, reverse=True)

--- a/src/copilot_usage/pricing.py
+++ b/src/copilot_usage/pricing.py
@@ -57,6 +57,7 @@ class ModelPricing(BaseModel):
 
 
 def _tier_from_multiplier(m: float) -> PricingTier:
+    """Map a numeric multiplier to the corresponding ``PricingTier``."""
     if m >= 3.0:
         return PricingTier.PREMIUM
     if m == 0.0:

--- a/src/copilot_usage/report.py
+++ b/src/copilot_usage/report.py
@@ -691,6 +691,7 @@ def _filter_sessions(
             UserWarning,
             stacklevel=2,
         )
+        return []
 
     if since is None and until is None:
         return sessions

--- a/tests/copilot_usage/test_report.py
+++ b/tests/copilot_usage/test_report.py
@@ -2566,6 +2566,17 @@ class TestFilterSessionsReversedDateRange:
         assert "--since" in str(caught[0].message)
         assert "after" in str(caught[0].message)
 
+    def test_reversed_range_warns_on_empty_list(self) -> None:
+        """Warning fires even with an empty sessions list (short-circuit)."""
+        since = datetime(2026, 12, 31, tzinfo=UTC)
+        until = datetime(2026, 1, 1, tzinfo=UTC)
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            result = _filter_sessions([], since=since, until=until)
+        assert result == []
+        assert len(caught) == 1
+        assert "--since" in str(caught[0].message)
+
     def test_normal_range_no_warning(self) -> None:
         """Passing since < until does NOT emit a warning."""
         session = SessionSummary(


### PR DESCRIPTION
Closes #340

### Changes

1. **Stale `parsed_data` property reference** (`models.py`): Updated `SessionEvent` docstring to reference the actual `parse_data()` method instead of non-existent `parsed_data` property.

2. **`_filter_sessions` short-circuit** (`report.py`): Return `[]` immediately after the reversed date-range warning instead of falling through into the filter loop.

3. **Missing helper docstrings**: Added one-line docstrings to:
   - `_sort_key` in `parser.py`
   - `_tier_from_multiplier` in `pricing.py`
   - `_emoji_patcher` in `logging_config.py`

### Testing

- Existing `test_reversed_since_until_warns` continues to pass.
- Added `test_reversed_range_warns_on_empty_list` to confirm the warning fires even with an empty sessions list (verifying the short-circuit path).
- All 641 tests pass. Coverage: 99.35%.




> Generated by [Issue Implementer](https://github.com/microsasa/cli-tools/actions/runs/23499635409) · [◷](https://github.com/search?q=repo%3Amicrosasa%2Fcli-tools+%22gh-aw-workflow-id%3A+issue-implementer%22&type=pullrequests)

> [!WARNING]
> <details>
> <summary>⚠️ Firewall blocked 1 domain</summary>
>
> The following domain was blocked by the firewall during workflow execution:
>
> - `astral.sh`
>
> To allow these domains, add them to the `network.allowed` list in your workflow frontmatter:
>
> ```yaml
> network:
>   allowed:
>     - defaults
>     - "astral.sh"
> ```
>
> See [Network Configuration](https://github.github.com/gh-aw/reference/network/) for more information.
>
> </details>


<!-- gh-aw-agentic-workflow: Issue Implementer, engine: copilot, model: claude-opus-4.6, id: 23499635409, workflow_id: issue-implementer, run: https://github.com/microsasa/cli-tools/actions/runs/23499635409 -->

<!-- gh-aw-workflow-id: issue-implementer -->