### PR TITLE
fix: extract magic literals to named constants in cli.py (#405)

### DIFF
--- a/src/copilot_usage/cli.py
+++ b/src/copilot_usage/cli.py
@@ -41,6 +41,12 @@ type _View = Literal["home", "detail", "cost"]
 
 _DATE_FORMATS = ["%Y-%m-%d", "%Y-%m-%dT%H:%M:%S"]
 
+_WATCHDOG_DEBOUNCE_SECS: float = 2.0  # Prevents rapid redraws during tool-use bursts
+
+_UUID_STR_LEN = 36
+_UUID_DASH_COUNT = 4
+_MIN_PREFIX_LEN_FOR_PREFILTER = 4
+
 console = Console()
 
 
@@ -155,7 +161,7 @@ class _FileChangeHandler(FileSystemEventHandler):  # type: ignore[misc]
 
     def dispatch(self, event: object) -> None:
         now = time.monotonic()
-        if now - self._last_trigger > 2.0:  # debounce 2s
+        if now - self._last_trigger > _WATCHDOG_DEBOUNCE_SECS:
             self._last_trigger = now
             self._change_event.set()
 
@@ -408,8 +414,14 @@ def session(ctx: click.Context, session_id: str, path: Path | None) -> None:
     available: list[str] = []
     for events_path in event_paths:
         dir_name = events_path.parent.name
-        is_uuid_dir = len(dir_name) == 36 and dir_name.count("-") == 4
-        if len(session_id) >= 4 and is_uuid_dir and not dir_name.startswith(session_id):
+        is_uuid_dir = (
+            len(dir_name) == _UUID_STR_LEN and dir_name.count("-") == _UUID_DASH_COUNT
+        )
+        if (
+            len(session_id) >= _MIN_PREFIX_LEN_FOR_PREFILTER
+            and is_uuid_dir
+            and not dir_name.startswith(session_id)
+        ):
             available.append(dir_name[:8])
             continue
         try:


### PR DESCRIPTION
Closes #405

## Changes

Extracts inline magic literals in `cli.py` to named module-level constants for improved readability and maintainability:

- **`_WATCHDOG_DEBOUNCE_SECS = 2.0`** — replaces the bare `2.0` in `_FileChangeHandler.dispatch()`, making the debounce interval self-documenting and easy to tune.
- **`_UUID_STR_LEN = 36`**, **`_UUID_DASH_COUNT = 4`**, **`_MIN_PREFIX_LEN_FOR_PREFILTER = 4`** — replaces the three inline numbers in the `session` command's UUID directory pre-filter logic.

### Already resolved prior to this PR
- `_MAX_CONTENT_LEN = 80` was already removed from `report.py` (it now lives only in `_formatting.py`).
- Regression tests for `_read_line_nonblocking` (timeout → `None`, data → stripped string) already exist in `TestReadLineNonblocking`.

## Verification

All checks pass locally:
- `ruff check` — 0 errors
- `ruff format` — clean
- `pyright` — 0 errors
- `pytest` — **724 passed**, 99.37% coverage (≥80% threshold met)




> [!WARNING]
> <details>
> <summary>⚠️ Firewall blocked 1 domain</summary>
>
> The following domain was blocked by the firewall during workflow execution:
>
> - `astral.sh`
>
> To allow these domains, add them to the `network.allowed` list in your workflow frontmatter:
>
> ```yaml
> network:
>   allowed:
>     - defaults
>     - "astral.sh"
> ```
>
> See [Network Configuration](https://github.github.com/gh-aw/reference/network/) for more information.
>
> </details>


> [!NOTE]
> <details>
> <summary>🔒 Integrity filtering filtered 1 item</summary>
>
> Integrity filtering activated and filtered the following item during workflow execution.
> This happens when a tool call accesses a resource that does not meet the required integrity or secrecy level of the workflow.
>
> - issue:microsasa/cli-tools#405 (`issue_read`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".)
>
> </details>


> Generated by [Issue Implementer](https://github.com/microsasa/cli-tools/actions/runs/23634820642) · [◷](https://github.com/search?q=repo%3Amicrosasa%2Fcli-tools+%22gh-aw-workflow-id%3A+issue-implementer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Issue Implementer, engine: copilot, model: claude-opus-4.6, id: 23634820642, workflow_id: issue-implementer, run: https://github.com/microsasa/cli-tools/actions/runs/23634820642 -->

<!-- gh-aw-workflow-id: issue-implementer -->