### PR TITLE
fix(#445): remove private symbol re-exports from report.py

### DIFF
--- a/src/copilot_usage/report.py
+++ b/src/copilot_usage/report.py
@@ -4,8 +4,8 @@ Uses Rich tables and panels to display session information in
 the terminal.
 
 Session-detail rendering (``render_session_detail`` and its private
-helpers) lives in :mod:`copilot_usage.render_detail` and is re-exported
-here so that external callers see no change.
+helpers) lives in :mod:`copilot_usage.render_detail`; only the public
+entry-point is re-exported here so that external callers see no change.
 """
 
 import warnings
@@ -34,27 +34,7 @@ from copilot_usage.models import (
     total_output_tokens,
 )
 from copilot_usage.pricing import lookup_model_pricing
-from copilot_usage.render_detail import (
-    _build_event_details as _build_event_details,  # pyright: ignore[reportPrivateUsage]  # noqa: F401
-    _event_type_label as _event_type_label,  # pyright: ignore[reportPrivateUsage]  # noqa: F401
-    _extract_tool_name as _extract_tool_name,  # pyright: ignore[reportPrivateUsage]  # noqa: F401
-    _format_detail_duration as _format_detail_duration,  # pyright: ignore[reportPrivateUsage]  # noqa: F401
-    _format_relative_time as _format_relative_time,  # pyright: ignore[reportPrivateUsage]  # noqa: F401
-    _render_aggregate_stats as _render_aggregate_stats,  # pyright: ignore[reportPrivateUsage]  # noqa: F401
-    _render_code_changes as _render_code_changes,  # pyright: ignore[reportPrivateUsage]  # noqa: F401
-    _render_header as _render_header,  # pyright: ignore[reportPrivateUsage]  # noqa: F401
-    _render_recent_events as _render_recent_events,  # pyright: ignore[reportPrivateUsage]  # noqa: F401
-    _render_shutdown_cycles as _render_shutdown_cycles,  # pyright: ignore[reportPrivateUsage]  # noqa: F401
-    _safe_event_data as _safe_event_data,  # pyright: ignore[reportPrivateUsage]  # noqa: F401
-    _truncate as _truncate,  # pyright: ignore[reportPrivateUsage]  # noqa: F401
-    render_session_detail as render_session_detail,
-)
-
-# Backward-compatible private aliases so existing internal call-sites and
-# tests that import the underscore-prefixed names keep working.
-_shutdown_output_tokens = shutdown_output_tokens
-_total_output_tokens = total_output_tokens
-_has_active_period_stats = has_active_period_stats
+from copilot_usage.render_detail import render_session_detail
 
 __all__ = [
     "format_duration",
@@ -93,7 +73,7 @@ class _EffectiveStats:
 
 def _effective_stats(session: SessionSummary) -> _EffectiveStats:
     """Return active-period stats if available, otherwise session totals."""
-    if _has_active_period_stats(session):
+    if has_active_period_stats(session):
         return _EffectiveStats(
             model_calls=session.active_model_calls,
             user_messages=session.active_user_messages,
@@ -102,7 +82,7 @@ def _effective_stats(session: SessionSummary) -> _EffectiveStats:
     return _EffectiveStats(
         model_calls=session.model_calls,
         user_messages=session.user_messages,
-        output_tokens=_total_output_tokens(session),
+        output_tokens=total_output_tokens(session),
     )
 
 
@@ -121,13 +101,13 @@ class _SessionTotals:
 def _compute_session_totals(
     sessions: list[SessionSummary],
     *,
-    token_fn: Callable[[SessionSummary], int] = _total_output_tokens,
+    token_fn: Callable[[SessionSummary], int] = total_output_tokens,
 ) -> _SessionTotals:
     """Compute aggregated totals across *sessions*.
 
     *token_fn* controls how output tokens are counted per session.  Defaults
-    to :func:`_total_output_tokens` (includes active tokens for resumed
-    sessions).  Pass :func:`_shutdown_output_tokens` for shutdown-only views.
+    to :func:`total_output_tokens` (includes active tokens for resumed
+    sessions).  Pass :func:`shutdown_output_tokens` for shutdown-only views.
     """
     return _SessionTotals(
         premium=sum(s.total_premium_requests for s in sessions),
@@ -364,7 +344,7 @@ def _render_session_table(
     """Render the per-session table sorted by start time (newest first).
 
     When *include_active_tokens* is ``False`` the table uses
-    :func:`_shutdown_output_tokens` so that only shutdown-derived metrics
+    :func:`shutdown_output_tokens` so that only shutdown-derived metrics
     appear (appropriate for historical / "Shutdown Data" views).
     """
     if not sessions:
@@ -390,7 +370,7 @@ def _render_session_table(
         model = s.model or "—"
 
         token_fn = (
-            _total_output_tokens if include_active_tokens else _shutdown_output_tokens
+            total_output_tokens if include_active_tokens else shutdown_output_tokens
         )
         output_tokens = token_fn(s)
 
@@ -472,7 +452,7 @@ def _render_historical_section(
         return
 
     # Totals panel — shutdown-only tokens for the historical view
-    totals = _compute_session_totals(historical, token_fn=_shutdown_output_tokens)
+    totals = _compute_session_totals(historical, token_fn=shutdown_output_tokens)
 
     lines = [
         f"[green]{totals.premium}[/green] premium requests   "
@@ -636,7 +616,7 @@ def render_cost_view(
             )
 
         grand_model_calls += s.model_calls
-        grand_output += _total_output_tokens(s)
+        grand_output += total_output_tokens(s)
 
         if s.is_active and s.has_shutdown_metrics:
             cost_stats = _effective_stats(s)

--- a/tests/copilot_usage/test_report.py
+++ b/tests/copilot_usage/test_report.py
@@ -25,29 +25,31 @@ from copilot_usage.models import (
     SessionEvent,
     SessionSummary,
     TokenUsage,
+    has_active_period_stats,
+    shutdown_output_tokens,
+    total_output_tokens,
 )
 from copilot_usage.parser import build_session_summary, parse_events
+from copilot_usage.render_detail import (
+    _build_event_details,
+    _event_type_label,
+    _format_detail_duration,
+    _format_relative_time,
+    _render_recent_events,
+    _render_shutdown_cycles,
+    _safe_event_data,
+    _truncate,
+)
 from copilot_usage.report import (
     _aggregate_model_metrics,
-    _build_event_details,
     _compute_session_totals,
     _effective_stats,
     _EffectiveStats,
     _estimate_premium_cost,
-    _event_type_label,
     _filter_sessions,
-    _format_detail_duration,
     _format_elapsed_since,
-    _format_relative_time,
     _format_session_running_time,
-    _has_active_period_stats,
     _render_model_table,
-    _render_recent_events,
-    _render_shutdown_cycles,
-    _safe_event_data,
-    _shutdown_output_tokens,
-    _total_output_tokens,
-    _truncate,
     format_duration,
     format_tokens,
     render_cost_view,
@@ -2849,7 +2851,7 @@ class TestRenderModelTable:
 
 
 # ---------------------------------------------------------------------------
-# _has_active_period_stats
+# has_active_period_stats
 # ---------------------------------------------------------------------------
 
 
@@ -3023,7 +3025,7 @@ class TestBuildEventDetailsCatchAll:
 
 
 class TestHasActivePeriodStats:
-    """Tests for the _has_active_period_stats helper."""
+    """Tests for the has_active_period_stats helper."""
 
     def test_returns_true_with_last_resume_time(self) -> None:
         """Resumed session with last_resume_time set returns True."""
@@ -3038,7 +3040,7 @@ class TestHasActivePeriodStats:
             active_output_tokens=0,
             active_model_calls=0,
         )
-        assert _has_active_period_stats(session) is True
+        assert has_active_period_stats(session) is True
 
     def test_returns_true_with_active_user_messages(self) -> None:
         """Session with positive active_user_messages returns True."""
@@ -3049,7 +3051,7 @@ class TestHasActivePeriodStats:
             active_output_tokens=0,
             active_model_calls=0,
         )
-        assert _has_active_period_stats(session) is True
+        assert has_active_period_stats(session) is True
 
     def test_returns_true_with_active_output_tokens(self) -> None:
         """Session with positive active_output_tokens returns True."""
@@ -3060,7 +3062,7 @@ class TestHasActivePeriodStats:
             active_output_tokens=1000,
             active_model_calls=0,
         )
-        assert _has_active_period_stats(session) is True
+        assert has_active_period_stats(session) is True
 
     def test_returns_true_with_active_model_calls(self) -> None:
         """Session with positive active_model_calls returns True."""
@@ -3071,7 +3073,7 @@ class TestHasActivePeriodStats:
             active_output_tokens=0,
             active_model_calls=3,
         )
-        assert _has_active_period_stats(session) is True
+        assert has_active_period_stats(session) is True
 
     def test_returns_false_for_pure_active_never_shutdown(self) -> None:
         """Pure-active session with no shutdown and all active_* counters zero returns False."""
@@ -3085,7 +3087,7 @@ class TestHasActivePeriodStats:
             active_output_tokens=0,
             active_model_calls=0,
         )
-        assert _has_active_period_stats(session) is False
+        assert has_active_period_stats(session) is False
 
 
 class TestEffectiveStats:
@@ -3133,7 +3135,7 @@ class TestEffectiveStats:
         assert isinstance(stats, _EffectiveStats)
         assert stats.model_calls == 12
         assert stats.user_messages == 8
-        # Falls back to _total_output_tokens which sums model_metrics
+        # Falls back to total_output_tokens which sums model_metrics
         assert stats.output_tokens == 4200
 
     def test_frozen_dataclass(self) -> None:
@@ -3533,12 +3535,12 @@ class TestRenderCostViewActiveModelNone:
 
 
 # ---------------------------------------------------------------------------
-# Issue #276 — _total_output_tokens and resumed-session token accounting
+# Issue #276 — total_output_tokens and resumed-session token accounting
 # ---------------------------------------------------------------------------
 
 
 class TestTotalOutputTokens:
-    """Tests for the _total_output_tokens helper (issue #276)."""
+    """Tests for the total_output_tokens helper (issue #276)."""
 
     def test_non_resumed_session(self) -> None:
         """A normal session returns model_metrics output tokens only."""
@@ -3551,7 +3553,7 @@ class TestTotalOutputTokens:
                 ),
             },
         )
-        assert _total_output_tokens(session) == 500
+        assert total_output_tokens(session) == 500
 
     def test_resumed_session_includes_active_tokens(self) -> None:
         """Resumed session with shutdown data adds active_output_tokens."""
@@ -3568,7 +3570,7 @@ class TestTotalOutputTokens:
                 ),
             },
         )
-        assert _total_output_tokens(session) == 600  # 350 + 250
+        assert total_output_tokens(session) == 600  # 350 + 250
 
     def test_pure_active_session_no_double_count(self) -> None:
         """Pure-active session (no shutdown data) does not double-count."""
@@ -3586,7 +3588,7 @@ class TestTotalOutputTokens:
             },
         )
         # has_shutdown_metrics=False → should NOT add active tokens
-        assert _total_output_tokens(session) == 400
+        assert total_output_tokens(session) == 400
 
     def test_empty_model_metrics(self) -> None:
         """Session with no model_metrics and no active tokens returns 0."""
@@ -3594,7 +3596,7 @@ class TestTotalOutputTokens:
             session_id="empty-1234",
             model_metrics={},
         )
-        assert _total_output_tokens(session) == 0
+        assert total_output_tokens(session) == 0
 
     def test_empty_model_metrics_with_active_tokens(self) -> None:
         """Active session with no model_metrics uses active_output_tokens."""
@@ -3605,7 +3607,7 @@ class TestTotalOutputTokens:
             active_output_tokens=500,
             model_metrics={},
         )
-        assert _total_output_tokens(session) == 500
+        assert total_output_tokens(session) == 500
 
     def test_multiple_models_resumed(self) -> None:
         """Resumed session sums across models and adds active tokens."""
@@ -3626,7 +3628,7 @@ class TestTotalOutputTokens:
                 ),
             },
         )
-        assert _total_output_tokens(session) == 600  # 200 + 300 + 100
+        assert total_output_tokens(session) == 600  # 200 + 300 + 100
 
     # -- Issue #351 regression tests --
 
@@ -3649,7 +3651,7 @@ class TestTotalOutputTokens:
                 ),
             },
         )
-        assert _total_output_tokens(session) == 400
+        assert total_output_tokens(session) == 400
 
     def test_resumed_session_with_shutdown_adds_active_tokens(self) -> None:
         """Resumed session with has_shutdown_metrics=True adds active tokens.
@@ -3672,7 +3674,7 @@ class TestTotalOutputTokens:
                 ),
             },
         )
-        assert _total_output_tokens(session) == shutdown_tokens + active_tokens
+        assert total_output_tokens(session) == shutdown_tokens + active_tokens
 
     def test_completed_session_empty_metrics_via_parser(self, tmp_path: Path) -> None:
         """Parser→report integration: shutdown with modelMetrics={} → 0 tokens."""
@@ -3713,7 +3715,7 @@ class TestTotalOutputTokens:
         events = parse_events(p)
         summary = build_session_summary(events, session_dir=p.parent)
         assert summary.model_metrics == {}
-        assert _total_output_tokens(summary) == 0
+        assert total_output_tokens(summary) == 0
 
     def test_resumed_session_empty_shutdown_metrics_via_parser(
         self, tmp_path: Path
@@ -3797,7 +3799,7 @@ class TestTotalOutputTokens:
         assert summary.is_active is True
         assert summary.model_metrics == {}
         assert summary.active_output_tokens == 400
-        assert _total_output_tokens(summary) == 400
+        assert total_output_tokens(summary) == 400
 
 
 class TestRenderAggregateStatsResumedTokens:
@@ -3807,7 +3809,7 @@ class TestRenderAggregateStatsResumedTokens:
         self,
     ) -> None:
         """Output tokens in Aggregate Stats panel include active_output_tokens for resumed sessions."""
-        from copilot_usage.report import _render_aggregate_stats
+        from copilot_usage.render_detail import _render_aggregate_stats
 
         session = SessionSummary(
             session_id="agg-resumed-1234",
@@ -3827,7 +3829,7 @@ class TestRenderAggregateStatsResumedTokens:
             },
         )
 
-        expected_total = _total_output_tokens(session)  # 350 + 250 = 600
+        expected_total = total_output_tokens(session)  # 350 + 250 = 600
         assert expected_total == 600
 
         output = _capture_console(_render_aggregate_stats, session)
@@ -3987,12 +3989,12 @@ class TestRenderCostViewResumed:
 
 
 # ---------------------------------------------------------------------------
-# Issue #276 — _shutdown_output_tokens and render_full_summary split-view
+# Issue #276 — shutdown_output_tokens and render_full_summary split-view
 # ---------------------------------------------------------------------------
 
 
 class TestShutdownOutputTokens:
-    """Tests for the _shutdown_output_tokens helper."""
+    """Tests for the shutdown_output_tokens helper."""
 
     def test_returns_baseline_only(self) -> None:
         """Shutdown helper returns model_metrics total without active tokens."""
@@ -4009,14 +4011,14 @@ class TestShutdownOutputTokens:
                 ),
             },
         )
-        assert _shutdown_output_tokens(session) == 350
-        # Contrast with _total_output_tokens which includes active
-        assert _total_output_tokens(session) == 600
+        assert shutdown_output_tokens(session) == 350
+        # Contrast with total_output_tokens which includes active
+        assert total_output_tokens(session) == 600
 
     def test_empty_metrics(self) -> None:
         """Empty model_metrics returns 0."""
         session = SessionSummary(session_id="empty-shut", model_metrics={})
-        assert _shutdown_output_tokens(session) == 0
+        assert shutdown_output_tokens(session) == 0
 
 
 class TestRenderFullSummaryResumedSplitView:


### PR DESCRIPTION
Closes #445

## What

Removes the two layers of synthetic re-exports in `report.py` that existed solely
for backward-compat with test imports:

- **Layer 1 removed**: 12-line `_x as _x` re-export block from `render_detail` (lines 38–51)
  with their `pyright: ignore[reportPrivateUsage]` + `noqa: F401` suppressions
- **Layer 2 removed**: 3 private alias assignments (`_shutdown_output_tokens`,
  `_total_output_tokens`, `_has_active_period_stats`) at lines 53–57

## How

- `test_report.py` now imports each symbol from its canonical home:
  - 8 helpers (`_build_event_details`, `_event_type_label`, etc.) from `copilot_usage.render_detail`
  - 3 helpers (`has_active_period_stats`, `shutdown_output_tokens`, `total_output_tokens`) from `copilot_usage.models`
- `report.py` internal call-sites updated to use the public names directly
- All 762 tests pass, 99.59% coverage, ruff/pyright clean




> [!WARNING]
> <details>
> <summary>⚠️ Firewall blocked 1 domain</summary>
>
> The following domain was blocked by the firewall during workflow execution:
>
> - `astral.sh`
>
> To allow these domains, add them to the `network.allowed` list in your workflow frontmatter:
>
> ```yaml
> network:
>   allowed:
>     - defaults
>     - "astral.sh"
> ```
>
> See [Network Configuration](https://github.github.com/gh-aw/reference/network/) for more information.
>
> </details>


> [!NOTE]
> <details>
> <summary>🔒 Integrity filtering filtered 1 item</summary>
>
> Integrity filtering activated and filtered the following item during workflow execution.
> This happens when a tool call accesses a resource that does not meet the required integrity or secrecy level of the workflow.
>
> - issue:microsasa/cli-tools#445 (`issue_read`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".)
>
> </details>


> Generated by [Issue Implementer](https://github.com/microsasa/cli-tools/actions/runs/23677441586) · [◷](https://github.com/search?q=repo%3Amicrosasa%2Fcli-tools+%22gh-aw-workflow-id%3A+issue-implementer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Issue Implementer, engine: copilot, model: claude-opus-4.6, id: 23677441586, workflow_id: issue-implementer, run: https://github.com/microsasa/cli-tools/actions/runs/23677441586 -->

<!-- gh-aw-workflow-id: issue-implementer -->