### PR TITLE
fix: validate active_model_calls <= model_calls invariant (#460)

### DIFF
--- a/src/copilot_usage/models.py
+++ b/src/copilot_usage/models.py
@@ -9,7 +9,7 @@ from datetime import UTC, datetime
 from enum import StrEnum
 from pathlib import Path
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 # Defensive alias for the built-in ``type`` to avoid shadowing by the
 # Pydantic field ``type: str`` defined on SessionEvent (and any future
@@ -340,6 +340,15 @@ class SessionSummary(BaseModel):
     active_model_calls: int = 0
     active_user_messages: int = 0
     active_output_tokens: int = 0
+
+    @model_validator(mode="after")
+    def _check_call_counts(self) -> "SessionSummary":
+        if self.active_model_calls > self.model_calls:
+            raise ValueError(
+                f"active_model_calls ({self.active_model_calls}) must be <= "
+                f"model_calls ({self.model_calls})"
+            )
+        return self
 
 
 # ---------------------------------------------------------------------------

--- a/src/copilot_usage/report.py
+++ b/src/copilot_usage/report.py
@@ -584,8 +584,6 @@ def render_cost_view(
         # shutdown-only model_metrics data. Otherwise, display total calls.
         if s.has_shutdown_metrics and has_active_period_stats(s):
             shutdown_model_calls = s.model_calls - s.active_model_calls
-            if shutdown_model_calls < 0:
-                shutdown_model_calls = 0
             model_calls_display = str(shutdown_model_calls)
         else:
             model_calls_display = str(s.model_calls)

--- a/tests/copilot_usage/test_models.py
+++ b/tests/copilot_usage/test_models.py
@@ -598,3 +598,45 @@ class TestSessionSortKey:
 
         session = SessionSummary(session_id="s", start_time=None)
         assert session_sort_key(session) == EPOCH
+
+
+# ---------------------------------------------------------------------------
+# Issue #460 — Validate active_model_calls <= model_calls
+# ---------------------------------------------------------------------------
+
+
+class TestSessionSummaryCallCountInvariant:
+    """Tests for the model_calls >= active_model_calls invariant."""
+
+    def test_rejects_active_calls_exceeding_total(self) -> None:
+        """SessionSummary must reject active_model_calls > model_calls."""
+        with pytest.raises(ValidationError):
+            SessionSummary(
+                session_id="inv",
+                model_calls=3,
+                active_model_calls=5,
+            )
+
+    def test_accepts_active_calls_equal_to_total(self) -> None:
+        """SessionSummary allows active_model_calls == model_calls."""
+        s = SessionSummary(
+            session_id="eq",
+            model_calls=5,
+            active_model_calls=5,
+        )
+        assert s.active_model_calls == s.model_calls
+
+    def test_accepts_active_calls_less_than_total(self) -> None:
+        """SessionSummary allows active_model_calls < model_calls."""
+        s = SessionSummary(
+            session_id="lt",
+            model_calls=10,
+            active_model_calls=3,
+        )
+        assert s.active_model_calls < s.model_calls
+
+    def test_accepts_zero_calls(self) -> None:
+        """SessionSummary allows both counts at zero (defaults)."""
+        s = SessionSummary(session_id="zero")
+        assert s.model_calls == 0
+        assert s.active_model_calls == 0

--- a/tests/copilot_usage/test_report.py
+++ b/tests/copilot_usage/test_report.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from unittest.mock import patch
 
 import pytest
+from pydantic import ValidationError
 from rich.console import Console
 
 from copilot_usage._formatting import (
@@ -301,6 +302,7 @@ class TestRenderLiveSessions:
             last_resume_time=now - timedelta(minutes=10),
             # Historical totals (from shutdown events)
             user_messages=263,
+            model_calls=275,
             model_metrics={
                 "claude-sonnet-4": ModelMetrics(
                     usage=TokenUsage(outputTokens=200_000),
@@ -333,6 +335,7 @@ class TestRenderLiveSessions:
             start_time=now - timedelta(hours=2),
             # Historical totals accumulated before the current active period
             user_messages=263,
+            model_calls=275,
             model_metrics={
                 "claude-sonnet-4": ModelMetrics(
                     usage=TokenUsage(outputTokens=200_000),
@@ -1626,6 +1629,7 @@ class TestRenderFullSummary:
             name="Empty",
             start_time=datetime(2025, 1, 15, 10, 0, tzinfo=UTC),
             is_active=True,
+            model_calls=1,
             active_model_calls=1,
             active_user_messages=1,
             active_output_tokens=100,
@@ -3174,6 +3178,7 @@ class TestHasActivePeriodStats:
         session = SessionSummary(
             session_id="active-calls-1234",
             is_active=True,
+            model_calls=3,
             active_user_messages=0,
             active_output_tokens=0,
             active_model_calls=3,
@@ -3247,6 +3252,7 @@ class TestEffectiveStats:
         """_EffectiveStats instances are immutable."""
         session = SessionSummary(
             session_id="frozen-test-1234",
+            model_calls=1,
             active_model_calls=1,
         )
         stats = _effective_stats(session)
@@ -3708,6 +3714,7 @@ class TestTotalOutputTokens:
         session = SessionSummary(
             session_id="no-metrics-active",
             is_active=True,
+            model_calls=3,
             active_model_calls=3,
             active_output_tokens=500,
             model_metrics={},
@@ -4303,37 +4310,29 @@ class TestRenderCostViewModelCallsConsistency:
             f"to equal total ({total_calls})"
         )
 
-    def test_negative_shutdown_model_calls_clamped_to_zero(self) -> None:
-        """When active_model_calls > model_calls, shutdown calls clamp to 0."""
-        session = SessionSummary(
-            session_id="calls-negative-409",
-            name="Negative Guard",
-            model="gpt-4",
-            start_time=datetime(2025, 7, 1, 10, 0, tzinfo=UTC),
-            is_active=True,
-            has_shutdown_metrics=True,
-            last_resume_time=datetime.now(tz=UTC),
-            model_calls=3,
-            user_messages=5,
-            active_model_calls=5,
-            active_user_messages=2,
-            active_output_tokens=250,
-            model_metrics={
-                "gpt-4": ModelMetrics(
-                    requests=RequestMetrics(count=2, cost=4),
-                    usage=TokenUsage(outputTokens=100),
-                ),
-            },
-        )
-        output = _capture_cost_view([session])
-        clean = re.sub(r"\x1b\[[0-9;]*m", "", output)
-        lines = clean.splitlines()
-
-        model_row = [ln for ln in lines if "gpt-4" in ln and "Negative Guard" in ln]
-        assert model_row, "Expected a per-model row with session name"
-        model_cols = [col.strip() for col in model_row[0].split("│")]
-        # shutdown_model_calls = 3 - 5 = -2, clamped to 0
-        assert model_cols[5] == "0"
+    def test_negative_shutdown_model_calls_rejected_by_validator(self) -> None:
+        """active_model_calls > model_calls is rejected by the model validator."""
+        with pytest.raises(ValidationError):
+            SessionSummary(
+                session_id="calls-negative-409",
+                name="Negative Guard",
+                model="gpt-4",
+                start_time=datetime(2025, 7, 1, 10, 0, tzinfo=UTC),
+                is_active=True,
+                has_shutdown_metrics=True,
+                last_resume_time=datetime.now(tz=UTC),
+                model_calls=3,
+                user_messages=5,
+                active_model_calls=5,
+                active_user_messages=2,
+                active_output_tokens=250,
+                model_metrics={
+                    "gpt-4": ModelMetrics(
+                        requests=RequestMetrics(count=2, cost=4),
+                        usage=TokenUsage(outputTokens=100),
+                    ),
+                },
+            )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #460

## Changes

### 1. Pydantic validator on `SessionSummary` (`models.py`)
Added a `@model_validator(mode="after")` that raises `ValueError` when `active_model_calls > model_calls`. This enforces the invariant at construction time instead of silently masking it at display time.

### 2. Removed silent clamp in `render_cost_view` (`report.py`)
Removed the `if shutdown_model_calls < 0: shutdown_model_calls = 0` guard. The validator now guarantees `model_calls >= active_model_calls`, making the clamp unnecessary.

### 3. Test updates
- **`test_models.py`**: Added `TestSessionSummaryCallCountInvariant` with 4 tests covering rejection of invalid input and acceptance of valid boundaries (equal, less-than, zero defaults).
- **`test_report.py`**: Fixed 6 existing tests that constructed `SessionSummary` with `active_model_calls > model_calls` (now invalid) by adding appropriate `model_calls` values. Replaced `test_negative_shutdown_model_calls_clamped_to_zero` with `test_negative_shutdown_model_calls_rejected_by_validator` that verifies the validator rejects the previously-clamped case.

## Verification
All 794 tests pass · 99.47% coverage · ruff/pyright clean




> [!WARNING]
> <details>
> <summary>⚠️ Firewall blocked 1 domain</summary>
>
> The following domain was blocked by the firewall during workflow execution:
>
> - `astral.sh`
>
> To allow these domains, add them to the `network.allowed` list in your workflow frontmatter:
>
> ```yaml
> network:
>   allowed:
>     - defaults
>     - "astral.sh"
> ```
>
> See [Network Configuration](https://github.github.com/gh-aw/reference/network/) for more information.
>
> </details>


> [!NOTE]
> <details>
> <summary>🔒 Integrity filtering filtered 1 item</summary>
>
> Integrity filtering activated and filtered the following item during workflow execution.
> This happens when a tool call accesses a resource that does not meet the required integrity or secrecy level of the workflow.
>
> - issue:microsasa/cli-tools#460 (`issue_read`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".)
>
> </details>


> Generated by [Issue Implementer](https://github.com/microsasa/cli-tools/actions/runs/23686972615) · [◷](https://github.com/search?q=repo%3Amicrosasa%2Fcli-tools+%22gh-aw-workflow-id%3A+issue-implementer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Issue Implementer, engine: copilot, model: claude-opus-4.6, id: 23686972615, workflow_id: issue-implementer, run: https://github.com/microsasa/cli-tools/actions/runs/23686972615 -->

<!-- gh-aw-workflow-id: issue-implementer -->