### PR TITLE
fix: minor code clarity bundle (#455)

### DIFF
--- a/src/copilot_usage/cli.py
+++ b/src/copilot_usage/cli.py
@@ -360,7 +360,7 @@ def _interactive_loop(path: Path | None) -> None:
             _write_prompt(_BACK_PROMPT)
 
     except KeyboardInterrupt:
-        pass
+        pass  # User pressed Ctrl-C; observer cleanup runs in finally
     finally:
         _stop_observer(observer)
 

--- a/src/copilot_usage/models.py
+++ b/src/copilot_usage/models.py
@@ -11,9 +11,9 @@ from pathlib import Path
 
 from pydantic import BaseModel, Field
 
-# Defensive alias for the built-in ``type`` so it remains usable inside
-# classes (like SessionEvent) that may define a Pydantic field ``type``
-# with a default/Field assignment in the future, which would shadow it.
+# Defensive alias for the built-in ``type`` to avoid shadowing by the
+# Pydantic field ``type: str`` defined on SessionEvent (and any future
+# class in this module that follows the same pattern).
 _type = type
 
 # ---------------------------------------------------------------------------

--- a/src/copilot_usage/parser.py
+++ b/src/copilot_usage/parser.py
@@ -387,14 +387,14 @@ def _build_active_summary(
     model = fp.model
 
     # Try to determine model from tool.execution_complete events
-    for idx_tool, ev in enumerate(events):
+    for idx, ev in enumerate(events):
         if ev.type == EventType.TOOL_EXECUTION_COMPLETE:
             try:
                 parsed = ev.as_tool_execution()
             except ValidationError as exc:
                 logger.debug(
                     "event {} — could not parse {} event ({}), skipping",
-                    idx_tool,
+                    idx,
                     ev.type,
                     exc.error_count(),
                 )


### PR DESCRIPTION
Three small code clarity improvements as specified in #455:

1. **`parser.py`** — Renamed `idx_tool` → `idx` in `_build_active_summary` to avoid implying tool-specific numbering when it's the full event list index.
2. **`models.py`** — Updated the `_type` alias comment to reflect that `SessionEvent` already shadows `type`, not that it might do so "in the future".
3. **`cli.py`** — Added a clarifying comment to `except KeyboardInterrupt: pass` explaining the intent (Ctrl-C cleanup via `finally`).

No logic changes — naming and comments only. All 788 existing tests pass.

Closes #455




> [!NOTE]
> <details>
> <summary>🔒 Integrity filtering filtered 11 items</summary>
>
> Integrity filtering activated and filtered the following items during workflow execution.
> This happens when a tool call accesses a resource that does not meet the required integrity or secrecy level of the workflow.
>
> - issue:microsasa/cli-tools#455 (`issue_read`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".)
> - issue:microsasa/cli-tools#455 (`list_issues`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".)
> - issue:microsasa/cli-tools#437 (`list_issues`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".)
> - issue:microsasa/cli-tools#221 (`list_issues`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".)
> - issue:microsasa/cli-tools#220 (`list_issues`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".)
> - issue:microsasa/cli-tools#173 (`list_issues`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".)
> - issue:microsasa/cli-tools#165 (`list_issues`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".)
> - issue:microsasa/cli-tools#131 (`list_issues`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".)
> - issue:microsasa/cli-tools#114 (`list_issues`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".)
> - issue:microsasa/cli-tools#111 (`list_issues`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".)
> - issue:microsasa/cli-tools#110 (`list_issues`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".)
>
> </details>


> Generated by [Issue Implementer](https://github.com/microsasa/cli-tools/actions/runs/23681825340) · [◷](https://github.com/search?q=repo%3Amicrosasa%2Fcli-tools+%22gh-aw-workflow-id%3A+issue-implementer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Issue Implementer, engine: copilot, model: claude-opus-4.6, id: 23681825340, workflow_id: issue-implementer, run: https://github.com/microsasa/cli-tools/actions/runs/23681825340 -->

<!-- gh-aw-workflow-id: issue-implementer -->