### PR TITLE
test: add coverage for render_cost_view date-filter branch (#461)

### DIFF
--- a/tests/copilot_usage/test_report.py
+++ b/tests/copilot_usage/test_report.py
@@ -1864,6 +1864,32 @@ class TestRenderCostView:
         output = _capture_cost_view([])
         assert "No sessions found" in output
 
+    def test_all_sessions_filtered_by_since_shows_no_sessions_found(self) -> None:
+        """Non-empty session list, all fall before --since → 'No sessions found'."""
+        session = SessionSummary(
+            session_id="early-0000-aaaaaa",
+            name="Old Session",
+            start_time=datetime(2024, 1, 1, tzinfo=UTC),
+            is_active=False,
+            total_premium_requests=5,
+        )
+        output = _capture_cost_view([session], since=datetime(2026, 1, 1, tzinfo=UTC))
+        assert "No sessions found" in output
+        assert "Cost Breakdown" not in output
+
+    def test_all_sessions_filtered_by_until_shows_no_sessions_found(self) -> None:
+        """Non-empty session list, all fall after --until → 'No sessions found'."""
+        session = SessionSummary(
+            session_id="future-1111-bbbbbb",
+            name="Future Session",
+            start_time=datetime(2030, 6, 1, tzinfo=UTC),
+            is_active=False,
+            total_premium_requests=3,
+        )
+        output = _capture_cost_view([session], until=datetime(2025, 1, 1, tzinfo=UTC))
+        assert "No sessions found" in output
+        assert "Cost Breakdown" not in output
+
     def test_completed_session_cost(self) -> None:
         session = SessionSummary(
             session_id="cost-1111-abcdef",


### PR DESCRIPTION
Closes #461

## What

Adds two missing tests to `TestRenderCostView` that cover the code path where `render_cost_view` receives a non-empty session list but all sessions are filtered out by `--since` or `--until` date parameters.

## Tests added

| Test | Scenario |
|------|----------|
| `test_all_sessions_filtered_by_since_shows_no_sessions_found` | Session with `start_time=2024-01-01` filtered by `since=2026-01-01` |
| `test_all_sessions_filtered_by_until_shows_no_sessions_found` | Session with `start_time=2030-06-01` filtered by `until=2025-01-01` |

Both tests assert:
- `"No sessions found"` appears in output
- `"Cost Breakdown"` does **not** appear (no table rendered)

## Regression coverage

If `if not filtered:` is ever changed to `if not sessions:`, these tests will catch it immediately while `test_no_sessions` would still pass.

## CI

All 796 tests pass, 99.47% coverage, ruff/pyright clean.




> [!WARNING]
> <details>
> <summary>⚠️ Firewall blocked 1 domain</summary>
>
> The following domain was blocked by the firewall during workflow execution:
>
> - `astral.sh`
>
> To allow these domains, add them to the `network.allowed` list in your workflow frontmatter:
>
> ```yaml
> network:
>   allowed:
>     - defaults
>     - "astral.sh"
> ```
>
> See [Network Configuration](https://github.github.com/gh-aw/reference/network/) for more information.
>
> </details>


> [!NOTE]
> <details>
> <summary>🔒 Integrity filtering filtered 1 item</summary>
>
> Integrity filtering activated and filtered the following item during workflow execution.
> This happens when a tool call accesses a resource that does not meet the required integrity or secrecy level of the workflow.
>
> - issue:microsasa/cli-tools#461 (`issue_read`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".)
>
> </details>


> Generated by [Issue Implementer](https://github.com/microsasa/cli-tools/actions/runs/23687221224) · [◷](https://github.com/search?q=repo%3Amicrosasa%2Fcli-tools+%22gh-aw-workflow-id%3A+issue-implementer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Issue Implementer, engine: copilot, model: claude-opus-4.6, id: 23687221224, workflow_id: issue-implementer, run: https://github.com/microsasa/cli-tools/actions/runs/23687221224 -->

<!-- gh-aw-workflow-id: issue-implementer -->