### PR TITLE
test: add value assertions for render_detail helpers (#453)

### DIFF
--- a/tests/copilot_usage/test_report.py
+++ b/tests/copilot_usage/test_report.py
@@ -826,14 +826,23 @@ class TestRenderSessionDetail:
 
         summary = _make_session(model=None, is_active=False, output_tokens=0)
         output = _capture_console(render_session_detail, [], summary)
-        assert "—" in output
+        # Ensure the Model header shows an em dash placeholder (and not "None")
+        model_lines = [line for line in output.splitlines() if "Model:" in line]
+        assert model_lines, "Model header not found in output"
+        assert any("—" in line for line in model_lines)
+        assert all("None" not in line for line in model_lines)
 
     def test_header_start_time_none_shows_dash(self) -> None:
         from copilot_usage.report import render_session_detail
 
         summary = _make_session(start_time=None, is_active=False)
         output = _capture_console(render_session_detail, [], summary)
-        assert "—" in output
+        assert "Started: —" in output
+        # Ensure the dash is not coming from the model field.
+        model_line = next(
+            (line for line in output.splitlines() if "Model:" in line), ""
+        )
+        assert "claude-sonnet-4" in model_line
 
 
 class TestRenderActivePeriodDirect:
@@ -872,12 +881,21 @@ class TestRenderHeaderDirect:
     def test_model_none_shows_dash(self) -> None:
         summary = _make_session(model=None, is_active=False, output_tokens=0)
         output = _capture_console(_render_header, summary)
-        assert "—" in output
+        model_line = next(
+            (line for line in output.splitlines() if "Model:" in line), ""
+        )
+        assert "—" in model_line
+        assert "None" not in model_line
 
     def test_start_time_none_shows_dash(self) -> None:
         summary = _make_session(start_time=None, is_active=False)
         output = _capture_console(_render_header, summary)
-        assert "—" in output
+        assert "Started: —" in output
+        # Ensure the dash is not coming from the model field.
+        model_line = next(
+            (line for line in output.splitlines() if "Model:" in line), ""
+        )
+        assert "claude-sonnet-4" in model_line
 
     def test_model_present_shows_model(self) -> None:
         summary = _make_session(model="gpt-4o", is_active=False)


### PR DESCRIPTION
Closes #453

## Summary

Adds missing data-value assertions for three `render_detail.py` helpers that previously only checked panel/table titles were present.

### Gap 1 — `_render_active_period`
- **`TestRenderActivePeriodDirect`**: direct unit tests verify `"3 model calls"`, `"2 user messages"`, `"500"` appear in output
- Tests `format_tokens` formatting with `active_output_tokens=1500` → asserts `"1.5K"`
- Tests `is_active=False` produces empty output
- Strengthened existing `test_active_session_shows_active_period` with inline value checks

### Gap 2 — `_render_header`
- **`TestRenderHeaderDirect`**: tests `model=None` → `"—"` fallback, `start_time=None` → `"—"` fallback, and non-None model renders correctly
- Added integration tests via `render_session_detail` for both `None` paths

### Gap 3 — `_render_aggregate_stats`
- **`TestRenderAggregateStatsDirect`**: asserts `format_tokens(5000)` = `"5.0K"` and `format_duration(60000)` = `"1m"` appear in non-resumed path
- Strengthened existing `test_renders_aggregate_stats` with `"5.0K"` and `"1m"` assertions

All 719 tests pass. Coverage: 99.47%.




> [!WARNING]
> <details>
> <summary>⚠️ Firewall blocked 1 domain</summary>
>
> The following domain was blocked by the firewall during workflow execution:
>
> - `astral.sh`
>
> To allow these domains, add them to the `network.allowed` list in your workflow frontmatter:
>
> ```yaml
> network:
>   allowed:
>     - defaults
>     - "astral.sh"
> ```
>
> See [Network Configuration](https://github.github.com/gh-aw/reference/network/) for more information.
>
> </details>


> [!NOTE]
> <details>
> <summary>🔒 Integrity filtering filtered 1 item</summary>
>
> Integrity filtering activated and filtered the following item during workflow execution.
> This happens when a tool call accesses a resource that does not meet the required integrity or secrecy level of the workflow.
>
> - issue:microsasa/cli-tools#453 (`issue_read`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".)
>
> </details>


> Generated by [Issue Implementer](https://github.com/microsasa/cli-tools/actions/runs/23680592772) · [◷](https://github.com/search?q=repo%3Amicrosasa%2Fcli-tools+%22gh-aw-workflow-id%3A+issue-implementer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Issue Implementer, engine: copilot, model: claude-opus-4.6, id: 23680592772, workflow_id: issue-implementer, run: https://github.com/microsasa/cli-tools/actions/runs/23680592772 -->

<!-- gh-aw-workflow-id: issue-implementer -->