### PR TITLE
fix: cache active sessions in `_SESSION_CACHE` to avoid full re-parse (#552)

### DIFF
--- a/src/copilot_usage/parser.py
+++ b/src/copilot_usage/parser.py
@@ -39,16 +39,21 @@ class _CachedSession:
     ``events.jsonl`` and ``plan.md`` so that the session name is only
     re-read when ``plan.md`` actually changes on disk.
 
-    For pure-active sessions (no shutdown metrics), ``config_model``
-    records the config model used during parsing so the cache can be
-    invalidated when the user edits ``~/.copilot/config.json``.
-    Resumed and completed sessions derive their model from the shutdown
-    event and store ``None``.
+    ``depends_on_config`` is ``True`` only when the session's model was
+    sourced from ``~/.copilot/config.json`` (i.e. neither the events nor
+    tool executions supplied a model).  When ``True``, ``config_model``
+    records the value that was read so the cache can be invalidated on
+    change — including the ``None → "gpt-…"`` transition.
+
+    Resumed and completed sessions always have
+    ``depends_on_config=False`` because their model comes from the
+    shutdown event.
     """
 
     file_id: tuple[int, int]
     plan_id: tuple[int, int]
     config_model: str | None
+    depends_on_config: bool
     summary: SessionSummary
 
 
@@ -489,6 +494,43 @@ def _build_active_summary(
 # ---------------------------------------------------------------------------
 
 
+@dataclasses.dataclass(frozen=True, slots=True)
+class _BuildMeta:
+    """Internal result from :func:`_build_session_summary_with_meta`.
+
+    Carries the summary together with a flag indicating whether the
+    model was resolved from the config file (as opposed to events).
+    """
+
+    summary: SessionSummary
+    used_config_fallback: bool
+
+
+def _build_session_summary_with_meta(
+    events: list[SessionEvent],
+    *,
+    session_dir: Path | None = None,
+    config_path: Path | None = None,
+    events_path: Path | None = None,
+) -> _BuildMeta:
+    """Build a summary and report whether the config fallback was used."""
+    fp = _first_pass(events)
+    name = _extract_session_name(session_dir) if session_dir else None
+
+    if fp.all_shutdowns:
+        resume = _detect_resume(events, fp.all_shutdowns)
+        return _BuildMeta(
+            _build_completed_summary(fp, name, resume, events_path=events_path),
+            used_config_fallback=False,
+        )
+
+    used_config = fp.model is None and fp.tool_model is None
+    return _BuildMeta(
+        _build_active_summary(fp, name, config_path, events_path=events_path),
+        used_config_fallback=used_config,
+    )
+
+
 def build_session_summary(
     events: list[SessionEvent],
     *,
@@ -522,14 +564,12 @@ def build_session_summary(
     If *session_dir* is given the session name is extracted from
     ``plan.md`` when present.
     """
-    fp = _first_pass(events)
-    name = _extract_session_name(session_dir) if session_dir else None
-
-    if fp.all_shutdowns:
-        resume = _detect_resume(events, fp.all_shutdowns)
-        return _build_completed_summary(fp, name, resume, events_path=events_path)
-
-    return _build_active_summary(fp, name, config_path, events_path=events_path)
+    return _build_session_summary_with_meta(
+        events,
+        session_dir=session_dir,
+        config_path=config_path,
+        events_path=events_path,
+    ).summary
 
 
 # ---------------------------------------------------------------------------
@@ -564,13 +604,11 @@ def get_all_sessions(base_path: Path | None = None) -> list[SessionSummary]:
     for events_path, file_id in discovered:
         cached = _SESSION_CACHE.get(events_path)
         if cached is not None and cached.file_id == file_id:
-            # Only pure-active sessions (no shutdown metrics) depend on
-            # the config file for their model; resumed sessions derive
-            # their model from the shutdown event.
-            if (
-                cached.config_model is not None
-                and cached.config_model != current_config_model
-            ):
+            # Only sessions whose model was sourced from config need
+            # invalidation when the config changes.  Sessions that
+            # derived their model from events or shutdown data are
+            # immune to config edits.
+            if cached.depends_on_config and cached.config_model != current_config_model:
                 pass  # stale config — fall through to re-parse
             else:
                 plan_id = _safe_file_identity(events_path.parent / "plan.md")
@@ -578,7 +616,11 @@ def get_all_sessions(base_path: Path | None = None) -> list[SessionSummary]:
                     fresh_name = _extract_session_name(events_path.parent)
                     summary = cached.summary.model_copy(update={"name": fresh_name})
                     _SESSION_CACHE[events_path] = _CachedSession(
-                        file_id, plan_id, cached.config_model, summary
+                        file_id,
+                        plan_id,
+                        cached.config_model,
+                        cached.depends_on_config,
+                        summary,
                     )
                 else:
                     summary = cached.summary
@@ -591,16 +633,16 @@ def get_all_sessions(base_path: Path | None = None) -> list[SessionSummary]:
             continue
         if not events:
             continue
-        summary = build_session_summary(
+        meta = _build_session_summary_with_meta(
             events, session_dir=events_path.parent, events_path=events_path
         )
+        summary = meta.summary
         plan_id = _safe_file_identity(events_path.parent / "plan.md")
         _SESSION_CACHE[events_path] = _CachedSession(
             file_id,
             plan_id,
-            current_config_model
-            if summary.is_active and not summary.has_shutdown_metrics
-            else None,
+            current_config_model if meta.used_config_fallback else None,
+            meta.used_config_fallback,
             summary,
         )
         summaries.append(summary)

--- a/tests/copilot_usage/test_parser.py
+++ b/tests/copilot_usage/test_parser.py
@@ -4549,7 +4549,7 @@ class TestSessionCacheMtime:
             assert spy.call_count == 2
 
     def test_resumed_session_is_cached(self, tmp_path: Path) -> None:
-        """A session that resumed after shutdown IS cached with config_model."""
+        """A session that resumed after shutdown IS cached with config_model=None (model from shutdown)."""
         start = json.dumps(
             {
                 "type": "session.start",
@@ -4714,15 +4714,24 @@ class TestActiveSessionCaching:
         p = tmp_path / "active-sess" / "events.jsonl"
         _write_events(p, *events_lines)
 
+        config = tmp_path / "config.json"
+        config.write_text('{"model": "gpt-5.1"}', encoding="utf-8")
+
         # First call — must parse
-        with patch("copilot_usage.parser.parse_events", wraps=parse_events) as spy:
+        with (
+            patch("copilot_usage.parser._CONFIG_PATH", config),
+            patch("copilot_usage.parser.parse_events", wraps=parse_events) as spy,
+        ):
             result1 = get_all_sessions(tmp_path)
             assert len(result1) == 1
             assert result1[0].is_active is True
             assert spy.call_count == 1
 
         # Second call — no file changes, should use cache
-        with patch("copilot_usage.parser.parse_events", wraps=parse_events) as spy:
+        with (
+            patch("copilot_usage.parser._CONFIG_PATH", config),
+            patch("copilot_usage.parser.parse_events", wraps=parse_events) as spy,
+        ):
             result2 = get_all_sessions(tmp_path)
             assert len(result2) == 1
             assert result2[0].is_active is True
@@ -4787,4 +4796,62 @@ class TestActiveSessionCaching:
 
         entry = _SESSION_CACHE[p]
         assert entry.config_model is None
+        assert entry.depends_on_config is False
         assert entry.summary.is_active is False
+
+    def test_active_session_config_none_to_real_invalidates(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Cache invalidates when config transitions from None to a real model."""
+        config = tmp_path / "config.json"
+        # Start with no config file → config model is None
+        p = tmp_path / "sessions" / "s1" / "events.jsonl"
+        _write_events(p, _START_EVENT, _USER_MSG, _ASSISTANT_MSG)
+
+        with patch("copilot_usage.parser._CONFIG_PATH", config):
+            result1 = get_all_sessions(tmp_path / "sessions")
+            assert len(result1) == 1
+            assert result1[0].model is None
+
+            entry = _SESSION_CACHE[p]
+            assert entry.depends_on_config is True
+            assert entry.config_model is None
+
+            # Now create a config with a model
+            config.write_text('{"model": "gpt-5.1"}', encoding="utf-8")
+
+            with patch("copilot_usage.parser.parse_events", wraps=parse_events) as spy:
+                result2 = get_all_sessions(tmp_path / "sessions")
+                assert len(result2) == 1
+                assert result2[0].model == "gpt-5.1"
+                assert spy.call_count == 1
+
+    def test_active_session_with_event_model_not_invalidated_by_config(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Active sessions whose model comes from events ignore config changes."""
+        config = tmp_path / "config.json"
+        config.write_text('{"model": "gpt-5.1"}', encoding="utf-8")
+
+        # _TOOL_EXEC has model "claude-sonnet-4" in its data
+        p = tmp_path / "sessions" / "s1" / "events.jsonl"
+        _write_events(p, _START_EVENT, _USER_MSG, _ASSISTANT_MSG, _TOOL_EXEC)
+
+        with patch("copilot_usage.parser._CONFIG_PATH", config):
+            result1 = get_all_sessions(tmp_path / "sessions")
+            assert len(result1) == 1
+            assert result1[0].model == "claude-sonnet-4"
+
+            entry = _SESSION_CACHE[p]
+            assert entry.depends_on_config is False
+
+            # Change config — should NOT trigger re-parse
+            config.write_text('{"model": "gpt-5.2"}', encoding="utf-8")
+
+            with patch("copilot_usage.parser.parse_events", wraps=parse_events) as spy:
+                result2 = get_all_sessions(tmp_path / "sessions")
+                assert len(result2) == 1
+                assert result2[0].model == "claude-sonnet-4"
+                assert spy.call_count == 0


### PR DESCRIPTION
Closes #552

## Problem

`_SESSION_CACHE` only stored **completed** (non-active) sessions. Every call to `get_all_sessions()` unconditionally re-parsed all active sessions — JSON-decoding every line, running Pydantic validation, and iterating the event list twice (`_first_pass` + `_detect_resume`). In the interactive loop this runs on every debounced file-change event (≥ every 2s), making refresh latency O(n_events) for active sessions even when their `events.jsonl` hasn't changed.

## Fix

- **Added `config_model` field to `_CachedSession`** — stores the config model used during parsing (`None` for non-active sessions).
- **`get_all_sessions` now reads the config model once** at the start via `_read_config_model(None)` and caches active sessions alongside their `config_model`.
- **Cache hit logic**: for active sessions, the cache requires both `file_id` match AND `config_model` match; if the user edits `~/.copilot/config.json`, the stale cache entry is invalidated and the session is re-parsed.
- **All sessions are now cached** (active, resumed, and completed), reducing per-refresh latency from O(n_events) to O(1) for unchanged files.

## Tests

- `test_active_session_parse_events_called_once`: Creates a 200-event active session, calls `get_all_sessions` twice without file changes, asserts `parse_events` is called exactly once.
- `test_active_session_cache_invalidated_on_config_change`: Verifies cache is invalidated when config model changes.
- `test_active_session_cache_hit_on_unchanged_config`: Verifies cache hit when config is unchanged.
- `test_completed_session_config_model_none_in_cache`: Verifies completed sessions store `config_model=None`.
- Updated `test_resumed_session_is_cached` to reflect that active sessions are now cached.




> Generated by [Issue Implementer](https://github.com/microsasa/cli-tools/actions/runs/23764661113/agentic_workflow) · [◷](https://github.com/search?q=repo%3Amicrosasa%2Fcli-tools+%22gh-aw-workflow-id%3A+issue-implementer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Issue Implementer, engine: copilot, model: claude-opus-4.6, id: 23764661113, workflow_id: issue-implementer, run: https://github.com/microsasa/cli-tools/actions/runs/23764661113 -->

<!-- gh-aw-workflow-id: issue-implementer -->