### PR TITLE
perf: cache plan.md file identity to skip redundant reads (#531)

### DIFF
--- a/src/copilot_usage/parser.py
+++ b/src/copilot_usage/parser.py
@@ -29,9 +29,24 @@ from copilot_usage.models import (
 _DEFAULT_BASE: Path = Path.home() / ".copilot" / "session-state"
 _CONFIG_PATH: Path = Path.home() / ".copilot" / "config.json"
 
-# Module-level file-identity cache: events_path → ((mtime_ns, size), SessionSummary).
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class _CachedSession:
+    """Cache entry pairing file identities with a built summary.
+
+    Stores the ``(st_mtime_ns, st_size)`` identity of both
+    ``events.jsonl`` and ``plan.md`` so that the session name is only
+    re-read when ``plan.md`` actually changes on disk.
+    """
+
+    file_id: tuple[int, int]
+    plan_id: tuple[int, int]
+    summary: SessionSummary
+
+
+# Module-level file-identity cache: events_path → _CachedSession.
 # Avoids re-parsing unchanged files on every interactive refresh.
-_SESSION_CACHE: dict[Path, tuple[tuple[int, int], SessionSummary]] = {}
+_SESSION_CACHE: dict[Path, _CachedSession] = {}
 
 _RESUME_INDICATOR_TYPES: frozenset[str] = frozenset(
     {
@@ -516,8 +531,8 @@ def get_all_sessions(base_path: Path | None = None) -> list[SessionSummary]:
     that unchanged files are not re-parsed on subsequent calls — only
     files whose ``(st_mtime_ns, st_size)`` has changed since the last
     invocation are re-read.  Cached summaries have their ``name``
-    refreshed from ``plan.md`` on every call so renames are picked up
-    even when ``events.jsonl`` is unchanged.
+    refreshed from ``plan.md`` only when ``plan.md``'s own file
+    identity has changed, avoiding redundant file reads.
 
     The ``_read_config_model`` cache is cleared at the start of each
     invocation so that interactive callers (e.g. ``_interactive_loop``)
@@ -529,14 +544,14 @@ def get_all_sessions(base_path: Path | None = None) -> list[SessionSummary]:
     summaries: list[SessionSummary] = []
     for events_path, file_id in discovered:
         cached = _SESSION_CACHE.get(events_path)
-        if cached is not None and cached[0] == file_id:
-            summary = cached[1]
-            # Refresh session name from plan.md so renames are picked up
-            # even when events.jsonl is unchanged.
-            fresh_name = _extract_session_name(events_path.parent)
-            if fresh_name != summary.name:
-                summary = summary.model_copy(update={"name": fresh_name})
-                _SESSION_CACHE[events_path] = (file_id, summary)
+        if cached is not None and cached.file_id == file_id:
+            plan_id = _safe_file_identity(events_path.parent / "plan.md")
+            if plan_id != cached.plan_id:
+                fresh_name = _extract_session_name(events_path.parent)
+                summary = cached.summary.model_copy(update={"name": fresh_name})
+                _SESSION_CACHE[events_path] = _CachedSession(file_id, plan_id, summary)
+            else:
+                summary = cached.summary
             summaries.append(summary)
             continue
         try:
@@ -552,7 +567,8 @@ def get_all_sessions(base_path: Path | None = None) -> list[SessionSummary]:
         # file.  Pure-active sessions (no shutdown) derive their model
         # from _read_config_model which can change between calls.
         if not summary.is_active:
-            _SESSION_CACHE[events_path] = (file_id, summary)
+            plan_id = _safe_file_identity(events_path.parent / "plan.md")
+            _SESSION_CACHE[events_path] = _CachedSession(file_id, plan_id, summary)
         summaries.append(summary)
 
     summaries.sort(key=session_sort_key, reverse=True)

--- a/tests/copilot_usage/test_parser.py
+++ b/tests/copilot_usage/test_parser.py
@@ -30,6 +30,7 @@ from copilot_usage.models import (
 from copilot_usage.parser import (
     _SESSION_CACHE,
     _build_active_summary,
+    _CachedSession,
     _detect_resume,
     _extract_session_name,
     _first_pass,
@@ -4420,20 +4421,20 @@ class TestSessionCacheMtime:
         assert len(second) == 1
         assert second[0].name == "Renamed Session"
         # The cache should have been updated in-place
-        cached_summary = _SESSION_CACHE[p][1]
+        cached_summary = _SESSION_CACHE[p].summary
         assert cached_summary.name == "Renamed Session"
 
     def test_single_stat_per_file(self, tmp_path: Path) -> None:
-        """Each events.jsonl is stat'd only once per get_all_sessions call."""
+        """events.jsonl stat'd once (discovery), plan.md stat'd once (cache store)."""
         self._make_session(tmp_path, "sess-a", "a")
 
         with patch(
             "copilot_usage.parser._safe_file_identity", wraps=_safe_file_identity
         ) as spy:
             get_all_sessions(tmp_path)
-            # _safe_file_identity called once by _discover_with_identity, not again
-            # by the cache check in get_all_sessions.
-            assert spy.call_count == 1
+            # _safe_file_identity called once by _discover_with_identity for
+            # events.jsonl, and once for plan.md when storing the cache entry.
+            assert spy.call_count == 2
 
     def test_resumed_session_not_cached(self, tmp_path: Path) -> None:
         """A session that resumed after shutdown is NOT cached (model may change)."""
@@ -4504,3 +4505,57 @@ class TestSessionCacheMtime:
 
         # Resumed session should NOT be in the cache
         assert events_path not in _SESSION_CACHE
+
+    def test_plan_md_not_reread_when_unchanged(self, tmp_path: Path) -> None:
+        """plan.md is not re-read for cached sessions when its identity is unchanged."""
+        p = self._make_session(tmp_path, "sess-a", "a")
+        plan = p.parent / "plan.md"
+        plan.write_text("# My Session\n", encoding="utf-8")
+
+        # First call populates cache
+        first = get_all_sessions(tmp_path)
+        assert len(first) == 1
+        assert first[0].name == "My Session"
+
+        # Second call with plan.md unchanged — _extract_session_name must NOT be called
+        with patch(
+            "copilot_usage.parser._extract_session_name",
+            wraps=_extract_session_name,
+        ) as spy:
+            second = get_all_sessions(tmp_path)
+            assert len(second) == 1
+            assert second[0].name == "My Session"
+            spy.assert_not_called()
+
+    def test_plan_md_reread_when_changed(self, tmp_path: Path) -> None:
+        """plan.md IS re-read when its file identity changes between calls."""
+        p = self._make_session(tmp_path, "sess-a", "a")
+        plan = p.parent / "plan.md"
+        plan.write_text("# Original\n", encoding="utf-8")
+
+        first = get_all_sessions(tmp_path)
+        assert first[0].name == "Original"
+
+        # Modify plan.md
+        plan.write_text("# Updated\n", encoding="utf-8")
+
+        with patch(
+            "copilot_usage.parser._extract_session_name",
+            wraps=_extract_session_name,
+        ) as spy:
+            second = get_all_sessions(tmp_path)
+            assert second[0].name == "Updated"
+            spy.assert_called_once()
+
+    def test_cached_session_stores_plan_id(self, tmp_path: Path) -> None:
+        """Cache entries use _CachedSession with plan_id field."""
+        p = self._make_session(tmp_path, "sess-a", "a")
+        plan = p.parent / "plan.md"
+        plan.write_text("# Test\n", encoding="utf-8")
+
+        get_all_sessions(tmp_path)
+
+        entry = _SESSION_CACHE[p]
+        assert isinstance(entry, _CachedSession)
+        assert entry.plan_id == _safe_file_identity(plan)
+        assert entry.summary.name == "Test"


### PR DESCRIPTION
Closes #531

## Problem

`get_all_sessions()` was unconditionally calling `_extract_session_name()` for every cached session on every invocation. This performed a `stat()` + `read_text()` on `plan.md` for each session — 50–100+ file reads per refresh cycle in interactive mode.

## Solution

Extend `_SESSION_CACHE` to store `plan.md`'s file identity `(st_mtime_ns, st_size)` alongside the `events.jsonl` identity, via a new `_CachedSession` frozen dataclass:

```python
`@dataclasses`.dataclass(frozen=True, slots=True)
class _CachedSession:
    file_id: tuple[int, int]       # events.jsonl identity
    plan_id: tuple[int, int]       # plan.md identity (0, 0) if absent
    summary: SessionSummary
```

On cache hits, `plan.md` is only re-read when its file identity has changed. This eliminates N file reads per refresh cycle for the common case where `plan.md` hasn't changed, while still picking up renames when they occur.

## Tests

- `test_plan_md_not_reread_when_unchanged` — verifies `_extract_session_name` is **not called** for cached sessions when `plan.md` is unchanged
- `test_plan_md_reread_when_changed` — verifies `_extract_session_name` **is called** when `plan.md` changes
- `test_cached_session_stores_plan_id` — verifies cache entries use `_CachedSession` with correct `plan_id`
- Updated `test_single_stat_per_file` to account for the additional `plan.md` stat on cache store

All 910 tests pass. 100% coverage on `parser.py`.




> Generated by [Issue Implementer](https://github.com/microsasa/cli-tools/actions/runs/23736333192/agentic_workflow) · [◷](https://github.com/search?q=repo%3Amicrosasa%2Fcli-tools+%22gh-aw-workflow-id%3A+issue-implementer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Issue Implementer, engine: copilot, model: claude-opus-4.6, id: 23736333192, workflow_id: issue-implementer, run: https://github.com/microsasa/cli-tools/actions/runs/23736333192 -->

<!-- gh-aw-workflow-id: issue-implementer -->