### PR TITLE
test: add missing branch coverage in `_build_event_details` (#542)

### DIFF
--- a/tests/copilot_usage/test_report.py
+++ b/tests/copilot_usage/test_report.py
@@ -2618,6 +2618,49 @@ class TestBuildEventDetails:
         ev = _make_event(EventType.SESSION_SHUTDOWN, data={"modelMetrics": "bad"})
         assert _build_event_details(ev) == ""
 
+    def test_assistant_message_tokens_only_no_content(self) -> None:
+        """outputTokens > 0 but content='' → shows tokens, no content."""
+        ev = _make_event(
+            EventType.ASSISTANT_MESSAGE,
+            data={"messageId": "m1", "outputTokens": 50, "content": ""},
+        )
+        details = _build_event_details(ev)
+        assert details == "tokens=50"
+
+    def test_assistant_message_tokens_only_large_count(self) -> None:
+        """outputTokens > 0 with large count and empty content."""
+        ev = _make_event(
+            EventType.ASSISTANT_MESSAGE,
+            data={"messageId": "m1", "outputTokens": 150_000, "content": ""},
+        )
+        details = _build_event_details(ev)
+        assert details == "tokens=150000"
+
+    def test_session_shutdown_empty_shutdown_type(self) -> None:
+        """shutdownType='' → returns empty string."""
+        ev = _make_event(
+            EventType.SESSION_SHUTDOWN,
+            data={
+                "shutdownType": "",
+                "totalPremiumRequests": 0,
+                "totalApiDurationMs": 0,
+                "modelMetrics": {},
+            },
+        )
+        assert _build_event_details(ev) == ""
+
+    def test_session_shutdown_default_data(self) -> None:
+        """SessionShutdownData() with all defaults → returns empty string."""
+        ev = _make_event(
+            EventType.SESSION_SHUTDOWN,
+            data={
+                "totalPremiumRequests": 0,
+                "totalApiDurationMs": 0,
+                "modelMetrics": {},
+            },
+        )
+        assert _build_event_details(ev) == ""
+
 
 class TestRenderShutdownCyclesEdgeCases:
     """Test _render_shutdown_cycles with malformed data and missing fields."""


### PR DESCRIPTION
Closes #542

## What

Adds four tests to `TestBuildEventDetails` covering two previously untested branches in `_build_event_details`:

### Branch 1 — Assistant message with tokens but empty content
LLM tool-call turns produce `outputTokens > 0` with an empty `content` field. Two new tests assert the `"tokens=N"` string is returned correctly:
- `test_assistant_message_tokens_only_no_content` — `outputTokens=50, content=""`
- `test_assistant_message_tokens_only_large_count` — `outputTokens=150000, content=""`

### Branch 2 — Session shutdown with empty `shutdownType`
`SessionShutdownData.shutdownType` defaults to `""`. Two new tests cover the falsy guard:
- `test_session_shutdown_empty_shutdown_type` — explicit `shutdownType=""`
- `test_session_shutdown_default_data` — omitted `shutdownType` (defaults to `""`)

## Verification
- `ruff check` — all checks passed
- `ruff format` — no changes needed
- `pyright` — 0 errors
- `pytest --cov --cov-fail-under=80` — 925 tests passed, 99.44% coverage




> Generated by [Issue Implementer](https://github.com/microsasa/cli-tools/actions/runs/23756654956/agentic_workflow) · [◷](https://github.com/search?q=repo%3Amicrosasa%2Fcli-tools+%22gh-aw-workflow-id%3A+issue-implementer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Issue Implementer, engine: copilot, model: claude-opus-4.6, id: 23756654956, workflow_id: issue-implementer, run: https://github.com/microsasa/cli-tools/actions/runs/23756654956 -->

<!-- gh-aw-workflow-id: issue-implementer -->