### PR TITLE
fix: import format_duration from _formatting instead of report (#533)

### DIFF
--- a/src/copilot_usage/vscode_report.py
+++ b/src/copilot_usage/vscode_report.py
@@ -6,8 +6,8 @@ from rich.console import Console
 from rich.panel import Panel
 from rich.table import Table
 
+from copilot_usage._formatting import format_duration
 from copilot_usage.pricing import lookup_model_pricing
-from copilot_usage.report import format_duration
 from copilot_usage.vscode_parser import VSCodeLogSummary
 
 __all__ = ["render_vscode_summary"]


### PR DESCRIPTION
Closes #533

## What

Changes the `format_duration` import in `vscode_report.py` from `copilot_usage.report` to `copilot_usage._formatting` — the canonical definition site.

## Why

The `_formatting` module was extracted specifically so that `vscode_report` and `render_detail` can import formatting utilities without going through `report`, avoiding unnecessary coupling and latent circular-import risk. Importing from `report` defeats that design.

## Testing

All 912 existing tests pass, including the two tests that exercise this code path:
- `test_api_time_rendered`
- `test_total_duration_formatted`

Pyright strict, ruff check, and ruff format all pass cleanly. Coverage at 99.44%.




> Generated by [Issue Implementer](https://github.com/microsasa/cli-tools/actions/runs/23737718947/agentic_workflow) · [◷](https://github.com/search?q=repo%3Amicrosasa%2Fcli-tools+%22gh-aw-workflow-id%3A+issue-implementer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Issue Implementer, engine: copilot, model: claude-opus-4.6, id: 23737718947, workflow_id: issue-implementer, run: https://github.com/microsasa/cli-tools/actions/runs/23737718947 -->

<!-- gh-aw-workflow-id: issue-implementer -->