### PR TITLE
fix: remove unexecuted doctests and make render_summary params keyword-only (#390)

### DIFF
--- a/src/copilot_usage/report.py
+++ b/src/copilot_usage/report.py
@@ -52,15 +52,8 @@ def session_display_name(session: SessionSummary) -> str:
 def format_tokens(n: int) -> str:
     """Format token count with K/M suffix.
 
-    Examples:
-        >>> format_tokens(1627935)
-        '1.6M'
-        >>> format_tokens(16655)
-        '16.7K'
-        >>> format_tokens(500)
-        '500'
-        >>> format_tokens(0)
-        '0'
+    Returns ``"1.6M"`` for 1 627 935, ``"16.7K"`` for 16 655, or the
+    raw integer string for values below 1 000.
     """
     if n >= 1_000_000:
         return f"{n / 1_000_000:.1f}M"
@@ -93,15 +86,8 @@ def _format_timedelta(td: timedelta) -> str:
 def format_duration(ms: int) -> str:
     """Format milliseconds to human-readable duration.
 
-    Examples:
-        >>> format_duration(389114)
-        '6m 29s'
-        >>> format_duration(5000)
-        '5s'
-        >>> format_duration(0)
-        '0s'
-        >>> format_duration(3661000)
-        '1h 1m 1s'
+    Returns compact strings such as ``"6m 29s"``, ``"5s"``, or
+    ``"1h 1m 1s"``.
     """
     return _format_timedelta(timedelta(milliseconds=ms))
 
@@ -857,9 +843,9 @@ def _render_session_table(
 
 def render_summary(
     sessions: list[SessionSummary],
+    *,
     since: datetime | None = None,
     until: datetime | None = None,
-    *,
     target_console: Console | None = None,
 ) -> None:
     """Render the full summary report to the terminal using Rich.

--- a/tests/copilot_usage/test_report.py
+++ b/tests/copilot_usage/test_report.py
@@ -1066,6 +1066,12 @@ class TestRenderSummary:
         output = _capture_summary([s])
         assert output.count("2026-03-07") >= 2  # appears in both ends of range
 
+    def test_render_summary_rejects_positional_since(self) -> None:
+        """render_summary requires since/until as keyword-only arguments."""
+        sessions: list[SessionSummary] = []
+        with pytest.raises(TypeError):
+            render_summary(sessions, datetime.now(tz=UTC))  # type: ignore[misc]
+
 
 # ---------------------------------------------------------------------------
 # Coverage gap tests — report.py


### PR DESCRIPTION
Closes #390

## Changes

### 1. Doctests replaced with plain docstrings (Option B)
`format_tokens` and `format_duration` carried `>>>` doctest examples that were never executed — `pyproject.toml` has no `--doctest-modules` in `addopts`. Replaced the doctest syntax with descriptive docstrings. The `format_tokens(1_627_935)` case is already covered by `test_format_tokens_millions`.

### 2. `render_summary` — `since`/`until` now keyword-only
Moved `*,` before `since` to match the keyword-only pattern used by `render_cost_view` and all other rendering functions. Every existing call site already uses keyword syntax, so this is a non-breaking change.

### 3. Regression test
Added `test_render_summary_rejects_positional_since` to verify that passing `since` positionally raises `TypeError`.

## Verification
- `ruff check` ✅
- `ruff format` ✅
- `pyright` ✅ (0 errors)
- `pytest --cov --cov-fail-under=80` ✅ (697 passed, 99.36% coverage)




> [!WARNING]
> <details>
> <summary>⚠️ Firewall blocked 1 domain</summary>
>
> The following domain was blocked by the firewall during workflow execution:
>
> - `astral.sh`
>
> To allow these domains, add them to the `network.allowed` list in your workflow frontmatter:
>
> ```yaml
> network:
>   allowed:
>     - defaults
>     - "astral.sh"
> ```
>
> See [Network Configuration](https://github.github.com/gh-aw/reference/network/) for more information.
>
> </details>


> [!NOTE]
> <details>
> <summary>🔒 Integrity filtering filtered 11 items</summary>
>
> Integrity filtering activated and filtered the following items during workflow execution.
> This happens when a tool call accesses a resource that does not meet the required integrity or secrecy level of the workflow.
>
> - issue:microsasa/cli-tools#390 (`issue_read`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".)
> - issue:microsasa/cli-tools#391 (`list_issues`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".)
> - issue:microsasa/cli-tools#390 (`list_issues`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".)
> - issue:microsasa/cli-tools#385 (`list_issues`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".)
> - issue:microsasa/cli-tools#352 (`list_issues`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".)
> - issue:microsasa/cli-tools#349 (`list_issues`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".)
> - issue:microsasa/cli-tools#330 (`list_issues`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".)
> - issue:microsasa/cli-tools#291 (`list_issues`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".)
> - issue:microsasa/cli-tools#224 (`list_issues`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".)
> - issue:microsasa/cli-tools#221 (`list_issues`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".)
> - issue:microsasa/cli-tools#220 (`list_issues`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".)
>
> </details>


> Generated by [Issue Implementer](https://github.com/microsasa/cli-tools/actions/runs/23587289971) · [◷](https://github.com/search?q=repo%3Amicrosasa%2Fcli-tools+%22gh-aw-workflow-id%3A+issue-implementer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Issue Implementer, engine: copilot, model: claude-opus-4.6, id: 23587289971, workflow_id: issue-implementer, run: https://github.com/microsasa/cli-tools/actions/runs/23587289971 -->

<!-- gh-aw-workflow-id: issue-implementer -->