### PR TITLE
fix: wrap fallback session_start and event timestamps with ensure_aware() (#360)

### DIFF
--- a/src/copilot_usage/report.py
+++ b/src/copilot_usage/report.py
@@ -571,7 +571,7 @@ def _render_recent_events(
 
     for ev in recent:
         if ev.timestamp is not None:
-            delta = ev.timestamp - session_start
+            delta = ensure_aware(ev.timestamp) - session_start
             rel = _format_relative_time(delta)
         else:
             rel = "—"
@@ -659,7 +659,7 @@ def render_session_detail(
         ensure_aware(summary.start_time)
         if summary.start_time
         else (
-            events[0].timestamp
+            ensure_aware(events[0].timestamp)
             if events and events[0].timestamp
             else datetime.now(tz=UTC)
         )

--- a/tests/copilot_usage/test_report.py
+++ b/tests/copilot_usage/test_report.py
@@ -1276,6 +1276,28 @@ class TestReportCoverageGaps:
         output = _capture_console(render_session_detail, events, summary)
         assert "Recent Events" in output
 
+    def test_session_detail_naive_first_event_with_aware_subsequent(self) -> None:
+        """Naive events[0].timestamp mixed with aware later timestamps must not raise TypeError."""
+        from copilot_usage.report import render_session_detail
+
+        naive_time = datetime(2025, 3, 1, 10, 0, 0)  # noqa: DTZ001
+        aware_time = datetime(2025, 3, 1, 10, 0, 5, tzinfo=UTC)
+        summary = SessionSummary(session_id="naive-start", start_time=None)
+        events = [
+            _make_event(
+                EventType.USER_MESSAGE,
+                data={"content": "hi"},
+                timestamp=naive_time,
+            ),
+            _make_event(
+                EventType.ASSISTANT_MESSAGE,
+                data={"content": "ok", "outputTokens": 10, "messageId": "m1"},
+                timestamp=aware_time,
+            ),
+        ]
+        output = _capture_console(render_session_detail, events, summary)
+        assert "Recent Events" in output
+
 
 # ---------------------------------------------------------------------------
 # Premium requests display (raw facts, no estimation)


### PR DESCRIPTION
## Summary

Fixes #360 — `render_session_detail` raises `TypeError` when the fallback `session_start` is a naive datetime.

## Changes

**`src/copilot_usage/report.py`** (2 lines changed):
- Wrapped `events[0].timestamp` with `ensure_aware()` in the `session_start` fallback (line 662)
- Wrapped `ev.timestamp` with `ensure_aware()` in `_render_recent_events` delta computation (line 574)

**`tests/copilot_usage/test_report.py`** (22 lines added):
- Added `test_session_detail_naive_first_event_with_aware_subsequent` regression test: calls `render_session_detail` with `start_time=None`, a naive `events[0].timestamp`, and an aware subsequent event — verifies no `TypeError` and "Recent Events" renders.

## Verification

All CI checks pass locally:
- `ruff check` ✅
- `ruff format` ✅
- `pyright` — 0 errors ✅
- `pytest --cov --cov-fail-under=80` — 666 passed, 99.36% coverage ✅




> Generated by [Issue Implementer](https://github.com/microsasa/cli-tools/actions/runs/23560950518) · [◷](https://github.com/search?q=repo%3Amicrosasa%2Fcli-tools+%22gh-aw-workflow-id%3A+issue-implementer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Issue Implementer, engine: copilot, model: claude-opus-4.6, id: 23560950518, workflow_id: issue-implementer, run: https://github.com/microsasa/cli-tools/actions/runs/23560950518 -->

<!-- gh-aw-workflow-id: issue-implementer -->