### PR TITLE
test: cover two untested defensive branches in vscode_parser.py (#518)

### DIFF
--- a/tests/copilot_usage/test_vscode_parser.py
+++ b/tests/copilot_usage/test_vscode_parser.py
@@ -116,6 +116,9 @@ class TestParseVscodeLog:
             f"{bad_ts} [info] ccreq:abc123.copilotmd"
             " | success | claude-sonnet-4 | 100ms | [panel]"
         )
+        # Ensure the constructed line still matches the CCREQ_RE regex; otherwise
+        # this test would no longer exercise the ValueError timestamp branch.
+        assert CCREQ_RE.match(bad_line) is not None
         good_line = _LOG_OPUS  # a valid known-good line
         log_file = tmp_path / "test.log"
         log_file.write_text(f"{bad_line}\n{good_line}", encoding="utf-8")
@@ -222,8 +225,13 @@ class TestDiscoverVscodeLogs:
         """Windows without APPDATA uses the home-relative fallback path."""
         monkeypatch.setattr("copilot_usage.vscode_parser.sys.platform", "win32")
         monkeypatch.setenv("APPDATA", "")  # empty → falsy
-        with patch.object(Path, "is_dir", return_value=False):
+        with patch.object(
+            Path, "is_dir", autospec=True, return_value=False
+        ) as mock_is_dir:
             result = discover_vscode_logs()
+        mock_is_dir.assert_any_call(
+            Path.home() / "AppData" / "Roaming" / "Code" / "logs"
+        )
         assert result == []
 
     def test_default_macos(self, monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
Closes #518

## Changes

Adds two tests to `tests/copilot_usage/test_vscode_parser.py` covering previously untested defensive branches in `vscode_parser.py`:

1. **`test_invalid_timestamp_line_is_skipped`** — Exercises the `except ValueError: continue` branch in `parse_vscode_log` by constructing a log line where the regex matches but the timestamp is unparseable (`9999-99-99 99:99:99.000`). Verifies the bad line is silently skipped while valid lines are still parsed.

2. **`test_default_windows_no_appdata`** — Exercises the Windows fallback path in `discover_vscode_logs` when `APPDATA` is empty/falsy. Verifies the function falls back to `~/AppData/Roaming/Code/logs` and returns `[]` when that path doesn't exist.

## Verification

- All lint checks pass (`ruff check`, `ruff format`)
- Type checking passes (`pyright`)
- All 904 tests pass with 99.43% coverage




> Generated by [Issue Implementer](https://github.com/microsasa/cli-tools/actions/runs/23728438546/agentic_workflow) · [◷](https://github.com/search?q=repo%3Amicrosasa%2Fcli-tools+%22gh-aw-workflow-id%3A+issue-implementer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Issue Implementer, engine: copilot, model: claude-opus-4.6, id: 23728438546, workflow_id: issue-implementer, run: https://github.com/microsasa/cli-tools/actions/runs/23728438546 -->

<!-- gh-aw-workflow-id: issue-implementer -->