### PR TITLE
perf: replace O(n×m) _aggregate_model_metrics with O(m) in-place accumulation (#499)

### DIFF
--- a/src/copilot_usage/report.py
+++ b/src/copilot_usage/report.py
@@ -25,10 +25,11 @@ from copilot_usage._formatting import (
 )
 from copilot_usage.models import (
     ModelMetrics,
+    RequestMetrics,
     SessionSummary,
+    TokenUsage,
     ensure_aware,
     has_active_period_stats,
-    merge_model_metrics,
     session_sort_key,
     shutdown_output_tokens,
     total_output_tokens,
@@ -237,14 +238,41 @@ def _filter_sessions(
     return filtered
 
 
+def _copy_model_metrics(mm: ModelMetrics) -> ModelMetrics:
+    """Create an independent copy of *mm* via explicit construction."""
+    return ModelMetrics(
+        requests=RequestMetrics(count=mm.requests.count, cost=mm.requests.cost),
+        usage=TokenUsage(
+            inputTokens=mm.usage.inputTokens,
+            outputTokens=mm.usage.outputTokens,
+            cacheReadTokens=mm.usage.cacheReadTokens,
+            cacheWriteTokens=mm.usage.cacheWriteTokens,
+        ),
+    )
+
+
 def _aggregate_model_metrics(
     sessions: list[SessionSummary],
 ) -> dict[str, ModelMetrics]:
-    """Merge model metrics across all sessions into a single dict."""
-    merged: dict[str, ModelMetrics] = {}
+    """Merge model metrics across all sessions into a single dict.
+
+    Accumulates in-place so each unique model name is copied at most once,
+    reducing copy overhead from O(n × m) to O(m).
+    """
+    result: dict[str, ModelMetrics] = {}
     for s in sessions:
-        merged = merge_model_metrics(merged, s.model_metrics)
-    return merged
+        for model_name, mm in s.model_metrics.items():
+            if model_name in result:
+                existing = result[model_name]
+                existing.requests.count += mm.requests.count
+                existing.requests.cost += mm.requests.cost
+                existing.usage.inputTokens += mm.usage.inputTokens
+                existing.usage.outputTokens += mm.usage.outputTokens
+                existing.usage.cacheReadTokens += mm.usage.cacheReadTokens
+                existing.usage.cacheWriteTokens += mm.usage.cacheWriteTokens
+            else:
+                result[model_name] = _copy_model_metrics(mm)
+    return result
 
 
 def _render_summary_header(

--- a/tests/copilot_usage/test_report.py
+++ b/tests/copilot_usage/test_report.py
@@ -47,6 +47,7 @@ from copilot_usage.render_detail import (
 from copilot_usage.report import (
     _aggregate_model_metrics,
     _compute_session_totals,
+    _copy_model_metrics,
     _effective_stats,
     _EffectiveStats,
     _estimate_premium_cost,
@@ -2813,6 +2814,63 @@ class TestAggregateModelMetrics:
         merged = _aggregate_model_metrics([s1, s2])
         assert merged["model-a"].requests.count == 5
         assert merged["model-a"].usage.outputTokens == 100
+
+
+# ---------------------------------------------------------------------------
+# Issue #499 — _aggregate_model_metrics O(m) copy overhead
+# ---------------------------------------------------------------------------
+
+
+class TestAggregateModelMetricsPerformance:
+    """Verify in-place accumulation correctness and O(m) copy overhead."""
+
+    _MODEL_NAMES: list[str] = ["model-a", "model-b", "model-c"]
+
+    @staticmethod
+    def _make_session(sid: str, model_names: list[str]) -> SessionSummary:
+        """Build a session with one ModelMetrics entry per *model_names*."""
+        return SessionSummary(
+            session_id=sid,
+            model_metrics={
+                name: ModelMetrics(
+                    requests=RequestMetrics(count=2, cost=1),
+                    usage=TokenUsage(
+                        inputTokens=100,
+                        outputTokens=50,
+                        cacheReadTokens=10,
+                        cacheWriteTokens=5,
+                    ),
+                )
+                for name in model_names
+            },
+        )
+
+    def test_many_sessions_correct_totals(self) -> None:
+        """50+ sessions × 3 models must sum correctly."""
+        n = 50
+        sessions = [self._make_session(f"s{i}", self._MODEL_NAMES) for i in range(n)]
+        merged = _aggregate_model_metrics(sessions)
+
+        assert set(merged.keys()) == set(self._MODEL_NAMES)
+        for name in self._MODEL_NAMES:
+            m = merged[name]
+            assert m.requests.count == 2 * n
+            assert m.requests.cost == 1 * n
+            assert m.usage.inputTokens == 100 * n
+            assert m.usage.outputTokens == 50 * n
+            assert m.usage.cacheReadTokens == 10 * n
+            assert m.usage.cacheWriteTokens == 5 * n
+
+    def test_copy_called_once_per_unique_model(self) -> None:
+        """_copy_model_metrics should be called exactly len(unique_models) times."""
+        n = 60
+        sessions = [self._make_session(f"s{i}", self._MODEL_NAMES) for i in range(n)]
+        with patch(
+            "copilot_usage.report._copy_model_metrics",
+            wraps=_copy_model_metrics,
+        ) as mock_copy:
+            _aggregate_model_metrics(sessions)
+            assert mock_copy.call_count == len(self._MODEL_NAMES)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #499

## What changed

Replaced the iterative `merge_model_metrics` loop in `_aggregate_model_metrics` with direct in-place accumulation. Each unique model entry is now copied **exactly once** regardless of session count, reducing copy overhead from **O(n × m)** to **O(m)**.

### Before
```python
for s in sessions:
    merged = merge_model_metrics(merged, s.model_metrics)
```
On iteration `k`, all `k-1` accumulated models were copied from scratch — O(n × m) total `_copy_model_metrics` calls.

### After
```python
for s in sessions:
    for model_name, mm in s.model_metrics.items():
        if model_name in result:
            # accumulate in-place
        else:
            result[model_name] = _copy_model_metrics(mm)
```
Each model is copied once on first encounter, then accumulated in-place — O(m) total copies.

## Testing

Added `TestAggregateModelMetricsPerformance` with:
- **`test_many_sessions_correct_totals`** — builds 50 sessions × 3 models and asserts all aggregated values are correct.
- **`test_copy_called_once_per_unique_model`** — patches `_copy_model_metrics` and asserts it is called exactly 3 times (once per unique model), not 180 times (3 × 60 sessions).

All 834 tests pass. Coverage: 99.61%.




> [!WARNING]
> <details>
> <summary>⚠️ Firewall blocked 1 domain</summary>
>
> The following domain was blocked by the firewall during workflow execution:
>
> - `astral.sh`
>
> To allow these domains, add them to the `network.allowed` list in your workflow frontmatter:
>
> ```yaml
> network:
>   allowed:
>     - defaults
>     - "astral.sh"
> ```
>
> See [Network Configuration](https://github.github.com/gh-aw/reference/network/) for more information.
>
> </details>


> [!NOTE]
> <details>
> <summary>🔒 Integrity filtering filtered 18 items</summary>
>
> Integrity filtering activated and filtered the following items during workflow execution.
> This happens when a tool call accesses a resource that does not meet the required integrity or secrecy level of the workflow.
>
> - issue:microsasa/cli-tools#499 (`issue_read`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".)
> - issue:microsasa/cli-tools#502 (`list_issues`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".)
> - issue:microsasa/cli-tools#499 (`list_issues`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".)
> - issue:microsasa/cli-tools#497 (`list_issues`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".)
> - issue:microsasa/cli-tools#491 (`list_issues`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".)
> - issue:microsasa/cli-tools#490 (`list_issues`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".)
> - issue:microsasa/cli-tools#468 (`list_issues`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".)
> - issue:microsasa/cli-tools#467 (`list_issues`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".)
> - issue:microsasa/cli-tools#437 (`list_issues`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".)
> - issue:microsasa/cli-tools#221 (`list_issues`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".)
> - issue:microsasa/cli-tools#220 (`list_issues`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".)
> - issue:microsasa/cli-tools#173 (`list_issues`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".)
> - issue:microsasa/cli-tools#165 (`list_issues`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".)
> - issue:microsasa/cli-tools#131 (`list_issues`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".)
> - issue:microsasa/cli-tools#114 (`list_issues`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".)
> - issue:microsasa/cli-tools#111 (`list_issues`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".)
> - ... and 2 more items
>
> </details>


> Generated by [Issue Implementer](https://github.com/microsasa/cli-tools/actions/runs/23711375373) · [◷](https://github.com/search?q=repo%3Amicrosasa%2Fcli-tools+%22gh-aw-workflow-id%3A+issue-implementer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Issue Implementer, engine: copilot, model: claude-opus-4.6, id: 23711375373, workflow_id: issue-implementer, run: https://github.com/microsasa/cli-tools/actions/runs/23711375373 -->

<!-- gh-aw-workflow-id: issue-implementer -->