### PR TITLE
fix: add missing `Final` annotations and remove inconsistent `__future__` import (#544)

### DIFF
--- a/src/copilot_usage/logging_config.py
+++ b/src/copilot_usage/logging_config.py
@@ -1,7 +1,5 @@
 """Logging configuration — console-only for CLI tool."""
 
-from __future__ import annotations
-
 import sys
 from typing import Final
 
@@ -26,7 +24,7 @@ CONSOLE_FORMAT: Final[str] = (
 )
 
 
-def _emoji_patcher(record: loguru.Record) -> None:
+def _emoji_patcher(record: "loguru.Record") -> None:
     """Inject a level-specific emoji into the log record's extras."""
     record["extra"]["emoji"] = LEVEL_EMOJI.get(record["level"].name, "  ")
 

--- a/src/copilot_usage/parser.py
+++ b/src/copilot_usage/parser.py
@@ -10,6 +10,7 @@ import json
 from datetime import datetime
 from functools import lru_cache
 from pathlib import Path
+from typing import Final
 
 from loguru import logger
 from pydantic import ValidationError
@@ -26,8 +27,8 @@ from copilot_usage.models import (
     session_sort_key,
 )
 
-_DEFAULT_BASE: Path = Path.home() / ".copilot" / "session-state"
-_CONFIG_PATH: Path = Path.home() / ".copilot" / "config.json"
+_DEFAULT_BASE: Final[Path] = Path.home() / ".copilot" / "session-state"
+_CONFIG_PATH: Final[Path] = Path.home() / ".copilot" / "config.json"
 
 
 @dataclasses.dataclass(frozen=True, slots=True)
@@ -48,7 +49,7 @@ class _CachedSession:
 # Avoids re-parsing unchanged files on every interactive refresh.
 _SESSION_CACHE: dict[Path, _CachedSession] = {}
 
-_RESUME_INDICATOR_TYPES: frozenset[str] = frozenset(
+_RESUME_INDICATOR_TYPES: Final[frozenset[EventType]] = frozenset(
     {
         EventType.SESSION_RESUME,
         EventType.USER_MESSAGE,

--- a/src/copilot_usage/vscode_report.py
+++ b/src/copilot_usage/vscode_report.py
@@ -1,6 +1,7 @@
 """Rendering for VS Code Copilot Chat usage data."""
 
 import warnings
+from typing import Final
 
 from rich.console import Console
 from rich.panel import Panel
@@ -12,7 +13,7 @@ from copilot_usage.vscode_parser import VSCodeLogSummary
 
 __all__ = ["render_vscode_summary"]
 
-_DAILY_ACTIVITY_LIMIT = 14
+_DAILY_ACTIVITY_LIMIT: Final[int] = 14
 
 
 def render_vscode_summary(


### PR DESCRIPTION
Closes #544

## Changes

**`src/copilot_usage/parser.py`**
- `_DEFAULT_BASE` and `_CONFIG_PATH`: annotated with `Final[Path]`
- `_RESUME_INDICATOR_TYPES`: annotated with `Final[frozenset[EventType]]` (was `frozenset[str]`)
- Added `from typing import Final`

**`src/copilot_usage/vscode_report.py`**
- `_DAILY_ACTIVITY_LIMIT`: annotated with `Final[int]` (had no annotation)
- Added `from typing import Final`

**`src/copilot_usage/logging_config.py`**
- Removed the only `from __future__ import annotations` in the codebase
- Changed `loguru.Record` annotation to a string literal `"loguru.Record"` since `Record` is a stub-only `TypedDict` not exposed at runtime

## Verification

All checks pass locally:
- `ruff check` — ✅
- `ruff format` — ✅
- `pyright` — 0 errors
- `pytest --cov --cov-fail-under=80` — 927 passed, 99.44% coverage




> Generated by [Issue Implementer](https://github.com/microsasa/cli-tools/actions/runs/23757697286/agentic_workflow) · [◷](https://github.com/search?q=repo%3Amicrosasa%2Fcli-tools+%22gh-aw-workflow-id%3A+issue-implementer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Issue Implementer, engine: copilot, model: claude-opus-4.6, id: 23757697286, workflow_id: issue-implementer, run: https://github.com/microsasa/cli-tools/actions/runs/23757697286 -->

<!-- gh-aw-workflow-id: issue-implementer -->