### PR TITLE
test: add coverage for prefix collision and non-UTC _normalize_until (#432)

### DIFF
--- a/tests/copilot_usage/test_cli.py
+++ b/tests/copilot_usage/test_cli.py
@@ -367,11 +367,15 @@ def test_session_prefix_collision_returns_newest_by_mtime(
     """
     older_uuid = "ab111111-0000-0000-0000-000000000000"
     newer_uuid = "ab222222-0000-0000-0000-000000000000"
-    _write_session(tmp_path, older_uuid, name="OlderSession")
-    _write_session(tmp_path, newer_uuid, name="NewerSession")
+    older_dir = _write_session(tmp_path, older_uuid, name="OlderSession")
+    newer_dir = _write_session(tmp_path, newer_uuid, name="NewerSession")
+
+    # Set explicit mtimes so the newer session sorts first even on filesystems
+    # with coarse mtime resolution (avoids CI flakiness).
+    os.utime(older_dir / "events.jsonl", (1_000_000, 1_000_000))
+    os.utime(newer_dir / "events.jsonl", (2_000_000, 2_000_000))
 
     def _fake_discover(_base: Path | None = None) -> list[Path]:
-        # Simulate discover_sessions returning newer session first (higher mtime)
         paths = list(tmp_path.glob("*/events.jsonl"))
         return sorted(paths, key=lambda p: p.stat().st_mtime, reverse=True)
 


### PR DESCRIPTION
Closes #432

## Changes

Adds three new tests to document and lock in two existing implicit contracts:

### Gap 1: Session prefix collision — newest-by-mtime wins
- **`test_session_prefix_collision_returns_newest_by_mtime`**: Creates two sessions sharing an `"ab"` prefix, monkeypatches `discover_sessions` to return newest-first (by mtime), and asserts only the newer session appears in output. This documents the "first discovered wins" contract.

### Gap 2: `_normalize_until` with non-UTC timezone-aware datetimes
- **`test_aware_midnight_non_utc_expanded_in_same_tz`**: Verifies a `+05:00` midnight datetime is expanded to `23:59:59.999999` while preserving the original timezone offset and calendar date.
- **`test_aware_non_midnight_non_utc_unchanged`**: Verifies a `-08:00` non-midnight datetime passes through unchanged.

## Verification

All CI checks pass locally:
- `ruff check` — All checks passed
- `ruff format` — No changes needed
- `pyright` — 0 errors
- `pytest --cov --cov-fail-under=80` — **760 passed**, 99.45% coverage




> [!WARNING]
> <details>
> <summary>⚠️ Firewall blocked 1 domain</summary>
>
> The following domain was blocked by the firewall during workflow execution:
>
> - `astral.sh`
>
> To allow these domains, add them to the `network.allowed` list in your workflow frontmatter:
>
> ```yaml
> network:
>   allowed:
>     - defaults
>     - "astral.sh"
> ```
>
> See [Network Configuration](https://github.github.com/gh-aw/reference/network/) for more information.
>
> </details>


> [!NOTE]
> <details>
> <summary>🔒 Integrity filtering filtered 1 item</summary>
>
> Integrity filtering activated and filtered the following item during workflow execution.
> This happens when a tool call accesses a resource that does not meet the required integrity or secrecy level of the workflow.
>
> - issue:microsasa/cli-tools#432 (`issue_read`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".)
>
> </details>


> Generated by [Issue Implementer](https://github.com/microsasa/cli-tools/actions/runs/23654523107) · [◷](https://github.com/search?q=repo%3Amicrosasa%2Fcli-tools+%22gh-aw-workflow-id%3A+issue-implementer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Issue Implementer, engine: copilot, model: claude-opus-4.6, id: 23654523107, workflow_id: issue-implementer, run: https://github.com/microsasa/cli-tools/actions/runs/23654523107 -->

<!-- gh-aw-workflow-id: issue-implementer -->