### PR TITLE
fix: add Final annotations to module-level constants (#497)

### DIFF
--- a/src/copilot_usage/cli.py
+++ b/src/copilot_usage/cli.py
@@ -10,7 +10,7 @@ import threading
 import time
 from datetime import datetime, time as dt_time
 from pathlib import Path
-from typing import Literal, Protocol, cast
+from typing import Final, Literal, Protocol, cast
 
 import click
 from loguru import logger
@@ -39,15 +39,17 @@ from copilot_usage.report import (
 
 type _View = Literal["home", "detail", "cost"]
 
-_DATE_FORMATS = ["%Y-%m-%d", "%Y-%m-%dT%H:%M:%S"]
+_DATE_FORMATS: Final[list[str]] = ["%Y-%m-%d", "%Y-%m-%dT%H:%M:%S"]
 
-_WATCHDOG_DEBOUNCE_SECS: float = 2.0  # Prevents rapid redraws during tool-use bursts
+_WATCHDOG_DEBOUNCE_SECS: Final[float] = (
+    2.0  # Prevents rapid redraws during tool-use bursts
+)
 
-_UUID_STR_LEN = 36
-_UUID_DASH_COUNT = 4
-_MIN_PREFIX_LEN_FOR_PREFILTER = 4
+_UUID_STR_LEN: Final[int] = 36
+_UUID_DASH_COUNT: Final[int] = 4
+_MIN_PREFIX_LEN_FOR_PREFILTER: Final[int] = 4
 
-console = Console()
+console: Final[Console] = Console()
 
 
 def _normalize_until(dt: datetime | None) -> datetime | None:
@@ -103,8 +105,10 @@ def _print_version_header(target: Console | None = None) -> None:
 # Interactive mode helpers
 # ---------------------------------------------------------------------------
 
-_HOME_PROMPT = "\nEnter session # for detail, [c] cost, [r] refresh, [q] quit: "
-_BACK_PROMPT = "\nPress Enter to go back... "
+_HOME_PROMPT: Final[str] = (
+    "\nEnter session # for detail, [c] cost, [r] refresh, [q] quit: "
+)
+_BACK_PROMPT: Final[str] = "\nPress Enter to go back... "
 
 
 def _render_session_list(console: Console, sessions: list[SessionSummary]) -> None:

--- a/src/copilot_usage/logging_config.py
+++ b/src/copilot_usage/logging_config.py
@@ -1,11 +1,12 @@
 """Logging configuration — console-only for CLI tool."""
 
 import sys
+from typing import Final
 
 import loguru
 from loguru import logger
 
-LEVEL_EMOJI: dict[str, str] = {
+LEVEL_EMOJI: Final[dict[str, str]] = {
     "TRACE": "🔍",
     "DEBUG": "🐛",
     "INFO": "ℹ️ ",
@@ -15,7 +16,7 @@ LEVEL_EMOJI: dict[str, str] = {
     "CRITICAL": "🔥",
 }
 
-CONSOLE_FORMAT = (
+CONSOLE_FORMAT: Final[str] = (
     "<dim>{time:HH:mm:ss}</dim> "
     "{extra[emoji]} "
     "<level>{level:<7}</level> "

--- a/src/copilot_usage/models.py
+++ b/src/copilot_usage/models.py
@@ -8,6 +8,7 @@ flexible fallback for unknown ones.
 from datetime import UTC, datetime
 from enum import StrEnum
 from pathlib import Path
+from typing import Final
 
 from pydantic import BaseModel, Field, model_validator
 
@@ -21,7 +22,7 @@ _type = type
 # ---------------------------------------------------------------------------
 
 # Aware datetime sentinel used as a sort-key fallback for sessions without a start_time.
-EPOCH: datetime = datetime.min.replace(tzinfo=UTC)
+EPOCH: Final[datetime] = datetime.min.replace(tzinfo=UTC)
 
 
 def ensure_aware(dt: datetime) -> datetime:


### PR DESCRIPTION
Closes #497

## Changes

Adds `Final[T]` annotations to all module-level constants that were missing them, per the coding guideline: _"Use `Final` for module-level constants that should never be reassigned."_

### `models.py`
- `EPOCH: datetime` → `EPOCH: Final[datetime]`
- Added `from typing import Final`

### `logging_config.py`
- `LEVEL_EMOJI: dict[str, str]` → `LEVEL_EMOJI: Final[dict[str, str]]`
- `CONSOLE_FORMAT` → `CONSOLE_FORMAT: Final[str]`
- Added `from typing import Final`

### `cli.py`
- `_DATE_FORMATS` → `_DATE_FORMATS: Final[list[str]]`
- `_WATCHDOG_DEBOUNCE_SECS: float` → `_WATCHDOG_DEBOUNCE_SECS: Final[float]`
- `_UUID_STR_LEN` → `_UUID_STR_LEN: Final[int]`
- `_UUID_DASH_COUNT` → `_UUID_DASH_COUNT: Final[int]`
- `_MIN_PREFIX_LEN_FOR_PREFILTER` → `_MIN_PREFIX_LEN_FOR_PREFILTER: Final[int]`
- `console` → `console: Final[Console]`
- `_HOME_PROMPT` → `_HOME_PROMPT: Final[str]`
- `_BACK_PROMPT` → `_BACK_PROMPT: Final[str]`
- Added `Final` to existing `from typing import` statement

### Already correct (no changes needed)
- **`_formatting.py`**: `MAX_CONTENT_LEN` already had `Final[int]`
- **`report.py`**: `_EffectiveStats` and `_SessionTotals` already had `slots=True`
- **`logging_config.py` string annotation**: `"loguru.Record"` must stay quoted because `Record` is only in loguru's type stubs, not a runtime attribute

## Verification

- `ruff check` — 0 errors
- `ruff format` — clean
- `pyright` — 0 errors, 2 pre-existing warnings (unrelated)
- `pytest --cov --cov-fail-under=80` — 879 passed, 99% coverage




> [!WARNING]
> <details>
> <summary>⚠️ Firewall blocked 1 domain</summary>
>
> The following domain was blocked by the firewall during workflow execution:
>
> - `astral.sh`
>
> To allow these domains, add them to the `network.allowed` list in your workflow frontmatter:
>
> ```yaml
> network:
>   allowed:
>     - defaults
>     - "astral.sh"
> ```
>
> See [Network Configuration](https://github.github.com/gh-aw/reference/network/) for more information.
>
> </details>


> [!NOTE]
> <details>
> <summary>🔒 Integrity filtering filtered 1 item</summary>
>
> Integrity filtering activated and filtered the following item during workflow execution.
> This happens when a tool call accesses a resource that does not meet the required integrity or secrecy level of the workflow.
>
> - issue:microsasa/cli-tools#497 (`issue_read`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".)
>
> </details>


> Generated by [Issue Implementer](https://github.com/microsasa/cli-tools/actions/runs/23727070987) · [◷](https://github.com/search?q=repo%3Amicrosasa%2Fcli-tools+%22gh-aw-workflow-id%3A+issue-implementer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Issue Implementer, engine: copilot, model: claude-opus-4.6, id: 23727070987, workflow_id: issue-implementer, run: https://github.com/microsasa/cli-tools/actions/runs/23727070987 -->

<!-- gh-aw-workflow-id: issue-implementer -->