### PR TITLE
fix: instruct implementer to include Closes keyword in PR body (#435)

### DIFF
--- a/.github/workflows/issue-implementer.md
+++ b/.github/workflows/issue-implementer.md
@@ -55,4 +55,4 @@ uv sync && uv run ruff check --fix . && uv run ruff format . && uv run pyright &
 
 Fix any lint or type errors found by ruff/pyright before committing. Iterate until all checks pass cleanly.
 
-Open a pull request with the fix. The PR title should reference the issue number. Include tests as specified in the issue. The PR must NOT be a draft — open it as a regular PR ready for review.
+Open a pull request with the fix. The PR title should reference the issue number. The PR body MUST include `Closes #${{ github.event.inputs.issue_number }}` so GitHub auto-closes the issue when the PR merges. Include tests as specified in the issue. The PR must NOT be a draft — open it as a regular PR ready for review.


### PR DESCRIPTION
Closes #435

## Problem

The issue-implementer agent inconsistently included `Closes #NNN` in PR bodies. When missing, GitHub didn't auto-close the issue on merge, leaving stale `aw-dispatched` issues open.

**Missing keyword (issue stayed open after merge):**
- PR #421 → issue #407 stayed open
- PR #428 → issue #420 stayed open
- PR #434 → issue #430 stayed open

**Had keyword (issue auto-closed):**
- PR #433 → `Closes #429` ✅
- PR #427 → `Closes #419` ✅
- PR #426 → `Closes #418` ✅

## Fix

Added explicit instruction in `issue-implementer.md` line 58 to always include `Closes #<issue_number>` in the PR body. The instruction uses the workflow input variable so it's always the correct issue number.

The `.lock.yml` doesn't change because it uses `runtime-import` to read the `.md` at execution time.