### PR TITLE
fix: show 'dates unavailable' when sessions lack start_time (#429)

### DIFF
--- a/src/copilot_usage/report.py
+++ b/src/copilot_usage/report.py
@@ -308,6 +308,8 @@ def _render_summary_header(
         earliest = min(start_times).strftime("%Y-%m-%d")
         latest = max(start_times).strftime("%Y-%m-%d")
         subtitle = f"{earliest}  →  {latest}"
+    elif sessions:
+        subtitle = "dates unavailable"
     else:
         subtitle = "no sessions"
     console.print()

--- a/tests/copilot_usage/test_report.py
+++ b/tests/copilot_usage/test_report.py
@@ -1068,6 +1068,23 @@ class TestRenderSummary:
         output = _capture_summary([s])
         assert output.count("2026-03-07") >= 2  # appears in both ends of range
 
+    def test_all_sessions_have_no_start_time_shows_dates_unavailable(self) -> None:
+        """Sessions with start_time=None produce 'dates unavailable', not 'no sessions'."""
+        session = SessionSummary(
+            session_id="abc123deadbeef",
+            start_time=None,
+            model="claude-sonnet-4",
+            total_premium_requests=2,
+        )
+        output = _capture_summary([session])
+        # Should NOT say "no sessions" — we have a session, just no start_time
+        assert "No sessions found" not in output
+        assert "no sessions" not in output.lower()
+        # Should use the "dates unavailable" fallback
+        assert "dates unavailable" in output
+        # Body should still render the session
+        assert "abc123deadbe" in output  # session_display_name truncates to 12 chars
+
     def test_render_summary_rejects_positional_since(self) -> None:
         """render_summary requires since/until as keyword-only arguments."""
         sessions: list[SessionSummary] = []
@@ -1280,10 +1297,10 @@ class TestReportCoverageGaps:
         assert "2025-01-01  →  2025-12-31" in output
 
     def test_summary_header_no_start_times(self) -> None:
-        """Sessions with no start_time → 'no sessions' subtitle (line 533)."""
+        """Sessions with no start_time → 'dates unavailable' subtitle."""
         session = SessionSummary(session_id="no-time", start_time=None)
         output = _capture_summary([session])
-        assert "no sessions" in output
+        assert "dates unavailable" in output
 
     def test_session_table_empty_sessions(self) -> None:
         """render_summary with sessions that all lack start_time still renders."""


### PR DESCRIPTION
Closes #429

## Problem

`_render_summary_header()` showed `(no sessions)` in the subtitle when all sessions had `start_time=None`, even though sessions existed and data was rendered below. This was contradictory.

## Fix

Added an `elif sessions:` branch in `_render_summary_header` to distinguish:
- **Sessions with dates** → `"2026-01-01  →  2026-06-01"`
- **Sessions without dates** → `"dates unavailable"` ← new
- **No sessions at all** → `"no sessions"`

## Tests

- Added `test_all_sessions_have_no_start_time_shows_dates_unavailable` in `TestRenderSummary`
- Updated existing `test_summary_header_no_start_times` in `TestReportCoverageGaps` to expect the new behavior

All 748 tests pass, 99.45% coverage, ruff/pyright clean.




> [!NOTE]
> <details>
> <summary>🔒 Integrity filtering filtered 1 item</summary>
>
> Integrity filtering activated and filtered the following item during workflow execution.
> This happens when a tool call accesses a resource that does not meet the required integrity or secrecy level of the workflow.
>
> - issue:microsasa/cli-tools#429 (`issue_read`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".)
>
> </details>


> Generated by [Issue Implementer](https://github.com/microsasa/cli-tools/actions/runs/23650775004) · [◷](https://github.com/search?q=repo%3Amicrosasa%2Fcli-tools+%22gh-aw-workflow-id%3A+issue-implementer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Issue Implementer, engine: copilot, model: claude-opus-4.6, id: 23650775004, workflow_id: issue-implementer, run: https://github.com/microsasa/cli-tools/actions/runs/23650775004 -->

<!-- gh-aw-workflow-id: issue-implementer -->