### PR TITLE
fix: replace implicit sentinel with explicit has_shutdown_metrics flag (#351)

### DIFF
--- a/src/copilot_usage/models.py
+++ b/src/copilot_usage/models.py
@@ -325,6 +325,7 @@ class SessionSummary(BaseModel):
     user_messages: int = 0
     last_resume_time: datetime | None = None
     is_active: bool = False
+    has_shutdown_metrics: bool = False
     events_path: Path | None = None
 
     # Post-shutdown activity (only populated for resumed/active sessions)

--- a/src/copilot_usage/parser.py
+++ b/src/copilot_usage/parser.py
@@ -319,6 +319,7 @@ def build_session_summary(
             model_calls=total_turn_starts,
             user_messages=user_message_count,
             is_active=session_resumed,
+            has_shutdown_metrics=bool(merged_metrics),
             last_resume_time=last_resume_time,
             active_model_calls=post_shutdown_turn_starts,
             active_user_messages=post_shutdown_user_messages,

--- a/src/copilot_usage/report.py
+++ b/src/copilot_usage/report.py
@@ -127,10 +127,10 @@ def _shutdown_output_tokens(session: SessionSummary) -> int:
 def _total_output_tokens(session: SessionSummary) -> int:
     """Return total output tokens including post-resume active tokens.
 
-    For resumed sessions whose ``model_metrics`` contain real shutdown data
-    (at least one model with ``requests.count > 0``), the
-    ``active_output_tokens`` field represents *additional* tokens produced
-    after the last shutdown and must be added to the historical baseline.
+    For resumed sessions whose ``has_shutdown_metrics`` flag is ``True``,
+    the ``active_output_tokens`` field represents *additional* tokens
+    produced after the last shutdown and must be added to the historical
+    baseline.
 
     When ``model_metrics`` is empty the baseline is zero, so the active
     tokens are the only source and are included unconditionally.
@@ -140,11 +140,8 @@ def _total_output_tokens(session: SessionSummary) -> int:
     would double-count.
     """
     baseline = _shutdown_output_tokens(session)
-    has_shutdown_metrics = any(
-        mm.requests.count > 0 for mm in session.model_metrics.values()
-    )
     if (
-        _has_active_period_stats(session) and has_shutdown_metrics
+        _has_active_period_stats(session) and session.has_shutdown_metrics
     ) or not session.model_metrics:
         return baseline + session.active_output_tokens
     return baseline

--- a/tests/copilot_usage/test_report.py
+++ b/tests/copilot_usage/test_report.py
@@ -1774,6 +1774,7 @@ class TestRenderCostView:
             model="claude-opus-4.6",
             start_time=datetime(2025, 1, 10, tzinfo=UTC),
             is_active=True,
+            has_shutdown_metrics=True,
             model_calls=12,
             user_messages=6,
             active_model_calls=4,
@@ -1823,6 +1824,7 @@ class TestRenderCostView:
             model="claude-opus-4.6",
             start_time=datetime(2025, 1, 15, 10, 0, tzinfo=UTC),
             is_active=True,
+            has_shutdown_metrics=True,
             model_calls=10,
             user_messages=4,
             active_model_calls=3,
@@ -1923,6 +1925,7 @@ class TestRenderCostView:
             model="claude-opus-4.5",
             start_time=datetime(2025, 1, 15, 10, 0, tzinfo=UTC),
             is_active=True,
+            has_shutdown_metrics=True,
             model_calls=5,
             active_model_calls=4,
             active_output_tokens=800,
@@ -3306,6 +3309,7 @@ class TestTotalOutputTokens:
         session = SessionSummary(
             session_id="resumed-1234",
             is_active=True,
+            has_shutdown_metrics=True,
             last_resume_time=datetime.now(tz=UTC),
             active_output_tokens=250,
             model_metrics={
@@ -3322,6 +3326,7 @@ class TestTotalOutputTokens:
         session = SessionSummary(
             session_id="pure-active-1234",
             is_active=True,
+            has_shutdown_metrics=False,
             last_resume_time=datetime.now(tz=UTC),
             active_output_tokens=400,
             model_metrics={
@@ -3331,7 +3336,7 @@ class TestTotalOutputTokens:
                 ),
             },
         )
-        # requests.count == 0 → synthetic metrics; should NOT add active tokens
+        # has_shutdown_metrics=False → should NOT add active tokens
         assert _total_output_tokens(session) == 400
 
     def test_empty_model_metrics(self) -> None:
@@ -3358,6 +3363,7 @@ class TestTotalOutputTokens:
         session = SessionSummary(
             session_id="multi-model-resumed",
             is_active=True,
+            has_shutdown_metrics=True,
             last_resume_time=datetime.now(tz=UTC),
             active_output_tokens=100,
             model_metrics={
@@ -3372,6 +3378,52 @@ class TestTotalOutputTokens:
             },
         )
         assert _total_output_tokens(session) == 600  # 200 + 300 + 100
+
+    # -- Issue #351 regression tests --
+
+    def test_active_session_with_nonzero_request_count_no_double_count(self) -> None:
+        """Active session with requests.count > 0 but has_shutdown_metrics=False.
+
+        Simulates a future scenario where in-flight requests bump count
+        without real shutdown data.  Must not double-count.
+        """
+        session = SessionSummary(
+            session_id="active-nonzero-req",
+            is_active=True,
+            has_shutdown_metrics=False,
+            last_resume_time=datetime.now(tz=UTC),
+            active_output_tokens=400,
+            model_metrics={
+                "gpt-4": ModelMetrics(
+                    requests=RequestMetrics(count=3, cost=0),
+                    usage=TokenUsage(outputTokens=400),
+                ),
+            },
+        )
+        assert _total_output_tokens(session) == 400
+
+    def test_resumed_session_with_shutdown_adds_active_tokens(self) -> None:
+        """Resumed session with has_shutdown_metrics=True adds active tokens.
+
+        Ensures shutdown_tokens + active_output_tokens, not
+        shutdown_tokens + 2 × active_output_tokens.
+        """
+        shutdown_tokens = 500
+        active_tokens = 200
+        session = SessionSummary(
+            session_id="resumed-explicit-flag",
+            is_active=True,
+            has_shutdown_metrics=True,
+            last_resume_time=datetime.now(tz=UTC),
+            active_output_tokens=active_tokens,
+            model_metrics={
+                "gpt-4": ModelMetrics(
+                    requests=RequestMetrics(count=10, cost=20),
+                    usage=TokenUsage(outputTokens=shutdown_tokens),
+                ),
+            },
+        )
+        assert _total_output_tokens(session) == shutdown_tokens + active_tokens
 
 
 class TestRenderAggregateStatsResumedTokens:
@@ -3390,6 +3442,7 @@ class TestRenderAggregateStatsResumedTokens:
             total_premium_requests=2,
             total_api_duration_ms=1500,
             is_active=True,
+            has_shutdown_metrics=True,
             last_resume_time=datetime.now(tz=UTC),
             active_output_tokens=250,
             model_metrics={
@@ -3423,6 +3476,7 @@ class TestComputeSessionTotalsResumed:
             user_messages=4,
             total_api_duration_ms=3000,
             is_active=True,
+            has_shutdown_metrics=True,
             last_resume_time=datetime.now(tz=UTC),
             active_output_tokens=250,
             model_metrics={
@@ -3457,6 +3511,7 @@ class TestComputeSessionTotalsResumed:
             user_messages=3,
             total_api_duration_ms=2000,
             is_active=True,
+            has_shutdown_metrics=True,
             last_resume_time=datetime.now(tz=UTC),
             active_output_tokens=200,
             model_metrics={
@@ -3482,6 +3537,7 @@ class TestRenderSessionTableResumed:
             model="gpt-4",
             start_time=datetime(2025, 6, 1, 10, 0, tzinfo=UTC),
             is_active=True,
+            has_shutdown_metrics=True,
             last_resume_time=datetime.now(tz=UTC),
             model_calls=10,
             user_messages=5,
@@ -3511,6 +3567,7 @@ class TestRenderCostViewResumed:
             model="gpt-4",
             start_time=datetime(2025, 6, 1, 10, 0, tzinfo=UTC),
             is_active=True,
+            has_shutdown_metrics=True,
             last_resume_time=datetime.now(tz=UTC),
             model_calls=10,
             user_messages=5,
@@ -3568,6 +3625,7 @@ class TestShutdownOutputTokens:
         session = SessionSummary(
             session_id="shutdown-only-1234",
             is_active=True,
+            has_shutdown_metrics=True,
             last_resume_time=datetime.now(tz=UTC),
             active_output_tokens=250,
             model_metrics={
@@ -3598,6 +3656,7 @@ class TestRenderFullSummaryResumedSplitView:
             model="gpt-4",
             start_time=datetime(2025, 6, 1, 10, 0, tzinfo=UTC),
             is_active=True,
+            has_shutdown_metrics=True,
             last_resume_time=datetime.now(tz=UTC),
             total_premium_requests=10,
             model_calls=8,


### PR DESCRIPTION
Closes #351

## Problem

`_total_output_tokens()` in `report.py` used `requests.count > 0` as a proxy to detect whether `model_metrics` contained real shutdown data or synthetic active-session metrics. This hidden behavioural contract between `parser.py` and `report.py` could silently break if a future change causes `requests.count` to become non-zero for active sessions (e.g., tracking in-flight requests), leading to double-counted output tokens.

## Solution

Added an explicit `has_shutdown_metrics: bool` field to `SessionSummary`:

- **`models.py`**: New `has_shutdown_metrics: bool = False` field on `SessionSummary`
- **`parser.py`**: Set `has_shutdown_metrics=bool(merged_metrics)` in the completed/resumed session path; active session path leaves default `False`
- **`report.py`**: `_total_output_tokens()` now checks `session.has_shutdown_metrics` directly instead of the proxy `requests.count > 0`

## Tests

- Two new regression tests per the issue spec:
  - Active session with `requests.count > 0` but `has_shutdown_metrics=False` → no double-counting
  - Resumed session with `has_shutdown_metrics=True` → `shutdown_tokens + active_output_tokens` (not `shutdown_tokens + 2 × active_output_tokens`)
- Updated all existing tests that construct resumed sessions to set `has_shutdown_metrics=True`
- All 650 tests pass, 99.35% coverage




> Generated by [Issue Implementer](https://github.com/microsasa/cli-tools/actions/runs/23544972844) · [◷](https://github.com/search?q=repo%3Amicrosasa%2Fcli-tools+%22gh-aw-workflow-id%3A+issue-implementer%22&type=pullrequests)

> [!WARNING]
> <details>
> <summary>⚠️ Firewall blocked 1 domain</summary>
>
> The following domain was blocked by the firewall during workflow execution:
>
> - `astral.sh`
>
> To allow these domains, add them to the `network.allowed` list in your workflow frontmatter:
>
> ```yaml
> network:
>   allowed:
>     - defaults
>     - "astral.sh"
> ```
>
> See [Network Configuration](https://github.github.com/gh-aw/reference/network/) for more information.
>
> </details>


<!-- gh-aw-agentic-workflow: Issue Implementer, engine: copilot, model: claude-opus-4.6, id: 23544972844, workflow_id: issue-implementer, run: https://github.com/microsasa/cli-tools/actions/runs/23544972844 -->

<!-- gh-aw-workflow-id: issue-implementer -->