### PR TITLE
perf: use defaultdict and cache strftime in _update_vscode_summary (#532)

### DIFF
--- a/src/copilot_usage/vscode_parser.py
+++ b/src/copilot_usage/vscode_parser.py
@@ -3,8 +3,9 @@
 import os
 import re
 import sys
+from collections import defaultdict
 from dataclasses import dataclass, field
-from datetime import datetime
+from datetime import date, datetime
 from pathlib import Path
 
 from loguru import logger
@@ -129,10 +130,18 @@ class _SummaryAccumulator:
 
     total_requests: int = 0
     total_duration_ms: int = 0
-    requests_by_model: dict[str, int] = field(default_factory=lambda: {})
-    duration_by_model: dict[str, int] = field(default_factory=lambda: {})
-    requests_by_category: dict[str, int] = field(default_factory=lambda: {})
-    requests_by_date: dict[str, int] = field(default_factory=lambda: {})
+    requests_by_model: defaultdict[str, int] = field(
+        default_factory=lambda: defaultdict(int)
+    )
+    duration_by_model: defaultdict[str, int] = field(
+        default_factory=lambda: defaultdict(int)
+    )
+    requests_by_category: defaultdict[str, int] = field(
+        default_factory=lambda: defaultdict(int)
+    )
+    requests_by_date: defaultdict[str, int] = field(
+        default_factory=lambda: defaultdict(int)
+    )
     first_timestamp: datetime | None = None
     last_timestamp: datetime | None = None
     log_files_parsed: int = 0
@@ -142,20 +151,22 @@ def _update_vscode_summary(
     acc: _SummaryAccumulator, requests: list[VSCodeRequest]
 ) -> None:
     """Merge *requests* into *acc* in-place, then discard."""
+    last_date_key: str = ""
+    last_date_val: date | None = None
+
     for req in requests:
         acc.total_requests += 1
         acc.total_duration_ms += req.duration_ms
 
-        acc.requests_by_model[req.model] = acc.requests_by_model.get(req.model, 0) + 1
-        acc.duration_by_model[req.model] = (
-            acc.duration_by_model.get(req.model, 0) + req.duration_ms
-        )
-        acc.requests_by_category[req.category] = (
-            acc.requests_by_category.get(req.category, 0) + 1
-        )
+        acc.requests_by_model[req.model] += 1
+        acc.duration_by_model[req.model] += req.duration_ms
+        acc.requests_by_category[req.category] += 1
 
-        date_key = req.timestamp.strftime("%Y-%m-%d")
-        acc.requests_by_date[date_key] = acc.requests_by_date.get(date_key, 0) + 1
+        ts_date = req.timestamp.date()
+        if last_date_val is None or ts_date != last_date_val:
+            last_date_key = req.timestamp.strftime("%Y-%m-%d")
+            last_date_val = ts_date
+        acc.requests_by_date[last_date_key] += 1
 
         if acc.first_timestamp is None or req.timestamp < acc.first_timestamp:
             acc.first_timestamp = req.timestamp
@@ -168,10 +179,10 @@ def _finalize_summary(acc: _SummaryAccumulator) -> VSCodeLogSummary:
     return VSCodeLogSummary(
         total_requests=acc.total_requests,
         total_duration_ms=acc.total_duration_ms,
-        requests_by_model=acc.requests_by_model,
-        duration_by_model=acc.duration_by_model,
-        requests_by_category=acc.requests_by_category,
-        requests_by_date=acc.requests_by_date,
+        requests_by_model=dict(acc.requests_by_model),
+        duration_by_model=dict(acc.duration_by_model),
+        requests_by_category=dict(acc.requests_by_category),
+        requests_by_date=dict(acc.requests_by_date),
         first_timestamp=acc.first_timestamp,
         last_timestamp=acc.last_timestamp,
         log_files_parsed=acc.log_files_parsed,

--- a/tests/copilot_usage/test_vscode_parser.py
+++ b/tests/copilot_usage/test_vscode_parser.py
@@ -359,3 +359,90 @@ class TestVscodeCliCommand:
         result = runner.invoke(main, ["vscode", "--vscode-logs", str(tmp_path)])
         assert result.exit_code == 0
         assert "VS Code Copilot Chat" in result.output
+
+
+# ---------------------------------------------------------------------------
+# Benchmark / correctness: large batch of requests
+# ---------------------------------------------------------------------------
+
+_NUM_BENCHMARK_REQUESTS = 10_000
+_MODELS = ["claude-opus-4.6", "gpt-4o-mini", "claude-sonnet-4"]
+_CATEGORIES = ["panel/editAgent", "inline", "copilotLanguageModelWrapper"]
+
+
+def _make_bulk_requests(n: int = _NUM_BENCHMARK_REQUESTS) -> list[VSCodeRequest]:
+    """Build *n* requests spread across a few models/categories on one date."""
+    from datetime import datetime
+
+    base = datetime(2026, 3, 13, 10, 0, 0)
+    return [
+        VSCodeRequest(
+            timestamp=base,
+            request_id=f"r{i}",
+            model=_MODELS[i % len(_MODELS)],
+            duration_ms=100 + (i % 7),
+            category=_CATEGORIES[i % len(_CATEGORIES)],
+        )
+        for i in range(n)
+    ]
+
+
+class TestBuildVscodeSummaryBulk:
+    """Correctness check using a large batch of requests."""
+
+    def test_bulk_aggregation_correctness(self) -> None:
+        requests = _make_bulk_requests()
+        summary = build_vscode_summary(requests)
+
+        assert summary.total_requests == _NUM_BENCHMARK_REQUESTS
+
+        # Model distribution: requests are round-robined across 3 models
+        for model in _MODELS:
+            expected = sum(1 for r in requests if r.model == model)
+            assert summary.requests_by_model[model] == expected
+
+        # Duration by model
+        for model in _MODELS:
+            expected_dur = sum(r.duration_ms for r in requests if r.model == model)
+            assert summary.duration_by_model[model] == expected_dur
+
+        # Category distribution
+        for cat in _CATEGORIES:
+            expected_cat = sum(1 for r in requests if r.category == cat)
+            assert summary.requests_by_category[cat] == expected_cat
+
+        # All requests share the same date
+        assert summary.requests_by_date == {"2026-03-13": _NUM_BENCHMARK_REQUESTS}
+
+        # Total duration
+        expected_total = sum(r.duration_ms for r in requests)
+        assert summary.total_duration_ms == expected_total
+
+    def test_bulk_multi_date(self) -> None:
+        """Requests spanning multiple dates are aggregated correctly."""
+        from datetime import datetime, timedelta
+
+        base = datetime(2026, 3, 10, 8, 0, 0)
+        requests = [
+            VSCodeRequest(
+                timestamp=base + timedelta(days=i // 100),
+                request_id=f"m{i}",
+                model="gpt-4o",
+                duration_ms=50,
+                category="panel",
+            )
+            for i in range(1000)
+        ]
+        summary = build_vscode_summary(requests)
+        assert summary.total_requests == 1000
+        assert sum(summary.requests_by_date.values()) == 1000
+        # 10 distinct dates (0..999 // 100 → 0..9)
+        assert len(summary.requests_by_date) == 10
+
+    def test_finalized_summary_uses_plain_dict(self) -> None:
+        """_finalize_summary converts defaultdict to plain dict."""
+        summary = build_vscode_summary(_make_bulk_requests())
+        assert type(summary.requests_by_model) is dict
+        assert type(summary.duration_by_model) is dict
+        assert type(summary.requests_by_category) is dict
+        assert type(summary.requests_by_date) is dict


### PR DESCRIPTION
Closes #532

## Changes

**`src/copilot_usage/vscode_parser.py`**

1. **Replace `dict` with `collections.defaultdict(int)`** in `_SummaryAccumulator` — the four counter dictionaries now use `defaultdict(int)`, so `_update_vscode_summary` uses single-lookup `+=` instead of double-lookup `.get(key, 0) + 1` / `__setitem__`. This halves hash operations per request (4 → 8 per iteration).

2. **Cache `strftime` result** when consecutive requests share the same date — `req.timestamp.date()` is compared to the previous value, and `strftime` is only called when the date changes. For real-world logs where requests cluster by date, this eliminates the vast majority of `strftime` calls.

3. **Convert `defaultdict` → plain `dict` in `_finalize_summary`** so the frozen `VSCodeLogSummary` type signature (`dict[str, int]`) is unchanged.

**`tests/copilot_usage/test_vscode_parser.py`**

- Added `TestBuildVscodeSummaryBulk` with three tests:
  - `test_bulk_aggregation_correctness` — 10,000 requests across 3 models/categories on a single date; verifies all counts, durations, and date aggregation.
  - `test_bulk_multi_date` — 1,000 requests spanning 10 dates; verifies multi-date aggregation.
  - `test_finalized_summary_uses_plain_dict` — asserts the finalized summary contains plain `dict`, not `defaultdict`.

## Verification

All 913 tests pass, pyright strict reports 0 errors, ruff lint/format clean, coverage 99.44%.




> Generated by [Issue Implementer](https://github.com/microsasa/cli-tools/actions/runs/23736986496/agentic_workflow) · [◷](https://github.com/search?q=repo%3Amicrosasa%2Fcli-tools+%22gh-aw-workflow-id%3A+issue-implementer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Issue Implementer, engine: copilot, model: claude-opus-4.6, id: 23736986496, workflow_id: issue-implementer, run: https://github.com/microsasa/cli-tools/actions/runs/23736986496 -->

<!-- gh-aw-workflow-id: issue-implementer -->