### PR TITLE
Add edge-case tests for _filter_sessions boundaries and lookup_model_pricing empty string (#355)

### DIFF
--- a/tests/copilot_usage/test_pricing.py
+++ b/tests/copilot_usage/test_pricing.py
@@ -282,3 +282,27 @@ class TestLookupModelPricingTieBreaking:
         expected = KNOWN_PRICING[first_key]
         assert p.multiplier == expected.multiplier
         assert p.tier == expected.tier
+
+
+# ---------------------------------------------------------------------------
+# Issue #355 — lookup_model_pricing empty/unknown string edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestLookupModelPricingEdgeCases:
+    def test_empty_string_warns_and_returns_standard(self) -> None:
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            p = lookup_model_pricing("")
+        assert p.multiplier == 1.0
+        assert p.tier == PricingTier.STANDARD
+        assert len(caught) == 1
+        assert "Unknown model" in str(caught[0].message)
+
+    def test_single_char_unknown_warns_and_returns_standard(self) -> None:
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            p = lookup_model_pricing("x")
+        assert p.multiplier == 1.0
+        assert len(w) == 1
+        assert "Unknown model" in str(w[0].message)

--- a/tests/copilot_usage/test_report.py
+++ b/tests/copilot_usage/test_report.py
@@ -3863,3 +3863,29 @@ class TestSessionDisplayName:
         """When session_id is shorter than 12 chars, return whatever slice gives."""
         s = SessionSummary(session_id="abc", name=None)
         assert session_display_name(s) == "abc"
+
+
+# ---------------------------------------------------------------------------
+# Issue #355 — _filter_sessions exact timestamp boundary semantics
+# ---------------------------------------------------------------------------
+
+
+class TestFilterSessionsExactBoundary:
+    def test_session_at_exact_since_is_included(self) -> None:
+        t = datetime(2025, 6, 15, 12, 0, 0, tzinfo=UTC)
+        s = SessionSummary(session_id="s", start_time=t)
+        result = _filter_sessions([s], since=t, until=None)
+        assert len(result) == 1
+
+    def test_session_at_exact_until_is_included(self) -> None:
+        t = datetime(2025, 6, 15, 12, 0, 0, tzinfo=UTC)
+        s = SessionSummary(session_id="s", start_time=t)
+        result = _filter_sessions([s], since=None, until=t)
+        assert len(result) == 1
+
+    def test_session_at_exact_point_range_is_included(self) -> None:
+        """since == until == session.start_time → included."""
+        t = datetime(2025, 6, 15, tzinfo=UTC)
+        s = SessionSummary(session_id="s", start_time=t)
+        result = _filter_sessions([s], since=t, until=t)
+        assert len(result) == 1


### PR DESCRIPTION
Closes #355

## Changes

Two test classes added to cover undocumented edge-case contracts identified in the issue:

### Gap 1 — `_filter_sessions` exact timestamp boundary semantics (`test_report.py`)

`TestFilterSessionsExactBoundary` asserts the inclusive boundary behavior:
- Session with `start_time == since` → **included**
- Session with `start_time == until` → **included**
- Session with `start_time == since == until` (point range) → **included**

### Gap 2 — `lookup_model_pricing("")` empty string query (`test_pricing.py`)

`TestLookupModelPricingEdgeCases` asserts the fallback path:
- `lookup_model_pricing("")` → `UserWarning` emitted, `multiplier == 1.0`, `tier == STANDARD`
- `lookup_model_pricing("x")` → same fallback behavior

## Verification

All CI checks pass locally:
- `ruff check` ✅
- `ruff format` ✅
- `pyright` ✅ (0 errors)
- `pytest --cov --cov-fail-under=80` ✅ (660 passed, 99.35% coverage)




> Generated by [Issue Implementer](https://github.com/microsasa/cli-tools/actions/runs/23555807537) · [◷](https://github.com/search?q=repo%3Amicrosasa%2Fcli-tools+%22gh-aw-workflow-id%3A+issue-implementer%22&type=pullrequests)

> [!WARNING]
> <details>
> <summary>⚠️ Firewall blocked 1 domain</summary>
>
> The following domain was blocked by the firewall during workflow execution:
>
> - `astral.sh`
>
> To allow these domains, add them to the `network.allowed` list in your workflow frontmatter:
>
> ```yaml
> network:
>   allowed:
>     - defaults
>     - "astral.sh"
> ```
>
> See [Network Configuration](https://github.github.com/gh-aw/reference/network/) for more information.
>
> </details>


<!-- gh-aw-agentic-workflow: Issue Implementer, engine: copilot, model: claude-opus-4.6, id: 23555807537, workflow_id: issue-implementer, run: https://github.com/microsasa/cli-tools/actions/runs/23555807537 -->

<!-- gh-aw-workflow-id: issue-implementer -->