### PR TITLE
fix: agents read copilot-instructions.md + add prioritization

### DIFF
--- a/.github/workflows/ci-fixer.md
+++ b/.github/workflows/ci-fixer.md
@@ -50,7 +50,7 @@ Fix CI failures on pull request #${{ github.event.inputs.pr_number }}.
 
 ## Instructions
 
-Read and follow the coding standards in `.github/CODING_GUIDELINES.md` for all code changes.
+Read `.github/copilot-instructions.md` and follow all referenced guidelines for code changes.
 
 1. First, check if PR #${{ github.event.inputs.pr_number }} has the label `aw-ci-fix-attempted`. If it does, add a comment saying "CI fix already attempted once — stopping to prevent loops. Manual intervention needed." and stop. Do NOT attempt another fix.
 

--- a/.github/workflows/code-health.md
+++ b/.github/workflows/code-health.md
@@ -32,10 +32,10 @@ Analyze the entire codebase for cleanup opportunities and open issues for anythi
 
 ## Instructions
 
-Read `.github/CODING_GUIDELINES.md`. Flag any violations of those standards in existing code as cleanup opportunities.
+Read `.github/copilot-instructions.md` and all referenced guidelines. Flag any violations of those standards in existing code as cleanup opportunities.
 
 Read all files in the repository. Read all open issues in the repository. Identify genuine cleanup opportunities — refactoring, dead code, inconsistencies, stale docs, dependency hygiene, or anything else that would make the codebase meaningfully better.
 
 For each finding, open an issue with root cause analysis and a clear spec for resolving it. Each issue must include a testing requirement — regression tests for bugs, coverage for new functionality. Prefix each issue title with `[aw][code health]` and label each issue with `aw` and `code-health`.
 
-Do not open issues for things already caught by CI (ruff, pyright, bandit). Do not open issues for things that already have an open issue. Do not open an issue that is just a nit — if there are many small nits that together form a meaningful cleanup, bundle them into one issue. Do not open issues for performance problems (those belong to perf-analysis). If nothing worth fixing is found, do not create any issues.
+Do not open issues for things already caught by CI (ruff, pyright, bandit). Do not open issues for things that already have an open issue. Do not open an issue that is just a nit — if there are many small nits that together form a meaningful cleanup, bundle them into one issue. Do not open issues for performance problems (those belong to perf-analysis). If you find more issues than you can open, prioritize by severity: prefer bugs and correctness issues over cosmetic cleanup. If nothing worth fixing is found, do not create any issues.

--- a/.github/workflows/issue-implementer.md
+++ b/.github/workflows/issue-implementer.md
@@ -45,7 +45,7 @@ Read the issue specified by the input, understand the problem, implement the sol
 
 ## Instructions
 
-Read and follow the coding standards in `.github/CODING_GUIDELINES.md` for all code you write.
+Read `.github/copilot-instructions.md` and follow all referenced guidelines for code you write.
 
 Read all files in the repository. Read issue #${{ github.event.inputs.issue_number }} to understand what needs to be fixed. Implement the fix following the spec in the issue, including any testing requirements.
 

--- a/.github/workflows/perf-analysis.md
+++ b/.github/workflows/perf-analysis.md
@@ -32,7 +32,7 @@ Analyze the codebase for performance problems and open issues for anything worth
 
 ## Instructions
 
-Read `.github/CODING_GUIDELINES.md` for context on the project's coding standards.
+Read `.github/copilot-instructions.md` and all referenced guidelines for context on the project's coding standards.
 
 Read all files in the repository. Read all open issues in the repository. Focus exclusively on performance — do not report code style, refactoring, or documentation issues (those belong to code-health).
 
@@ -40,4 +40,4 @@ Look for performance problems such as algorithmic inefficiency (O(n²) loops, re
 
 For each finding, open an issue with: the specific file and function, what makes it slow, a concrete fix with expected improvement, and a testing requirement (benchmark or assertion that the optimized path is exercised). Prefix each issue title with `[aw][perf]` and label each issue with `aw` and `perf`.
 
-Do not open issues for micro-optimizations that save nanoseconds. Do not open issues for things already caught by CI (ruff PERF rules). Do not open issues for things that already have an open issue. If nothing worth optimizing is found, do not create any issues.
+Do not open issues for micro-optimizations that save nanoseconds. Do not open issues for things already caught by CI (ruff PERF rules). Do not open issues for things that already have an open issue. If you find more issues than you can open, prioritize by impact: prefer findings in hot paths, high-frequency call sites, or code that scales with input size. If nothing worth optimizing is found, do not create any issues.

--- a/.github/workflows/quality-gate.md
+++ b/.github/workflows/quality-gate.md
@@ -50,7 +50,7 @@ Evaluate pull request #${{ inputs.pr_number }} for autonomous merge eligibility.
 
 ## Instructions
 
-Read `.github/CODING_GUIDELINES.md` and verify that the PR's code changes comply with those standards.
+Read `.github/copilot-instructions.md` and all referenced guidelines. Verify that the PR's code changes comply with those standards.
 
 This workflow is dispatched by the pipeline orchestrator when a PR has CI green and all review threads resolved.
 

--- a/.github/workflows/review-responder.md
+++ b/.github/workflows/review-responder.md
@@ -54,7 +54,7 @@ Address review comments on pull request #${{ inputs.pr_number }}.
 
 ## Instructions
 
-Read and follow the coding standards in `.github/CODING_GUIDELINES.md` for all code changes.
+Read `.github/copilot-instructions.md` and follow all referenced guidelines for code changes.
 
 This workflow addresses unresolved review comments on a pull request.
 

--- a/.github/workflows/test-analysis.md
+++ b/.github/workflows/test-analysis.md
@@ -32,10 +32,10 @@ Analyze the test suite for coverage gaps and suggest new tests.
 
 ## Instructions
 
-Read `.github/CODING_GUIDELINES.md` for context on the project's coding standards.
+Read `.github/copilot-instructions.md` and all referenced guidelines for context on the project's coding standards.
 
 Read all files in the repository. Read all open issues in the repository. Identify meaningful test gaps across unit tests, e2e tests, and integration tests — untested code paths, missing scenarios, weak assertions, or anything else that would improve confidence in the code.
 
 For each area with gaps, open an issue with root cause analysis, repro steps where applicable, and a clear spec for what tests to add. Each issue must specify the expected behavior to assert and any regression scenarios to cover. Prefix each issue title with `[aw][test audit]` and label each issue with `aw` and `test-audit`.
 
-Do not suggest trivial tests or tests that duplicate existing coverage. Do not open issues for things that already have an open issue. Do not open an issue that is just a nit — if there are many small gaps that together form a meaningful improvement, bundle them into one issue. If the test suite is already comprehensive, do not create any issues.
+Do not suggest trivial tests or tests that duplicate existing coverage. Do not open issues for things that already have an open issue. Do not open an issue that is just a nit — if there are many small gaps that together form a meaningful improvement, bundle them into one issue. If you find more issues than you can open, prioritize by risk: prefer coverage gaps in core business logic over edge-case branches. If the test suite is already comprehensive, do not create any issues.


### PR DESCRIPTION
## Summary

Two fixes:

### #486 — Agents bypass copilot-instructions.md
All 7 agent workflows were hardcoding `.github/CODING_GUIDELINES.md` directly instead of reading `.github/copilot-instructions.md` (the central hub). Now they all read the instructions file, which points them to guidelines and any future instruction files. Adding a new instruction doc only requires updating `copilot-instructions.md` once.

### #487 — No prioritization when findings exceed the 2-issue cap
The 3 scheduled analysis workflows (code-health, test-analysis, perf-analysis) had no guidance on which findings to prioritize when they find more than 2 issues. Now each has a prioritization instruction:
- **code-health**: prefer bugs and correctness over cosmetic cleanup
- **test-analysis**: prefer coverage gaps in core business logic over edge cases
- **perf-analysis**: prefer hot paths and code that scales with input size

Body-only changes — no recompilation needed (verified).

Closes #486
Closes #487