### PR TITLE
docs: update changelog, architecture, and implementation docs

### DIFF
--- a/src/copilot_usage/docs/architecture.md
+++ b/src/copilot_usage/docs/architecture.md
@@ -34,25 +34,25 @@ Monorepo containing Python CLI utilities that share tooling, CI, and common depe
 | Module | Responsibility |
 |--------|---------------|
 | `cli.py` | Click command group — routes commands to parser/report functions, handles CLI options, error display. Also contains the interactive loop (invoked when no subcommand is given) with watchdog-based auto-refresh (2-second debounce). |
-| `parser.py` | Discovers sessions, reads events.jsonl line by line, builds SessionSummary per session. Counts raw events (model calls via assistant.turn_start, user messages). |
+| `parser.py` | Discovers sessions, reads events.jsonl line by line, builds SessionSummary per session via focused helpers: `_first_pass()` (extract identity/shutdowns/counters), `_detect_resume()` (post-shutdown scan), `_build_completed_summary()`, `_build_active_summary()`. |
 | `models.py` | Pydantic v2 models for all event types + SessionSummary aggregate (includes model_calls and user_messages fields). Runtime validation at parse boundary. |
-| `report.py` | Rich-formatted terminal output — summary tables (with Model Calls and User Msgs columns), session detail, live view, premium request breakdown. Shows raw counts and `~`-prefixed premium cost estimates for live/active sessions; historical post-shutdown views display exact API-provided numbers. |
+| `report.py` | Rich-formatted terminal output — summary tables (with Model Calls and User Msgs columns), live view, premium request breakdown. Shows raw counts and `~`-prefixed premium cost estimates for live/active sessions; historical post-shutdown views display exact API-provided numbers. |
+| `render_detail.py` | Session detail rendering — extracted from report.py. Displays event timeline, per-event metadata, and session-level aggregates. |
+| `_formatting.py` | Shared formatting utilities — `format_duration()` and `format_tokens()` with doctest-verified examples. Used by report.py and render_detail.py. |
 | `pricing.py` | Model pricing registry — multiplier lookup, tier categorization. Multipliers are used for `~`-prefixed cost estimates in live/active views (`render_live_sessions`, `render_cost_view`); historical post-shutdown views use exact API-provided numbers exclusively. |
-| `logging_config.py` | Loguru setup — stderr warnings only, no file output. Called once from CLI entry point. |
+| `logging_config.py` | Loguru setup — stderr warnings only, no file output. `loguru` module import guarded behind `TYPE_CHECKING` for the `"loguru.Record"` type annotation. Called once from CLI entry point. |
 
 ### Event Processing Pipeline
 
 1. **Discovery** — `discover_sessions()` scans `~/.copilot/session-state/*/events.jsonl`, returns paths sorted by modification time
 2. **Parsing** — `parse_events()` reads each line as JSON, creates `SessionEvent` objects via Pydantic validation. Malformed lines are skipped with a warning.
 3. **Typed dispatch** — `SessionEvent.parse_data()` uses match/case on event type to return the correct typed data model (`SessionStartData`, `AssistantMessageData`, etc.)
-4. **Summarization** — `build_session_summary()` walks the event list:
-   - Extracts session metadata from `session.start`
-   - Counts raw events: model calls (assistant.turn_start count), user messages (user.message count)
-   - For completed sessions: uses `session.shutdown` aggregate metrics directly — **sums all shutdown events** (shutdown metrics are per-lifecycle, not cumulative)
-   - For active/resumed sessions: sums `outputTokens` from individual `assistant.message` events
-   - Detects resumed sessions: if events exist after `session.shutdown`, marks `is_active = True`
-   - Tracks `last_resume_time` from `session.resume` events — used to calculate "Running" duration for active sessions
-   - Reports exact premium requests from shutdown data; multiplier-based `~` estimates are used only in live/active views
+4. **Summarization** — `build_session_summary()` orchestrates four focused helpers:
+   - `_first_pass()`: single pass over events — extracts session metadata from `session.start`, counts raw events (model calls, user messages, output tokens), collects all shutdown data
+   - `_detect_resume()`: scans events after the last shutdown for resume indicators (`session.resume`, `user.message`, `assistant.message`)
+   - `_build_completed_summary()`: merges all shutdown cycles (metrics, premium requests, code changes) into a SessionSummary. Sets `is_active=True` if resumed.
+   - `_build_active_summary()`: for sessions with no shutdowns — infers model from `tool.execution_complete` events or `~/.copilot/config.json`, builds synthetic metrics from output tokens
+   - Two frozen dataclasses (`_FirstPassResult`, `_ResumeInfo`) carry state between helpers
 5. **Rendering** — Report functions receive `SessionSummary` objects and render Rich output
 
 ### Key Design Decisions
@@ -75,14 +75,19 @@ tests/
 │   ├── test_models.py          Pydantic model creation and validation
 │   ├── test_parser.py          Event parsing, session summary building, edge cases
 │   ├── test_pricing.py         Pricing lookups, cost estimation
-│   ├── test_report.py          Rich output formatting, rendering functions
+│   ├── test_report.py          Rich output & session-detail rendering
+│   ├── test_formatting.py      Formatting helpers and string utilities
+│   ├── test_logging_config.py  Loguru configuration
 │   └── test_cli.py             Click command invocation via CliRunner
+├── test_packaging.py           Wheel build test — verifies docs excluded from distribution
+├── test_docs.py                Documentation tests
 └── e2e/                        E2e tests — real CLI commands against fixture data
-    ├── fixtures/               Anonymized events from real Copilot sessions (9 fixtures)
+    ├── fixtures/               Anonymized events from real Copilot sessions
     └── test_e2e.py             Full pipeline: CLI → parser → models → report → output
 ```
 
-- **Unit tests**: 96% coverage, test individual functions with synthetic data
-- **E2e tests**: Run actual CLI commands against 9 anonymized fixture sessions, assert on output content
+- **Unit tests**: 99% coverage, test individual functions with synthetic data
+- **Doctests**: `_formatting.py` functions have `>>>` examples executed via `--doctest-modules`
+- **E2e tests**: Run actual CLI commands against anonymized fixture sessions, assert on output content
 - Test counts grow regularly — run `make test` to see the current numbers
 - Coverage is measured on unit tests only (e2e coverage would be misleading)

--- a/src/copilot_usage/docs/changelog.md
+++ b/src/copilot_usage/docs/changelog.md
@@ -1,6 +1,62 @@
 # CLI Tools — Changelog
 
 Append-only history of what was planned and delivered, PR by PR. Newest entries first.
+Manual work only — autonomous agent pipeline PRs are not tracked here.
+
+---
+
+## refactor: split build_session_summary into focused helpers — 2026-03-28
+
+**PR**: #451 — Closes #224
+
+**Plan**: Break the ~200-line `build_session_summary` monolith into focused private helpers while preserving identical behavior.
+
+**Done**:
+- Extracted 4 helpers: `_first_pass()`, `_detect_resume()`, `_build_completed_summary()`, `_build_active_summary()`
+- Two frozen dataclasses (`_FirstPassResult`, `_ResumeInfo`) carry state between phases
+- `build_session_summary` is now a 6-line coordinator
+- Public API unchanged — all ~90 existing tests pass without modification
+- Addressed Copilot review: removed unused `seen_session_start` field, dropped unused `current_model` from shutdown tuple
+
+---
+
+## fix: three protected-files code health issues — 2026-03-28
+
+**PR**: #449 — Closes #291, #330, #352
+
+**Plan**: Fix three `aw-protected-files` issues that autonomous agents cannot touch.
+
+**Done**:
+- **#291**: Wrapped bare `import loguru` in `TYPE_CHECKING` guard in `logging_config.py`
+- **#330**: Added `exclude = ["src/copilot_usage/docs"]` to hatchling wheel config; created `tests/test_packaging.py` using `shutil.which("uv")` for S607 compliance
+- **#352**: Restored doctest examples in `_formatting.py`, enabled `--doctest-modules` with `testpaths = ["tests", "src"]`
+- Updated Makefile: unit test targets use `--ignore=tests/e2e` instead of explicit paths, letting `pyproject.toml` `testpaths` guide collection
+
+---
+
+## fix: implementer missing Closes keyword in PR body — 2026-03-28
+
+**PR**: #439 — Closes #435
+
+**Plan**: Issues stayed open after their PRs merged because the implementer LLM non-deterministically omitted `Closes #NNN` from PR bodies.
+
+**Done**:
+- Added explicit instruction to `.github/workflows/issue-implementer.md` (line 58): PR body MUST include `Closes #${{ github.event.inputs.issue_number }}`
+- No lock file change needed — implementer uses `runtime-import`
+
+---
+
+## fix: CI re-trigger for dropped workflow_dispatch events — 2026-03-28
+
+**PR**: #414 — Closes #412
+
+**Plan**: Fix 4 bugs found during Copilot code review of the CI re-trigger mechanism.
+
+**Done**:
+- Removed `inputs.ref` from CI checkout — default `github.ref` is correct for both `pull_request` and `workflow_dispatch` triggers
+- Normalized empty `CI_CONCLUSION` to `NO_CI_RESULT` instead of silently proceeding
+- Changed `-f ref="$BRANCH"` to `--ref "$BRANCH"` in orchestrator dispatch (these are completely different: `-f` passes an input parameter, `--ref` sets the git ref)
+- Made date parse bail on failure instead of computing garbage age (~29M minutes from epoch)
 
 ---
 

--- a/src/copilot_usage/docs/implementation.md
+++ b/src/copilot_usage/docs/implementation.md
@@ -93,21 +93,21 @@ Each `session.shutdown` event represents the metrics for **one lifecycle** (star
 
 ### The code path
 
-In `build_session_summary()` (in `parser.py`):
+`build_session_summary()` (in `parser.py`) delegates to four focused helpers:
 
-**Phase 1 — Collect all shutdowns** (in `parser.py`):
+**`_first_pass(events)` → `_FirstPassResult`** — single pass collecting all shutdowns:
 ```python
-all_shutdowns: list[tuple[int, SessionShutdownData, str | None]] = []
+all_shutdowns: list[tuple[int, SessionShutdownData]] = []
 # ...
 elif ev.type == EventType.SESSION_SHUTDOWN:
     # ... validate, extract data ...
-    all_shutdowns.append((idx, data, current_model))
+    all_shutdowns.append((idx, data))
 ```
-Each tuple stores `(event_index, shutdown_data, resolved_model)`.
+Each tuple stores `(event_index, shutdown_data)`. The model is resolved inline and stored on `_FirstPassResult.model`.
 
-**Phase 2 — Sum across all shutdowns** (in `parser.py`):
+**`_build_completed_summary(fp, name, resume)` → `SessionSummary`** — sums across all shutdowns:
 ```python
-for _idx, sd, _m in all_shutdowns:
+for _idx, sd in fp.all_shutdowns:
     total_premium += sd.totalPremiumRequests
     total_api_duration += sd.totalApiDurationMs
     # ... merge model_metrics ...
@@ -144,23 +144,20 @@ The model name for a shutdown is resolved in priority order (in `parser.py`):
 
 ### Detection logic
 
-After collecting all shutdowns, `build_session_summary()` scans events after the last shutdown index (in `parser.py`):
+After the first pass, `build_session_summary()` calls `_detect_resume(events, fp.all_shutdowns)` (in `parser.py`) which scans events after the last shutdown index:
 
 ```python
-_RESUME_INDICATOR_TYPES: frozenset[str] = frozenset({
-    EventType.SESSION_RESUME,
-    EventType.USER_MESSAGE,
-    EventType.ASSISTANT_MESSAGE,
-})
+def _detect_resume(events, all_shutdowns):
+    # ...
+    last_shutdown_idx = all_shutdowns[-1][0]
 
-last_shutdown_idx = all_shutdowns[-1][0] if all_shutdowns else -1
-
-if all_shutdowns and last_shutdown_idx >= 0:
     for ev in events[last_shutdown_idx + 1:]:
         if ev.type in _RESUME_INDICATOR_TYPES:
             session_resumed = True
         # ... count post-shutdown tokens, messages, model calls ...
 ```
+
+The helper includes a defensive guard for empty `all_shutdowns` (returns empty `_ResumeInfo`), making it safe to call independently.
 
 The presence of **any** `session.resume`, `user.message`, or `assistant.message` event after the last shutdown triggers `session_resumed = True`.
 
@@ -368,7 +365,7 @@ Two levels of protection against files disappearing between discovery and read:
 
 Events with types not in `EventType` still parse successfully — `SessionEvent.type` is `str`, not the enum. `parse_data()` returns `GenericEventData(extra="allow")` for unknown types, accepting any fields.
 
-In `build_session_summary()`, unknown types are simply ignored — the `for idx, ev in enumerate(events)` loop only has branches for known types, with no `else` clause needed.
+In `_first_pass()` (in `parser.py`), unknown types are simply ignored — the loop only has branches for known types, with no `else` clause needed.
 
 ### Unknown models in pricing
 
@@ -426,7 +423,7 @@ Tier is derived from the multiplier (in `pricing.py`): ≥3.0 → Premium, = 0.0
 
 ### Model resolution for active sessions
 
-When no shutdown data exists, the model is resolved in `build_session_summary()` (in `parser.py`):
+When no shutdown data exists, the model is resolved in `_build_active_summary()` (in `parser.py`):
 
-1. Scan `tool.execution_complete` events for a `model` field (in `parser.py`)
+1. Scan `tool.execution_complete` events for a `model` field
 2. Fall back to `~/.copilot/config.json` → `data.model` field (`_read_config_model()` in `parser.py`)


### PR DESCRIPTION
## Summary

Catches up all three internal docs after ~2 weeks of manual work.

### changelog.md
- 4 new entries for manual PRs: #414, #439, #449, #451
- Added note that changelog tracks manual work only (not agent PRs)

### architecture.md
- Added `_formatting.py` and `render_detail.py` to components table
- Updated `parser.py` description to reflect helper-based structure (PR #451)
- Updated testing section: `test_packaging.py`, doctests, 99% coverage

### implementation.md
- Rewrote shutdown processing, resume detection, and model resolution sections to reference the new helper functions (`_first_pass`, `_detect_resume`, `_build_completed_summary`, `_build_active_summary`)
- Updated tuple structure from 3-element to 2-element

Docs-only change — no code modifications.