### PR TITLE
test: assert ev.currentModel takes priority over data.currentModel (#389)

### DIFF
--- a/tests/copilot_usage/test_parser.py
+++ b/tests/copilot_usage/test_parser.py
@@ -1818,6 +1818,32 @@ class TestBuildSessionSummaryEdgeCases:
         summary = build_session_summary(events)
         assert summary.model == "gpt-4"
 
+    def test_ev_currentModel_takes_priority_over_data_currentModel(
+        self, tmp_path: Path
+    ) -> None:
+        """Top-level ev.currentModel wins over data.currentModel."""
+        shutdown_ev = json.dumps(
+            {
+                "type": "session.shutdown",
+                "currentModel": "claude-opus-4.6",
+                "data": {
+                    "shutdownType": "routine",
+                    "totalPremiumRequests": 1,
+                    "totalApiDurationMs": 100,
+                    "sessionStartTime": 0,
+                    "currentModel": "claude-sonnet-4",
+                    "modelMetrics": {},
+                },
+                "id": "ev-sd",
+                "timestamp": "2026-03-07T11:00:00.000Z",
+            }
+        )
+        p = tmp_path / "s" / "events.jsonl"
+        _write_events(p, _START_EVENT, shutdown_ev)
+        events = parse_events(p)
+        summary = build_session_summary(events)
+        assert summary.model == "claude-opus-4.6"
+
     def test_assistant_message_without_output_tokens(self, tmp_path: Path) -> None:
         msg_no_tokens = json.dumps(
             {


### PR DESCRIPTION
Closes #389

## What

Adds `test_ev_currentModel_takes_priority_over_data_currentModel` to
`TestBuildSessionSummaryEdgeCases` in `tests/copilot_usage/test_parser.py`.

## Why

The existing `test_shutdown_model_from_data_currentModel` only covers the fallback
path where `ev.currentModel` is absent. There was no test asserting that when **both**
`ev.currentModel` and `data.currentModel` are present, the top-level field wins
(`ev.currentModel or data.currentModel` at parser.py:268). If someone accidentally
reversed the operands, no test would catch the regression.

## Test details

The new test builds a `session.shutdown` event with:
- `ev.currentModel = "claude-opus-4.6"`
- `data.currentModel = "claude-sonnet-4"`

and asserts `summary.model == "claude-opus-4.6"`.

## CI

All 696 tests pass · 99.36% coverage · ruff/pyright clean.




> [!WARNING]
> <details>
> <summary>⚠️ Firewall blocked 1 domain</summary>
>
> The following domain was blocked by the firewall during workflow execution:
>
> - `astral.sh`
>
> To allow these domains, add them to the `network.allowed` list in your workflow frontmatter:
>
> ```yaml
> network:
>   allowed:
>     - defaults
>     - "astral.sh"
> ```
>
> See [Network Configuration](https://github.github.com/gh-aw/reference/network/) for more information.
>
> </details>


> [!NOTE]
> <details>
> <summary>🔒 Integrity filtering filtered 1 item</summary>
>
> Integrity filtering activated and filtered the following item during workflow execution.
> This happens when a tool call accesses a resource that does not meet the required integrity or secrecy level of the workflow.
>
> - issue:microsasa/cli-tools#389 (`issue_read`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".)
>
> </details>


> Generated by [Issue Implementer](https://github.com/microsasa/cli-tools/actions/runs/23586771544) · [◷](https://github.com/search?q=repo%3Amicrosasa%2Fcli-tools+%22gh-aw-workflow-id%3A+issue-implementer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Issue Implementer, engine: copilot, model: claude-opus-4.6, id: 23586771544, workflow_id: issue-implementer, run: https://github.com/microsasa/cli-tools/actions/runs/23586771544 -->

<!-- gh-aw-workflow-id: issue-implementer -->