### PR TITLE
perf: cache `_read_config_model` with `@lru_cache` (#508)

### DIFF
--- a/src/copilot_usage/parser.py
+++ b/src/copilot_usage/parser.py
@@ -490,7 +490,13 @@ def get_all_sessions(base_path: Path | None = None) -> list[SessionSummary]:
 
     Returns list sorted by ``start_time`` (newest first).  Sessions
     without a ``start_time`` sort last.
+
+    The ``_read_config_model`` cache is cleared at the start of each
+    invocation so that interactive callers (e.g. ``_interactive_loop``)
+    pick up config-file edits between refreshes while still avoiding
+    redundant reads *within* a single invocation.
     """
+    _read_config_model.cache_clear()
     paths = discover_sessions(base_path)
     summaries: list[SessionSummary] = []
     for events_path in paths:

--- a/tests/copilot_usage/test_parser.py
+++ b/tests/copilot_usage/test_parser.py
@@ -3707,6 +3707,54 @@ class TestReadConfigModelCaching:
         # Config file read at most once thanks to lru_cache
         assert read_count <= 1
 
+    def test_get_all_sessions_clears_cache_between_calls(self, tmp_path: Path) -> None:
+        """Successive get_all_sessions calls pick up config edits."""
+        _read_config_model.cache_clear()
+        config = tmp_path / "config.json"
+        config.write_text('{"model": "gpt-5.1"}', encoding="utf-8")
+
+        session_start = json.dumps(
+            {
+                "type": "session.start",
+                "data": {
+                    "sessionId": "s1",
+                    "version": 1,
+                    "startTime": "2026-03-07T10:00:00.000Z",
+                    "context": {},
+                },
+                "id": "ev-s1",
+                "timestamp": "2026-03-07T10:00:00.000Z",
+            }
+        )
+        user_msg = json.dumps(
+            {
+                "type": "user.message",
+                "data": {
+                    "content": "hello",
+                    "transformedContent": "hello",
+                    "attachments": [],
+                    "interactionId": "int-1",
+                },
+                "id": "ev-u-s1",
+                "timestamp": "2026-03-07T10:01:00.000Z",
+            }
+        )
+        _write_events(
+            tmp_path / "sessions" / "s1" / "events.jsonl",
+            session_start,
+            user_msg,
+        )
+
+        with patch("copilot_usage.parser._CONFIG_PATH", config):
+            summaries = get_all_sessions(tmp_path / "sessions")
+            assert summaries[0].model == "gpt-5.1"
+
+            # Edit the config file between calls
+            config.write_text('{"model": "claude-sonnet-4"}', encoding="utf-8")
+
+            summaries = get_all_sessions(tmp_path / "sessions")
+            assert summaries[0].model == "claude-sonnet-4"
+
 
 # ---------------------------------------------------------------------------
 # Issue #418 — Gap 1: malformed session.start (ValidationError)


### PR DESCRIPTION
Closes #508

## Problem

`get_all_sessions` calls `build_session_summary` for every session without passing `config_path`, so for each active-modelless session `_read_config_model` opens and reads `~/.copilot/config.json` from disk. With N such sessions the same file is read N times — every read returns the same result. In interactive mode this compounds on every 2 s auto-refresh cycle.

## Fix

Add `@lru_cache(maxsize=4)` to `_read_config_model`. The cache is keyed on `config_path` (which is `Path | None`, both hashable). After the first call for a given path, subsequent calls return the cached result with no disk I/O. `maxsize=4` bounds memory for CLI/test invocations with non-default paths.

## Tests added

- `TestReadConfigModelCaching::test_repeated_calls_same_path_hit_cache` — verifies 3 calls with the same path produce 1 miss + 2 hits
- `TestReadConfigModelCaching::test_different_paths_are_cached_independently` — verifies distinct paths are separate cache entries
- `TestReadConfigModelCaching::test_get_all_sessions_reads_config_at_most_once` — end-to-end: 3 active-modelless sessions through `get_all_sessions`, asserts config file is read at most once via `Path.read_text` spy

All 847 existing tests pass. Coverage: 99.61%.




> [!NOTE]
> <details>
> <summary>🔒 Integrity filtering filtered 1 item</summary>
>
> Integrity filtering activated and filtered the following item during workflow execution.
> This happens when a tool call accesses a resource that does not meet the required integrity or secrecy level of the workflow.
>
> - issue:microsasa/cli-tools#508 (`issue_read`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".)
>
> </details>


> Generated by [Issue Implementer](https://github.com/microsasa/cli-tools/actions/runs/23718682429) · [◷](https://github.com/search?q=repo%3Amicrosasa%2Fcli-tools+%22gh-aw-workflow-id%3A+issue-implementer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Issue Implementer, engine: copilot, model: claude-opus-4.6, id: 23718682429, workflow_id: issue-implementer, run: https://github.com/microsasa/cli-tools/actions/runs/23718682429 -->

<!-- gh-aw-workflow-id: issue-implementer -->