### PR TITLE
fix: propagate OSError from parse_vscode_log instead of swallowing it (#545)

### DIFF
--- a/src/copilot_usage/vscode_parser.py
+++ b/src/copilot_usage/vscode_parser.py
@@ -89,37 +89,34 @@ def discover_vscode_logs(base_path: Path | None = None) -> list[Path]:
     return logs
 
 
-def parse_vscode_log(log_path: Path) -> list[VSCodeRequest] | None:
+def parse_vscode_log(log_path: Path) -> list[VSCodeRequest]:
     """Parse a single VS Code Copilot Chat log file into request objects.
 
-    Returns a list of parsed requests, or ``None`` if the file could not be
-    opened/read (so callers can distinguish "no matching lines" from "I/O
-    failure").
+    Returns a list of parsed requests (possibly empty when no lines match).
+
+    Raises:
+        OSError: If the file cannot be opened or read.
     """
     requests: list[VSCodeRequest] = []
-    try:
-        with log_path.open(encoding="utf-8", errors="replace") as f:
-            for line in f:
-                m = CCREQ_RE.match(line)
-                if m is None:
-                    continue
-                ts_str, req_id, model, duration_str, category = m.groups()
-                try:
-                    ts = datetime.strptime(ts_str, "%Y-%m-%d %H:%M:%S.%f")
-                except ValueError:
-                    continue
-                requests.append(
-                    VSCodeRequest(
-                        timestamp=ts,
-                        request_id=req_id,
-                        model=model,
-                        duration_ms=int(duration_str),
-                        category=category,
-                    )
+    with log_path.open(encoding="utf-8", errors="replace") as f:
+        for line in f:
+            m = CCREQ_RE.match(line)
+            if m is None:
+                continue
+            ts_str, req_id, model, duration_str, category = m.groups()
+            try:
+                ts = datetime.strptime(ts_str, "%Y-%m-%d %H:%M:%S.%f")
+            except ValueError:
+                continue
+            requests.append(
+                VSCodeRequest(
+                    timestamp=ts,
+                    request_id=req_id,
+                    model=model,
+                    duration_ms=int(duration_str),
+                    category=category,
                 )
-    except OSError as exc:
-        logger.warning("Could not read log file {}: {}", log_path, exc)
-        return None
+            )
     logger.debug("Parsed {} request(s) from {}", len(requests), log_path)
     return requests
 
@@ -201,8 +198,11 @@ def get_vscode_summary(base_path: Path | None = None) -> VSCodeLogSummary:
     logs = discover_vscode_logs(base_path)
     acc = _SummaryAccumulator()
     for log_path in logs:
-        result = parse_vscode_log(log_path)
-        if result is not None:
-            _update_vscode_summary(acc, result)
-            acc.log_files_parsed += 1
+        try:
+            result = parse_vscode_log(log_path)
+        except OSError as exc:
+            logger.warning("Could not read log file {}: {}", log_path, exc)
+            continue
+        _update_vscode_summary(acc, result)
+        acc.log_files_parsed += 1
     return _finalize_summary(acc)

--- a/tests/copilot_usage/test_vscode_parser.py
+++ b/tests/copilot_usage/test_vscode_parser.py
@@ -91,7 +91,6 @@ class TestParseVscodeLog:
             encoding="utf-8",
         )
         requests = parse_vscode_log(log_file)
-        assert requests is not None
         assert len(requests) == 3
         assert requests[0].model == "claude-opus-4.6"
         assert requests[0].duration_ms == 8003
@@ -103,9 +102,10 @@ class TestParseVscodeLog:
         log_file.write_text("", encoding="utf-8")
         assert parse_vscode_log(log_file) == []
 
-    def test_missing_file(self, tmp_path: Path) -> None:
+    def test_missing_file_raises_oserror(self, tmp_path: Path) -> None:
         missing = tmp_path / "no_such.log"
-        assert parse_vscode_log(missing) is None
+        with pytest.raises(OSError):
+            parse_vscode_log(missing)
 
     def test_invalid_timestamp_line_is_skipped(self, tmp_path: Path) -> None:
         """A regex-matching line with an unparseable timestamp is skipped."""
@@ -121,7 +121,6 @@ class TestParseVscodeLog:
         log_file = tmp_path / "test.log"
         log_file.write_text(f"{bad_line}\n{good_line}", encoding="utf-8")
         result = parse_vscode_log(log_file)
-        assert result is not None
         assert len(result) == 1  # bad line skipped
         assert result[0].model == "claude-opus-4.6"
 
@@ -138,7 +137,6 @@ class TestParseVscodeLog:
         log_file = tmp_path / "all_bad.log"
         log_file.write_text(f"{bad_line}\n{bad_line}\n", encoding="utf-8")
         result = parse_vscode_log(log_file)
-        assert result is not None, "Must return [] (not None) — not an I/O error"
         assert result == []
 
 
@@ -366,6 +364,43 @@ class TestGetVscodeSummary:
         # be called because get_vscode_summary now aggregates per-file via
         # _update_vscode_summary instead of collecting all requests first.
         mock_build.assert_not_called()
+
+    def test_oserror_skips_file_and_continues(self) -> None:
+        """When one log file raises OSError, the other is still processed."""
+        from datetime import datetime
+
+        file_a = Path("/fake/log_a.log")
+        file_b = Path("/fake/log_b.log")
+        requests_b = [
+            VSCodeRequest(
+                timestamp=datetime(2026, 3, 14, 12, 0, 0),
+                request_id="b1",
+                model="claude-sonnet-4",
+                duration_ms=300,
+                category="inline",
+            ),
+        ]
+
+        def _fake_parse(path: Path) -> list[VSCodeRequest]:
+            if path == file_a:
+                raise OSError("Permission denied")
+            return list(requests_b)
+
+        with (
+            patch(
+                "copilot_usage.vscode_parser.discover_vscode_logs",
+                return_value=[file_a, file_b],
+            ),
+            patch(
+                "copilot_usage.vscode_parser.parse_vscode_log",
+                side_effect=_fake_parse,
+            ),
+        ):
+            summary = get_vscode_summary()
+
+        assert summary.log_files_parsed == 1
+        assert summary.total_requests == 1
+        assert summary.requests_by_model["claude-sonnet-4"] == 1
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #545

## Summary

Aligns `parse_vscode_log` with `parse_events` by letting `OSError` propagate to callers instead of catching it and returning `None`. Moves the `try/except` into `get_vscode_summary` so it can log-and-skip per file — matching the pattern used by `get_all_sessions`.

## Changes

### `src/copilot_usage/vscode_parser.py`
- **`parse_vscode_log`**: Removed the `try/except OSError` block. Return type simplified from `list[VSCodeRequest] | None` to `list[VSCodeRequest]`. Docstring updated to document `Raises: OSError`.
- **`get_vscode_summary`**: Wraps `parse_vscode_log` call in `try/except OSError`, logs a warning, and continues to the next file on failure.

### `tests/copilot_usage/test_vscode_parser.py`
- `test_missing_file` → renamed to `test_missing_file_raises_oserror` and now asserts `OSError` propagates (was asserting `None` return).
- Removed unnecessary `is not None` assertions from existing tests.
- Added `test_oserror_skips_file_and_continues` verifying that when one log file raises `OSError`, the other file is still processed and `log_files_parsed == 1`.

## Verification

All 928 tests pass. Coverage at 99.49%. Ruff, pyright all clean.




> Generated by [Issue Implementer](https://github.com/microsasa/cli-tools/actions/runs/23758303123/agentic_workflow) · [◷](https://github.com/search?q=repo%3Amicrosasa%2Fcli-tools+%22gh-aw-workflow-id%3A+issue-implementer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Issue Implementer, engine: copilot, model: claude-opus-4.6, id: 23758303123, workflow_id: issue-implementer, run: https://github.com/microsasa/cli-tools/actions/runs/23758303123 -->

<!-- gh-aw-workflow-id: issue-implementer -->