### PR TITLE
perf: extract tool_model in _first_pass to eliminate redundant scan (#498)

### DIFF
--- a/src/copilot_usage/parser.py
+++ b/src/copilot_usage/parser.py
@@ -202,6 +202,7 @@ class _FirstPassResult:
     user_message_count: int
     total_output_tokens: int
     total_turn_starts: int
+    tool_model: str | None
 
 
 @dataclasses.dataclass(frozen=True, slots=True)
@@ -232,6 +233,7 @@ def _first_pass(events: list[SessionEvent]) -> _FirstPassResult:
     user_message_count = 0
     total_output_tokens = 0
     total_turn_starts = 0
+    tool_model: str | None = None
 
     for idx, ev in enumerate(events):
         if ev.type == EventType.SESSION_START:
@@ -279,6 +281,19 @@ def _first_pass(events: list[SessionEvent]) -> _FirstPassResult:
             if (tokens := _safe_int_tokens(ev.data.get("outputTokens"))) is not None:
                 total_output_tokens += tokens
 
+        elif ev.type == EventType.TOOL_EXECUTION_COMPLETE and tool_model is None:
+            try:
+                parsed = ev.as_tool_execution()
+                if parsed.model:
+                    tool_model = parsed.model
+            except ValidationError as exc:
+                logger.debug(
+                    "event {} — could not parse {} event ({}), skipping",
+                    idx,
+                    ev.type,
+                    exc.error_count(),
+                )
+
     return _FirstPassResult(
         session_id=session_id,
         start_time=start_time,
@@ -289,6 +304,7 @@ def _first_pass(events: list[SessionEvent]) -> _FirstPassResult:
         user_message_count=user_message_count,
         total_output_tokens=total_output_tokens,
         total_turn_starts=total_turn_starts,
+        tool_model=tool_model,
     )
 
 
@@ -380,28 +396,10 @@ def _build_completed_summary(
 def _build_active_summary(
     fp: _FirstPassResult,
     name: str | None,
-    events: list[SessionEvent],
     config_path: Path | None,
 ) -> SessionSummary:
     """Build a :class:`SessionSummary` for a session with no shutdown data."""
-    model = fp.model
-
-    # Try to determine model from tool.execution_complete events
-    for idx, ev in enumerate(events):
-        if ev.type == EventType.TOOL_EXECUTION_COMPLETE:
-            try:
-                parsed = ev.as_tool_execution()
-            except ValidationError as exc:
-                logger.debug(
-                    "event {} — could not parse {} event ({}), skipping",
-                    idx,
-                    ev.type,
-                    exc.error_count(),
-                )
-                continue
-            if parsed.model:
-                model = parsed.model
-                break
+    model = fp.model or fp.tool_model
 
     # Fall back to ~/.copilot/config.json for active sessions
     if model is None:
@@ -477,7 +475,7 @@ def build_session_summary(
         resume = _detect_resume(events, fp.all_shutdowns)
         return _build_completed_summary(fp, name, resume)
 
-    return _build_active_summary(fp, name, events, config_path)
+    return _build_active_summary(fp, name, config_path)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/copilot_usage/test_parser.py
+++ b/tests/copilot_usage/test_parser.py
@@ -3979,5 +3979,153 @@ class TestBuildActiveSummaryConfigFallback:
         _write_events(p, _START_EVENT, _USER_MSG, _ASSISTANT_MSG)
         events = parse_events(p)
         fp = _first_pass(events)
-        result = _build_active_summary(fp, name=None, events=events, config_path=config)
+        result = _build_active_summary(fp, name=None, config_path=config)
         assert result.model == "gpt-4o"
+
+
+# ---------------------------------------------------------------------------
+# Issue #498 — _first_pass captures tool_model, eliminating second pass
+# ---------------------------------------------------------------------------
+
+
+class TestFirstPassToolModel:
+    """Verify _first_pass populates tool_model from tool.execution_complete events."""
+
+    def test_tool_model_captured_in_first_pass(self, tmp_path: Path) -> None:
+        """tool_model is set from the first tool.execution_complete with a model."""
+        turn_start = json.dumps(
+            {
+                "type": "assistant.turn_start",
+                "data": {"turnId": "t1"},
+                "id": "ev-ts1",
+                "timestamp": "2026-03-07T10:00:30.000Z",
+            }
+        )
+        assistant = json.dumps(
+            {
+                "type": "assistant.message",
+                "data": {"messageId": "m1", "content": "hi", "outputTokens": 100},
+                "id": "ev-a1",
+                "timestamp": "2026-03-07T10:01:00.000Z",
+            }
+        )
+        tool = json.dumps(
+            {
+                "type": "tool.execution_complete",
+                "data": {
+                    "toolCallId": "tc-1",
+                    "model": "claude-sonnet-4",
+                    "success": True,
+                },
+                "id": "ev-t1",
+                "timestamp": "2026-03-07T10:02:00.000Z",
+            }
+        )
+        p = tmp_path / "s" / "events.jsonl"
+        _write_events(p, _START_EVENT, _USER_MSG, turn_start, assistant, tool)
+        events = parse_events(p)
+        fp = _first_pass(events)
+        assert fp.tool_model == "claude-sonnet-4"
+
+    def test_tool_model_none_when_no_tool_events(self, tmp_path: Path) -> None:
+        """tool_model is None when no tool.execution_complete events exist."""
+        p = tmp_path / "s" / "events.jsonl"
+        _write_events(p, _START_EVENT, _USER_MSG, _ASSISTANT_MSG)
+        events = parse_events(p)
+        fp = _first_pass(events)
+        assert fp.tool_model is None
+
+    def test_tool_model_skips_none_model(self, tmp_path: Path) -> None:
+        """tool.execution_complete with model=None is skipped; next one wins."""
+        tool_no_model = json.dumps(
+            {
+                "type": "tool.execution_complete",
+                "data": {"toolCallId": "tc-1", "model": None, "success": True},
+                "id": "ev-t1",
+                "timestamp": "2026-03-07T10:01:00.000Z",
+            }
+        )
+        tool_with_model = json.dumps(
+            {
+                "type": "tool.execution_complete",
+                "data": {"toolCallId": "tc-2", "model": "gpt-5.1", "success": True},
+                "id": "ev-t2",
+                "timestamp": "2026-03-07T10:02:00.000Z",
+            }
+        )
+        p = tmp_path / "s" / "events.jsonl"
+        _write_events(p, _START_EVENT, _USER_MSG, tool_no_model, tool_with_model)
+        events = parse_events(p)
+        fp = _first_pass(events)
+        assert fp.tool_model == "gpt-5.1"
+
+    def test_active_session_resolves_model_via_first_pass(self, tmp_path: Path) -> None:
+        """Active session (no shutdown) resolves model from _first_pass.tool_model."""
+        turn_start = json.dumps(
+            {
+                "type": "assistant.turn_start",
+                "data": {"turnId": "t1"},
+                "id": "ev-ts1",
+                "timestamp": "2026-03-07T10:00:30.000Z",
+            }
+        )
+        assistant = json.dumps(
+            {
+                "type": "assistant.message",
+                "data": {"messageId": "m1", "content": "hi", "outputTokens": 200},
+                "id": "ev-a1",
+                "timestamp": "2026-03-07T10:01:00.000Z",
+            }
+        )
+        tool = json.dumps(
+            {
+                "type": "tool.execution_complete",
+                "data": {
+                    "toolCallId": "tc-1",
+                    "model": "claude-sonnet-4",
+                    "success": True,
+                },
+                "id": "ev-t1",
+                "timestamp": "2026-03-07T10:02:00.000Z",
+            }
+        )
+        p = tmp_path / "s" / "events.jsonl"
+        _write_events(p, _START_EVENT, _USER_MSG, turn_start, assistant, tool)
+        events = parse_events(p)
+
+        # Verify _first_pass captures tool_model
+        fp = _first_pass(events)
+        assert fp.tool_model == "claude-sonnet-4"
+
+        # Verify build_session_summary uses tool_model correctly
+        summary = build_session_summary(events, config_path=tmp_path / "no-config.json")
+        assert summary.model == "claude-sonnet-4"
+        assert summary.is_active is True
+
+    def test_malformed_tool_event_skipped(self, tmp_path: Path) -> None:
+        """A malformed tool.execution_complete is skipped; next valid one wins."""
+        bad_tool = json.dumps(
+            {
+                "type": "tool.execution_complete",
+                "data": {"toolCallId": "tc-1", "toolTelemetry": "invalid"},
+                "id": "ev-t1",
+                "timestamp": "2026-03-07T10:01:00.000Z",
+            }
+        )
+        good_tool = json.dumps(
+            {
+                "type": "tool.execution_complete",
+                "data": {
+                    "toolCallId": "tc-2",
+                    "model": "gpt-5.1",
+                    "success": True,
+                },
+                "id": "ev-t2",
+                "timestamp": "2026-03-07T10:02:00.000Z",
+            }
+        )
+        p = tmp_path / "s" / "events.jsonl"
+        _write_events(p, _START_EVENT, _USER_MSG, bad_tool, good_tool)
+        events = parse_events(p)
+        fp = _first_pass(events)
+        assert fp.tool_model == "gpt-5.1"


### PR DESCRIPTION
Closes #498

## Problem

`_build_active_summary` performed a **second full O(n_events) iteration** over the event list to locate a model name in `TOOL_EXECUTION_COMPLETE` events — data already visited by `_first_pass`. For tool-heavy active sessions (hundreds or thousands of events), this was a wasted scan, multiplied across all active sessions on every CLI invocation.

## Fix

- **Extended `_FirstPassResult`** with a `tool_model: str | None` field.
- **Updated `_first_pass`** to capture the first non-None model from `tool.execution_complete` events during its single pass (with the same `ValidationError` handling as the old code).
- **Simplified `_build_active_summary`** to read `fp.tool_model` directly (`model = fp.model or fp.tool_model`), removing the `events` parameter and the redundant loop entirely.

## Testing

Added `TestFirstPassToolModel` class with 5 tests:
1. `test_tool_model_captured_in_first_pass` — verifies `_FirstPassResult.tool_model` is populated
2. `test_tool_model_none_when_no_tool_events` — verifies `tool_model` is `None` when absent
3. `test_tool_model_skips_none_model` — verifies `None` models are skipped, next valid one wins
4. `test_active_session_resolves_model_via_first_pass` — end-to-end: `build_session_summary` resolves model correctly for active sessions
5. `test_malformed_tool_event_skipped` — malformed tool events are skipped gracefully

All 831 tests pass. Coverage: 99.60%.




> [!NOTE]
> <details>
> <summary>🔒 Integrity filtering filtered 11 items</summary>
>
> Integrity filtering activated and filtered the following items during workflow execution.
> This happens when a tool call accesses a resource that does not meet the required integrity or secrecy level of the workflow.
>
> - issue:microsasa/cli-tools#498 (`issue_read`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".)
> - issue:microsasa/cli-tools#502 (`list_issues`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".)
> - issue:microsasa/cli-tools#499 (`list_issues`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".)
> - issue:microsasa/cli-tools#498 (`list_issues`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".)
> - issue:microsasa/cli-tools#497 (`list_issues`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".)
> - issue:microsasa/cli-tools#491 (`list_issues`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".)
> - issue:microsasa/cli-tools#490 (`list_issues`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".)
> - issue:microsasa/cli-tools#468 (`list_issues`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".)
> - issue:microsasa/cli-tools#467 (`list_issues`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".)
> - issue:microsasa/cli-tools#437 (`list_issues`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".)
> - issue:microsasa/cli-tools#221 (`list_issues`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".)
>
> </details>


> Generated by [Issue Implementer](https://github.com/microsasa/cli-tools/actions/runs/23711068967) · [◷](https://github.com/search?q=repo%3Amicrosasa%2Fcli-tools+%22gh-aw-workflow-id%3A+issue-implementer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Issue Implementer, engine: copilot, model: claude-opus-4.6, id: 23711068967, workflow_id: issue-implementer, run: https://github.com/microsasa/cli-tools/actions/runs/23711068967 -->

<!-- gh-aw-workflow-id: issue-implementer -->