### PR TITLE
fix: code health cleanup (#420)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ security: ## Security scan (bandit)
 # Tests with coverage
 test: ## Run unit + e2e tests with coverage
 	@printf "\n$(BOLD)$(CYAN)🧪 Testing...$(RESET)\n"
-	@COV=$$(uv run pytest tests/copilot_usage $(TEST_FLAGS) 2>&1); \
+	@COV=$$(uv run pytest tests/copilot_usage tests/test_docs.py $(TEST_FLAGS) 2>&1); \
 		if [ $$? -eq 0 ]; then \
 			COV_PCT=$$(echo "$$COV" | grep "^TOTAL" | awk '{print $$NF}' | tr -d '%'); \
 			printf "  $(GREEN)✅ unit tests ($${COV_PCT}%% coverage)$(RESET)\n"; \

--- a/src/copilot_usage/docs/implementation.md
+++ b/src/copilot_usage/docs/implementation.md
@@ -422,7 +422,7 @@ From `pricing.py` — `_RAW_MULTIPLIERS` dict:
 
 Tier is derived from the multiplier (in `pricing.py`): ≥3.0 → Premium, = 0.0 → Free, < 1.0 → Light, otherwise Standard.
 
-**Important:** `pricing.py` is **reference data only**. The multipliers are not used in any runtime calculations — premium request counts come exclusively from `session.shutdown` events. The pricing module exists for `categorize_model()` (tier lookup) and potential future use.
+**Note:** `pricing.py` multipliers are used **only for `~`-prefixed estimates** on live/active sessions (`render_live_sessions`, `render_cost_view`). Historical and shutdown-based views use exact API-provided premium request counts exclusively — the multipliers play no role there.
 
 ### Model resolution for active sessions
 

--- a/src/copilot_usage/pricing.py
+++ b/src/copilot_usage/pricing.py
@@ -20,7 +20,6 @@ __all__: list[str] = [
     "PricingTier",
     "KNOWN_PRICING",
     "lookup_model_pricing",
-    "categorize_model",
 ]
 
 
@@ -147,8 +146,3 @@ def lookup_model_pricing(model_name: str) -> ModelPricing:
     return ModelPricing(
         model_name=model_name, multiplier=1.0, tier=PricingTier.STANDARD
     )
-
-
-def categorize_model(model_name: str) -> PricingTier:
-    """Return the pricing tier for *model_name*."""
-    return lookup_model_pricing(model_name).tier

--- a/tests/copilot_usage/test_pricing.py
+++ b/tests/copilot_usage/test_pricing.py
@@ -11,7 +11,6 @@ from copilot_usage.pricing import (
     ModelPricing,
     PricingTier,
     _tier_from_multiplier,
-    categorize_model,
     lookup_model_pricing,
 )
 
@@ -136,28 +135,6 @@ class TestLookupModelPricing:
             warnings.simplefilter("always")
             p = lookup_model_pricing("mystery")
         assert p.model_name == "mystery"
-
-
-# ---------------------------------------------------------------------------
-# categorize_model
-# ---------------------------------------------------------------------------
-
-
-class TestCategorizeModel:
-    def test_premium(self) -> None:
-        assert categorize_model("claude-opus-4.6") == PricingTier.PREMIUM
-
-    def test_standard(self) -> None:
-        assert categorize_model("gpt-5.4") == PricingTier.STANDARD
-
-    def test_light(self) -> None:
-        assert categorize_model("claude-haiku-4.5") == PricingTier.LIGHT
-
-    def test_free(self) -> None:
-        assert categorize_model("gpt-5-mini") == PricingTier.FREE
-
-    def test_free_gpt_4_1(self) -> None:
-        assert categorize_model("gpt-4.1") == PricingTier.FREE
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Addresses the four cleanup items from #420:

### 1. Remove dead `categorize_model()` from `pricing.py`
- Removed `"categorize_model"` from `__all__`
- Deleted the function entirely (was never called from production code)
- Removed corresponding `TestCategorizeModel` tests in `test_pricing.py`

### 2. Fix `make test` silently omitting `tests/test_docs.py`
- Added `tests/test_docs.py` to the `test` target's pytest invocation so that doc-drift guards run during local `make test` / `make check`, matching CI behavior

### 3. Fix stale claim in `implementation.md`
- Replaced the incorrect paragraph claiming multipliers are "not used in any runtime calculations" and that the module exists for `categorize_model()`
- New text accurately states multipliers are used for `~`-prefixed estimates on live/active sessions via `_estimate_premium_cost()`

### 4. `except Exception` in `_start_observer` — already fixed
- The cleanup `except` block already uses `except (OSError, RuntimeError)` — no change needed

### Verification
- All 747 tests pass (99.58% coverage, well above the 80% threshold)
- `ruff check`, `ruff format`, and `pyright` all pass cleanly




> [!NOTE]
> <details>
> <summary>🔒 Integrity filtering filtered 1 item</summary>
>
> Integrity filtering activated and filtered the following item during workflow execution.
> This happens when a tool call accesses a resource that does not meet the required integrity or secrecy level of the workflow.
>
> - issue:microsasa/cli-tools#420 (`issue_read`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".)
>
> </details>


> Generated by [Issue Implementer](https://github.com/microsasa/cli-tools/actions/runs/23644471164) · [◷](https://github.com/search?q=repo%3Amicrosasa%2Fcli-tools+%22gh-aw-workflow-id%3A+issue-implementer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Issue Implementer, engine: copilot, model: claude-opus-4.6, id: 23644471164, workflow_id: issue-implementer, run: https://github.com/microsasa/cli-tools/actions/runs/23644471164 -->

<!-- gh-aw-workflow-id: issue-implementer -->