### PR TITLE
perf: cache `lookup_model_pricing` with `lru_cache` (#493)

### DIFF
--- a/src/copilot_usage/pricing.py
+++ b/src/copilot_usage/pricing.py
@@ -11,6 +11,7 @@ AI model used.  This module provides:
 
 import warnings
 from enum import StrEnum
+from functools import lru_cache
 from typing import Final
 
 from pydantic import BaseModel
@@ -136,6 +137,12 @@ def lookup_model_pricing(model_name: str) -> ModelPricing:
             model_name=normalized, multiplier=1.0, tier=PricingTier.STANDARD
         )
 
+    return _cached_lookup(normalized)
+
+
+@lru_cache(maxsize=256)
+def _cached_lookup(normalized: str) -> ModelPricing:
+    """Cached inner lookup — called after normalization and empty-name guard."""
     # 1. Exact
     if normalized in KNOWN_PRICING:
         return KNOWN_PRICING[normalized]
@@ -159,9 +166,9 @@ def lookup_model_pricing(model_name: str) -> ModelPricing:
 
     # 3. Unknown
     warnings.warn(
-        f"Unknown model '{model_name}'; assuming 1× standard pricing.",
+        f"Unknown model '{normalized}'; assuming 1× standard pricing.",
         UserWarning,
-        stacklevel=2,
+        stacklevel=3,
     )
     return ModelPricing(
         model_name=normalized, multiplier=1.0, tier=PricingTier.STANDARD

--- a/tests/copilot_usage/test_pricing.py
+++ b/tests/copilot_usage/test_pricing.py
@@ -3,16 +3,26 @@
 # pyright: reportPrivateUsage=false
 
 import warnings
+from functools import lru_cache
 
 import pytest
 
+from copilot_usage import pricing
 from copilot_usage.pricing import (
     KNOWN_PRICING,
     ModelPricing,
     PricingTier,
+    _cached_lookup,
     _tier_from_multiplier,
     lookup_model_pricing,
 )
+
+
+@pytest.fixture(autouse=True)
+def _clear_pricing_cache() -> None:
+    """Reset the LRU cache between tests to prevent cross-test leakage."""
+    _cached_lookup.cache_clear()
+
 
 # ---------------------------------------------------------------------------
 # ModelPricing basics
@@ -181,6 +191,7 @@ class TestPartialMatchTieBreaking:
             ),
         }
         monkeypatch.setattr("copilot_usage.pricing.KNOWN_PRICING", local_pricing)
+        _cached_lookup.cache_clear()
 
         p = lookup_model_pricing("gpt-5.1-cod")
         expected = local_pricing["gpt-5.1-codex"]
@@ -210,6 +221,7 @@ class TestPartialMatchTieBreaking:
             ),
         }
         monkeypatch.setattr("copilot_usage.pricing.KNOWN_PRICING", local_pricing)
+        _cached_lookup.cache_clear()
 
         p = lookup_model_pricing("gpt-5")
         expected = local_pricing["gpt-5-mini"]
@@ -357,3 +369,35 @@ class TestLookupModelPricingCaseNormalization:
         assert len(caught) == 0
         assert p.multiplier == 6.0
         assert p.tier == PricingTier.PREMIUM
+
+
+# ---------------------------------------------------------------------------
+# Caching behaviour (issue #493)
+# ---------------------------------------------------------------------------
+
+
+class TestLookupModelPricingCached:
+    """Verify that repeated lookups hit the LRU cache instead of rescanning."""
+
+    def test_lookup_model_pricing_cached(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        call_count = 0
+        original = pricing._cached_lookup.__wrapped__
+
+        def counting_lookup(normalized: str) -> ModelPricing:
+            nonlocal call_count
+            call_count += 1
+            return original(normalized)
+
+        monkeypatch.setattr(
+            pricing,
+            "_cached_lookup",
+            lru_cache(maxsize=256)(counting_lookup),
+        )
+        pricing._cached_lookup.cache_clear()
+
+        for _ in range(50):
+            pricing.lookup_model_pricing("claude-sonnet-4.6")
+
+        assert call_count == 1, (
+            "Should only scan KNOWN_PRICING once for a repeated model name"
+        )


### PR DESCRIPTION
Closes #493

## Changes

**`src/copilot_usage/pricing.py`**
- Split `lookup_model_pricing` into a public wrapper and a private `_cached_lookup` function decorated with `@lru_cache(maxsize=256)`.
- The public wrapper handles the empty-name guard (which must not be cached since it emits a warning every time), then delegates to the cached inner function.
- Unknown-model warnings use `stacklevel=3` to compensate for the extra call frame.

**`tests/copilot_usage/test_pricing.py`**
- Added `_clear_pricing_cache` autouse fixture to reset the LRU cache between tests, preventing cross-test cache leakage.
- Added `_cached_lookup.cache_clear()` calls in monkeypatch tests that replace `KNOWN_PRICING`.
- Added `TestLookupModelPricingCached` with a call-count assertion verifying that 50 repeated lookups for the same model only scan `KNOWN_PRICING` once.

## Performance improvement

With a typical session list of 50 sessions sharing 2–4 distinct model names, this reduces ~50 O(k) scans to ~4. In interactive mode with frequent auto-refreshes the savings multiply further.

## Verification

- `ruff check` — all checks passed
- `ruff format` — clean
- `pyright` — 0 errors
- `pytest --cov --cov-fail-under=80` — 826 passed, coverage 99.60%




> [!WARNING]
> <details>
> <summary>⚠️ Firewall blocked 1 domain</summary>
>
> The following domain was blocked by the firewall during workflow execution:
>
> - `astral.sh`
>
> To allow these domains, add them to the `network.allowed` list in your workflow frontmatter:
>
> ```yaml
> network:
>   allowed:
>     - defaults
>     - "astral.sh"
> ```
>
> See [Network Configuration](https://github.github.com/gh-aw/reference/network/) for more information.
>
> </details>


> [!NOTE]
> <details>
> <summary>🔒 Integrity filtering filtered 11 items</summary>
>
> Integrity filtering activated and filtered the following items during workflow execution.
> This happens when a tool call accesses a resource that does not meet the required integrity or secrecy level of the workflow.
>
> - issue:microsasa/cli-tools#493 (`issue_read`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".)
> - issue:microsasa/cli-tools#493 (`list_issues`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".)
> - issue:microsasa/cli-tools#491 (`list_issues`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".)
> - issue:microsasa/cli-tools#490 (`list_issues`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".)
> - issue:microsasa/cli-tools#468 (`list_issues`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".)
> - issue:microsasa/cli-tools#467 (`list_issues`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".)
> - issue:microsasa/cli-tools#437 (`list_issues`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".)
> - issue:microsasa/cli-tools#221 (`list_issues`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".)
> - issue:microsasa/cli-tools#220 (`list_issues`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".)
> - issue:microsasa/cli-tools#173 (`list_issues`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".)
> - issue:microsasa/cli-tools#165 (`list_issues`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".)
>
> </details>


> Generated by [Issue Implementer](https://github.com/microsasa/cli-tools/actions/runs/23705744355) · [◷](https://github.com/search?q=repo%3Amicrosasa%2Fcli-tools+%22gh-aw-workflow-id%3A+issue-implementer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Issue Implementer, engine: copilot, model: claude-opus-4.6, id: 23705744355, workflow_id: issue-implementer, run: https://github.com/microsasa/cli-tools/actions/runs/23705744355 -->

<!-- gh-aw-workflow-id: issue-implementer -->