### PR TITLE
fix: remove duplicate _copy_model_metrics and add slots=True (#505)

### DIFF
--- a/src/copilot_usage/models.py
+++ b/src/copilot_usage/models.py
@@ -98,7 +98,7 @@ class ModelMetrics(BaseModel):
     usage: TokenUsage = Field(default_factory=TokenUsage)
 
 
-def _copy_model_metrics(mm: ModelMetrics) -> ModelMetrics:
+def copy_model_metrics(mm: ModelMetrics) -> ModelMetrics:
     """Create an independent copy of *mm* via explicit construction.
 
     Builds new ``ModelMetrics``/``RequestMetrics``/``TokenUsage`` instances
@@ -121,7 +121,7 @@ def merge_model_metrics(
     additional: dict[str, ModelMetrics],
 ) -> dict[str, ModelMetrics]:
     """Return a new dict merging *additional* into *base* without mutation."""
-    result = {name: _copy_model_metrics(mm) for name, mm in base.items()}
+    result = {name: copy_model_metrics(mm) for name, mm in base.items()}
     for name, mm in additional.items():
         if name in result:
             existing = result[name]
@@ -132,7 +132,7 @@ def merge_model_metrics(
             existing.usage.cacheReadTokens += mm.usage.cacheReadTokens
             existing.usage.cacheWriteTokens += mm.usage.cacheWriteTokens
         else:
-            result[name] = _copy_model_metrics(mm)
+            result[name] = copy_model_metrics(mm)
     return result
 
 

--- a/src/copilot_usage/report.py
+++ b/src/copilot_usage/report.py
@@ -25,9 +25,8 @@ from copilot_usage._formatting import (
 )
 from copilot_usage.models import (
     ModelMetrics,
-    RequestMetrics,
     SessionSummary,
-    TokenUsage,
+    copy_model_metrics,
     ensure_aware,
     has_active_period_stats,
     session_sort_key,
@@ -63,7 +62,7 @@ def _format_elapsed_since(start: datetime) -> str:
     return format_timedelta(delta)
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class _EffectiveStats:
     """Active-period stats when available, otherwise session totals."""
 
@@ -87,7 +86,7 @@ def _effective_stats(session: SessionSummary) -> _EffectiveStats:
     )
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class _SessionTotals:
     """Aggregated totals across a list of sessions."""
 
@@ -238,19 +237,6 @@ def _filter_sessions(
     return filtered
 
 
-def _copy_model_metrics(mm: ModelMetrics) -> ModelMetrics:
-    """Create an independent copy of *mm* via explicit construction."""
-    return ModelMetrics(
-        requests=RequestMetrics(count=mm.requests.count, cost=mm.requests.cost),
-        usage=TokenUsage(
-            inputTokens=mm.usage.inputTokens,
-            outputTokens=mm.usage.outputTokens,
-            cacheReadTokens=mm.usage.cacheReadTokens,
-            cacheWriteTokens=mm.usage.cacheWriteTokens,
-        ),
-    )
-
-
 def _aggregate_model_metrics(
     sessions: list[SessionSummary],
 ) -> dict[str, ModelMetrics]:
@@ -271,7 +257,7 @@ def _aggregate_model_metrics(
                 existing.usage.cacheReadTokens += mm.usage.cacheReadTokens
                 existing.usage.cacheWriteTokens += mm.usage.cacheWriteTokens
             else:
-                result[model_name] = _copy_model_metrics(mm)
+                result[model_name] = copy_model_metrics(mm)
     return result
 
 

--- a/tests/copilot_usage/test_report.py
+++ b/tests/copilot_usage/test_report.py
@@ -26,6 +26,7 @@ from copilot_usage.models import (
     SessionEvent,
     SessionSummary,
     TokenUsage,
+    copy_model_metrics,
     has_active_period_stats,
     shutdown_output_tokens,
     total_output_tokens,
@@ -47,7 +48,6 @@ from copilot_usage.render_detail import (
 from copilot_usage.report import (
     _aggregate_model_metrics,
     _compute_session_totals,
-    _copy_model_metrics,
     _effective_stats,
     _EffectiveStats,
     _estimate_premium_cost,
@@ -2862,12 +2862,12 @@ class TestAggregateModelMetricsPerformance:
             assert m.usage.cacheWriteTokens == 5 * n
 
     def test_copy_called_once_per_unique_model(self) -> None:
-        """_copy_model_metrics should be called exactly len(unique_models) times."""
+        """copy_model_metrics should be called exactly len(unique_models) times."""
         n = 60
         sessions = [self._make_session(f"s{i}", self._MODEL_NAMES) for i in range(n)]
         with patch(
-            "copilot_usage.report._copy_model_metrics",
-            wraps=_copy_model_metrics,
+            "copilot_usage.report.copy_model_metrics",
+            wraps=copy_model_metrics,
         ) as mock_copy:
             _aggregate_model_metrics(sessions)
             assert mock_copy.call_count == len(self._MODEL_NAMES)


### PR DESCRIPTION
Closes #505

## Changes

- **Remove duplicate `_copy_model_metrics`** from `report.py` — it was a byte-for-byte copy of the one in `models.py`. Now imported from `models.py` instead.
- **Rename to `copy_model_metrics`** (public) since pyright strict mode flags cross-module use of `_`-prefixed names as `reportPrivateUsage` errors. Making it public is the clean solution for same-package sharing.
- **Add `slots=True`** to `_EffectiveStats` and `_SessionTotals` frozen dataclasses in `report.py`, matching the convention used by `_FirstPassResult` and `_ResumeInfo` in `parser.py`.
- **Update test references** in `test_report.py` to import from `models` and patch the new name.

## Verification

- `ruff check` — 0 errors
- `ruff format` — 23 files unchanged
- `pyright` — 0 errors, 2 pre-existing warnings
- `pytest --cov --cov-fail-under=80` — 833 passed, 99.61% coverage




> [!WARNING]
> <details>
> <summary>⚠️ Firewall blocked 1 domain</summary>
>
> The following domain was blocked by the firewall during workflow execution:
>
> - `astral.sh`
>
> To allow these domains, add them to the `network.allowed` list in your workflow frontmatter:
>
> ```yaml
> network:
>   allowed:
>     - defaults
>     - "astral.sh"
> ```
>
> See [Network Configuration](https://github.github.com/gh-aw/reference/network/) for more information.
>
> </details>


> [!NOTE]
> <details>
> <summary>🔒 Integrity filtering filtered 1 item</summary>
>
> Integrity filtering activated and filtered the following item during workflow execution.
> This happens when a tool call accesses a resource that does not meet the required integrity or secrecy level of the workflow.
>
> - issue:microsasa/cli-tools#505 (`issue_read`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".)
>
> </details>


> Generated by [Issue Implementer](https://github.com/microsasa/cli-tools/actions/runs/23717225061) · [◷](https://github.com/search?q=repo%3Amicrosasa%2Fcli-tools+%22gh-aw-workflow-id%3A+issue-implementer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Issue Implementer, engine: copilot, model: claude-opus-4.6, id: 23717225061, workflow_id: issue-implementer, run: https://github.com/microsasa/cli-tools/actions/runs/23717225061 -->

<!-- gh-aw-workflow-id: issue-implementer -->