### PR TITLE
fix(#354): reject negative tokens in _safe_int_tokens and use first session.start

### DIFF
--- a/src/copilot_usage/parser.py
+++ b/src/copilot_usage/parser.py
@@ -207,6 +207,7 @@ def build_session_summary(
     end_time = None
     cwd: str | None = None
     model: str | None = None
+    seen_session_start = False
     all_shutdowns: list[tuple[int, SessionShutdownData, str | None]] = []
     user_message_count = 0
     total_output_tokens = 0
@@ -227,7 +228,8 @@ def build_session_summary(
                 continue
             # First valid session.start wins — subsequent ones are ignored
             # so that duplicate events don't silently overwrite identity.
-            if not session_id:
+            if not seen_session_start:
+                seen_session_start = True
                 session_id = data.sessionId
                 start_time = data.startTime
                 cwd = data.context.cwd

--- a/tests/copilot_usage/test_parser.py
+++ b/tests/copilot_usage/test_parser.py
@@ -1896,8 +1896,50 @@ class TestBuildSessionSummaryEdgeCases:
         assert summary.start_time.minute == 0
         assert summary.cwd == "/home/user/project"
 
+    def test_empty_session_id_blocks_subsequent_start(self, tmp_path: Path) -> None:
+        """First session.start with empty sessionId still blocks later starts."""
+        empty_id_start = json.dumps(
+            {
+                "type": "session.start",
+                "data": {
+                    "sessionId": "",
+                    "version": 1,
+                    "producer": "copilot-agent",
+                    "copilotVersion": "1.0.0",
+                    "startTime": "2026-03-07T09:00:00.000Z",
+                    "context": {"cwd": "/home/user/first"},
+                },
+                "id": "ev-empty-start",
+                "timestamp": "2026-03-07T09:00:00.000Z",
+                "parentId": None,
+            }
+        )
+        second_start = json.dumps(
+            {
+                "type": "session.start",
+                "data": {
+                    "sessionId": "real-session-id",
+                    "version": 1,
+                    "producer": "copilot-agent",
+                    "copilotVersion": "1.0.0",
+                    "startTime": "2026-03-07T10:00:00.000Z",
+                    "context": {"cwd": "/home/user/second"},
+                },
+                "id": "ev-start-2",
+                "timestamp": "2026-03-07T10:00:00.000Z",
+                "parentId": None,
+            }
+        )
+        p = tmp_path / "s" / "events.jsonl"
+        _write_events(p, empty_id_start, second_start, _USER_MSG, _ASSISTANT_MSG)
+        events = parse_events(p)
+        summary = build_session_summary(events)
+        # First start wins even with empty sessionId
+        assert summary.session_id == ""
+        assert summary.cwd == "/home/user/first"
+        assert summary.start_time is not None
+        assert summary.start_time.hour == 9
 
-class TestGetAllSessionsEdgeCases:
     def test_skips_empty_events_files(self, tmp_path: Path) -> None:
         _write_events(tmp_path / "empty" / "events.jsonl")
         _write_events(tmp_path / "valid" / "events.jsonl", _START_EVENT)


### PR DESCRIPTION
## Summary

Fixes two parser-level gaps identified in #354 that could silently corrupt session statistics.

### Gap 1 — Multiple `session.start` events overwrite session identity

`build_session_summary` now uses the **first valid** `session.start` event (first wins). Previously, every additional `session.start` unconditionally overwrote `session_id`, `start_time`, and `cwd`, causing incorrect session identity and shorter elapsed-time calculations.

### Gap 2 — `_safe_int_tokens` silently accepts negative integers

`_safe_int_tokens` now rejects negative integers by returning `None`. Previously, values like `"outputTokens": -50` passed the `isinstance(raw, int)` check and were accumulated, potentially driving token counts negative.

## Changes

### `src/copilot_usage/parser.py`
- `_safe_int_tokens`: added `raw >= 0` guard to reject negative ints
- `build_session_summary`: wrapped session.start identity assignment in `if not session_id:` so only the first valid event sets `session_id`, `start_time`, and `cwd`

### `tests/copilot_usage/test_parser.py`
- `TestSafeIntTokens`: replaced `test_returns_negative_for_negative_int` with `test_returns_none_for_negative_int` and added `test_returns_none_for_large_negative`
- `TestBuildSessionSummaryEdgeCases`: added `test_negative_output_tokens_not_accumulated`, `test_mixed_valid_bool_negative_tokens`, and `test_multiple_session_start_uses_first`

## Verification

All 654 tests pass, coverage 99.35%, ruff/pyright clean.

Closes #354




> Generated by [Issue Implementer](https://github.com/microsasa/cli-tools/actions/runs/23551425564) · [◷](https://github.com/search?q=repo%3Amicrosasa%2Fcli-tools+%22gh-aw-workflow-id%3A+issue-implementer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Issue Implementer, engine: copilot, model: claude-opus-4.6, id: 23551425564, workflow_id: issue-implementer, run: https://github.com/microsasa/cli-tools/actions/runs/23551425564 -->

<!-- gh-aw-workflow-id: issue-implementer -->