### PR TITLE
fix: add Final annotations, slots=True, and unquote loguru.Record (#497)

### DIFF
--- a/src/copilot_usage/cli.py
+++ b/src/copilot_usage/cli.py
@@ -10,7 +10,7 @@ import threading
 import time
 from datetime import datetime, time as dt_time
 from pathlib import Path
-from typing import Literal, Protocol, cast
+from typing import Final, Literal, Protocol, cast
 
 import click
 from loguru import logger
@@ -39,15 +39,17 @@ from copilot_usage.report import (
 
 type _View = Literal["home", "detail", "cost"]
 
-_DATE_FORMATS = ["%Y-%m-%d", "%Y-%m-%dT%H:%M:%S"]
+_DATE_FORMATS: Final[list[str]] = ["%Y-%m-%d", "%Y-%m-%dT%H:%M:%S"]
 
-_WATCHDOG_DEBOUNCE_SECS: float = 2.0  # Prevents rapid redraws during tool-use bursts
+_WATCHDOG_DEBOUNCE_SECS: Final[float] = (
+    2.0  # Prevents rapid redraws during tool-use bursts
+)
 
-_UUID_STR_LEN = 36
-_UUID_DASH_COUNT = 4
-_MIN_PREFIX_LEN_FOR_PREFILTER = 4
+_UUID_STR_LEN: Final[int] = 36
+_UUID_DASH_COUNT: Final[int] = 4
+_MIN_PREFIX_LEN_FOR_PREFILTER: Final[int] = 4
 
-console = Console()
+console: Final[Console] = Console()
 
 
 def _normalize_until(dt: datetime | None) -> datetime | None:
@@ -103,8 +105,10 @@ def _print_version_header(target: Console | None = None) -> None:
 # Interactive mode helpers
 # ---------------------------------------------------------------------------
 
-_HOME_PROMPT = "\nEnter session # for detail, [c] cost, [r] refresh, [q] quit: "
-_BACK_PROMPT = "\nPress Enter to go back... "
+_HOME_PROMPT: Final[str] = (
+    "\nEnter session # for detail, [c] cost, [r] refresh, [q] quit: "
+)
+_BACK_PROMPT: Final[str] = "\nPress Enter to go back... "
 
 
 def _render_session_list(console: Console, sessions: list[SessionSummary]) -> None:

--- a/src/copilot_usage/logging_config.py
+++ b/src/copilot_usage/logging_config.py
@@ -1,11 +1,14 @@
 """Logging configuration — console-only for CLI tool."""
 
+from __future__ import annotations
+
 import sys
+from typing import Final
 
 import loguru
 from loguru import logger
 
-LEVEL_EMOJI: dict[str, str] = {
+LEVEL_EMOJI: Final[dict[str, str]] = {
     "TRACE": "🔍",
     "DEBUG": "🐛",
     "INFO": "ℹ️ ",
@@ -15,7 +18,7 @@ LEVEL_EMOJI: dict[str, str] = {
     "CRITICAL": "🔥",
 }
 
-CONSOLE_FORMAT = (
+CONSOLE_FORMAT: Final[str] = (
     "<dim>{time:HH:mm:ss}</dim> "
     "{extra[emoji]} "
     "<level>{level:<7}</level> "
@@ -23,7 +26,7 @@ CONSOLE_FORMAT = (
 )
 
 
-def _emoji_patcher(record: "loguru.Record") -> None:
+def _emoji_patcher(record: loguru.Record) -> None:
     """Inject a level-specific emoji into the log record's extras."""
     record["extra"]["emoji"] = LEVEL_EMOJI.get(record["level"].name, "  ")
 

--- a/src/copilot_usage/models.py
+++ b/src/copilot_usage/models.py
@@ -8,6 +8,7 @@ flexible fallback for unknown ones.
 from datetime import UTC, datetime
 from enum import StrEnum
 from pathlib import Path
+from typing import Final
 
 from pydantic import BaseModel, Field, model_validator
 
@@ -21,7 +22,7 @@ _type = type
 # ---------------------------------------------------------------------------
 
 # Aware datetime sentinel used as a sort-key fallback for sessions without a start_time.
-EPOCH: datetime = datetime.min.replace(tzinfo=UTC)
+EPOCH: Final[datetime] = datetime.min.replace(tzinfo=UTC)
 
 
 def ensure_aware(dt: datetime) -> datetime:

--- a/src/copilot_usage/report.py
+++ b/src/copilot_usage/report.py
@@ -62,7 +62,7 @@ def _format_elapsed_since(start: datetime) -> str:
     return format_timedelta(delta)
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class _EffectiveStats:
     """Active-period stats when available, otherwise session totals."""
 
@@ -86,7 +86,7 @@ def _effective_stats(session: SessionSummary) -> _EffectiveStats:
     )
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class _SessionTotals:
     """Aggregated totals across a list of sessions."""
 


### PR DESCRIPTION
Closes #497

## Changes

Addresses coding guideline violations across four source files:

### Missing `Final` on module-level constants
- **`models.py`**: `EPOCH` → `Final[datetime]`
- **`logging_config.py`**: `LEVEL_EMOJI` → `Final[dict[str, str]]`, `CONSOLE_FORMAT` → `Final[str]`
- **`cli.py`**: `_DATE_FORMATS` → `Final[list[str]]`, `_WATCHDOG_DEBOUNCE_SECS` → `Final[float]`, `_UUID_STR_LEN`/`_UUID_DASH_COUNT`/`_MIN_PREFIX_LEN_FOR_PREFILTER` → `Final[int]`, `console` → `Final[Console]`, `_HOME_PROMPT`/`_BACK_PROMPT` → `Final[str]`

### Frozen dataclasses missing `slots=True`
- **`report.py`**: Added `slots=True` to `_EffectiveStats` and `_SessionTotals`

### Unnecessary string annotation
- **`logging_config.py`**: Changed `"loguru.Record"` → `loguru.Record`, enabled by adding `from __future__ import annotations` (since `Record` is only defined in loguru's type stubs, not exposed at runtime)

## Verification
- All 827 tests pass
- pyright strict: 0 errors
- ruff check/format: clean
- Coverage: 99.60% (≥80% threshold)




> [!WARNING]
> <details>
> <summary>⚠️ Firewall blocked 1 domain</summary>
>
> The following domain was blocked by the firewall during workflow execution:
>
> - `astral.sh`
>
> To allow these domains, add them to the `network.allowed` list in your workflow frontmatter:
>
> ```yaml
> network:
>   allowed:
>     - defaults
>     - "astral.sh"
> ```
>
> See [Network Configuration](https://github.github.com/gh-aw/reference/network/) for more information.
>
> </details>


> [!NOTE]
> <details>
> <summary>🔒 Integrity filtering filtered 1 item</summary>
>
> Integrity filtering activated and filtered the following item during workflow execution.
> This happens when a tool call accesses a resource that does not meet the required integrity or secrecy level of the workflow.
>
> - issue:microsasa/cli-tools#497 (`issue_read`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".)
>
> </details>


> Generated by [Issue Implementer](https://github.com/microsasa/cli-tools/actions/runs/23710945098) · [◷](https://github.com/search?q=repo%3Amicrosasa%2Fcli-tools+%22gh-aw-workflow-id%3A+issue-implementer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Issue Implementer, engine: copilot, model: claude-opus-4.6, id: 23710945098, workflow_id: issue-implementer, run: https://github.com/microsasa/cli-tools/actions/runs/23710945098 -->

<!-- gh-aw-workflow-id: issue-implementer -->