### PR TITLE
test: add missing branch coverage for `_render_code_changes` guard (#462)

### DIFF
--- a/tests/copilot_usage/test_report.py
+++ b/tests/copilot_usage/test_report.py
@@ -1377,6 +1377,38 @@ class TestReportCoverageGaps:
         # Ensure the files-modified metric specifically shows a count of 2.
         assert re.search(r"Files?\s+modified[^\n]*\b2\b", output)
 
+    def test_code_changes_additions_only_renders(self) -> None:
+        """linesAdded>0, linesRemoved=0, no files → Code Changes section IS shown."""
+        from copilot_usage.report import render_session_detail
+
+        summary = SessionSummary(
+            session_id="add-only",
+            code_changes=CodeChanges(
+                filesModified=[],
+                linesAdded=5,
+                linesRemoved=0,
+            ),
+        )
+        output = _capture_console(render_session_detail, [], summary)
+        assert "Code Changes" in output
+        assert "+5" in output
+
+    def test_code_changes_removals_only_renders(self) -> None:
+        """linesRemoved>0, linesAdded=0, no files → Code Changes section IS shown."""
+        from copilot_usage.report import render_session_detail
+
+        summary = SessionSummary(
+            session_id="rem-only",
+            code_changes=CodeChanges(
+                filesModified=[],
+                linesAdded=0,
+                linesRemoved=7,
+            ),
+        )
+        output = _capture_console(render_session_detail, [], summary)
+        assert "Code Changes" in output
+        assert "-7" in output
+
     def test_summary_header_shows_date_range(self) -> None:
         """_render_summary_header date range: earliest date → latest date."""
         s1 = _make_summary_session(


### PR DESCRIPTION
Closes #462

## What

Adds two missing test cases to `TestReportCoverageGaps` in `tests/copilot_usage/test_report.py` that exercise the previously untested branches of the three-term early-return guard in `_render_code_changes`.

## Tests added

| Test | Input | Assertion |
|------|-------|-----------|
| `test_code_changes_additions_only_renders` | `linesAdded=5, linesRemoved=0, filesModified=[]` | "Code Changes" rendered, "+5" present |
| `test_code_changes_removals_only_renders` | `linesAdded=0, linesRemoved=7, filesModified=[]` | "Code Changes" rendered, "-7" present |

These complement the existing tests:
- `test_renders_code_changes` — all fields truthy
- `test_code_changes_all_zeros` — all fields falsy (early return)
- `test_code_changes_files_only_no_line_counts` — only `filesModified` truthy

Together they ensure every branch of the `not filesModified and not linesAdded and not linesRemoved` guard is exercised.

## CI

- `ruff check` ✅
- `ruff format` ✅
- `pyright` ✅ (0 errors)
- `pytest --cov --cov-fail-under=80` ✅ (797 passed, 99.47% coverage)




> [!WARNING]
> <details>
> <summary>⚠️ Firewall blocked 1 domain</summary>
>
> The following domain was blocked by the firewall during workflow execution:
>
> - `astral.sh`
>
> To allow these domains, add them to the `network.allowed` list in your workflow frontmatter:
>
> ```yaml
> network:
>   allowed:
>     - defaults
>     - "astral.sh"
> ```
>
> See [Network Configuration](https://github.github.com/gh-aw/reference/network/) for more information.
>
> </details>


> [!NOTE]
> <details>
> <summary>🔒 Integrity filtering filtered 1 item</summary>
>
> Integrity filtering activated and filtered the following item during workflow execution.
> This happens when a tool call accesses a resource that does not meet the required integrity or secrecy level of the workflow.
>
> - issue:microsasa/cli-tools#462 (`issue_read`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".)
>
> </details>


> Generated by [Issue Implementer](https://github.com/microsasa/cli-tools/actions/runs/23687439394) · [◷](https://github.com/search?q=repo%3Amicrosasa%2Fcli-tools+%22gh-aw-workflow-id%3A+issue-implementer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Issue Implementer, engine: copilot, model: claude-opus-4.6, id: 23687439394, workflow_id: issue-implementer, run: https://github.com/microsasa/cli-tools/actions/runs/23687439394 -->

<!-- gh-aw-workflow-id: issue-implementer -->