### PR TITLE
fix: make `_FirstPassResult.all_shutdowns` an immutable tuple (#554)

### DIFF
--- a/src/copilot_usage/parser.py
+++ b/src/copilot_usage/parser.py
@@ -251,7 +251,7 @@ class _FirstPassResult:
     end_time: datetime | None
     cwd: str | None
     model: str | None
-    all_shutdowns: list[tuple[int, SessionShutdownData]]
+    all_shutdowns: tuple[tuple[int, SessionShutdownData], ...]
     user_message_count: int
     total_output_tokens: int
     total_turn_starts: int
@@ -282,7 +282,7 @@ def _first_pass(events: list[SessionEvent]) -> _FirstPassResult:
     cwd: str | None = None
     model: str | None = None
     seen_session_start = False
-    all_shutdowns: list[tuple[int, SessionShutdownData]] = []
+    _shutdowns: list[tuple[int, SessionShutdownData]] = []
     user_message_count = 0
     total_output_tokens = 0
     total_turn_starts = 0
@@ -320,7 +320,7 @@ def _first_pass(events: list[SessionEvent]) -> _FirstPassResult:
             current_model = ev.currentModel or data.currentModel
             if not current_model and data.modelMetrics:
                 current_model = _infer_model_from_metrics(data.modelMetrics)
-            all_shutdowns.append((idx, data))
+            _shutdowns.append((idx, data))
             end_time = ev.timestamp
             model = current_model
 
@@ -353,7 +353,7 @@ def _first_pass(events: list[SessionEvent]) -> _FirstPassResult:
         end_time=end_time,
         cwd=cwd,
         model=model,
-        all_shutdowns=all_shutdowns,
+        all_shutdowns=tuple(_shutdowns),
         user_message_count=user_message_count,
         total_output_tokens=total_output_tokens,
         total_turn_starts=total_turn_starts,
@@ -363,7 +363,7 @@ def _first_pass(events: list[SessionEvent]) -> _FirstPassResult:
 
 def _detect_resume(
     events: list[SessionEvent],
-    all_shutdowns: list[tuple[int, SessionShutdownData]],
+    all_shutdowns: tuple[tuple[int, SessionShutdownData], ...],
 ) -> _ResumeInfo:
     """Scan events after the last shutdown for resume indicators."""
     if not all_shutdowns:

--- a/tests/copilot_usage/test_parser.py
+++ b/tests/copilot_usage/test_parser.py
@@ -4107,8 +4107,17 @@ class TestFirstPassDirect:
         _write_events(p, _START_EVENT, _USER_MSG, bad_shutdown)
         events = parse_events(p)
         result = _first_pass(events)
-        assert result.all_shutdowns == []
+        assert result.all_shutdowns == ()
         assert result.session_id == "test-session-001"
+
+    def test_all_shutdowns_is_tuple(self, tmp_path: Path) -> None:
+        """_first_pass returns all_shutdowns as an immutable tuple."""
+        p = tmp_path / "s" / "events.jsonl"
+        _write_events(p, _START_EVENT, _USER_MSG, _SHUTDOWN_EVENT)
+        events = parse_events(p)
+        fp = _first_pass(events)
+        assert isinstance(fp.all_shutdowns, tuple)
+        assert len(fp.all_shutdowns) == 1
 
 
 # ---------------------------------------------------------------------------
@@ -4121,7 +4130,7 @@ class TestDetectResumeDirect:
 
     def test_empty_shutdowns_returns_zeroed(self) -> None:
         """No shutdowns → zeroed _ResumeInfo."""
-        result = _detect_resume(events=[], all_shutdowns=[])
+        result = _detect_resume(events=[], all_shutdowns=())
         assert result.session_resumed is False
         assert result.post_shutdown_output_tokens == 0
         assert result.post_shutdown_turn_starts == 0


### PR DESCRIPTION
Closes #554

## Problem

`_FirstPassResult` is decorated with `@dataclasses.dataclass(frozen=True, slots=True)` but its `all_shutdowns` field was typed as `list[tuple[int, SessionShutdownData]]` — a mutable collection. Python's `frozen=True` only prevents reassignment; the list itself could still be mutated, violating the immutability contract.

## Changes

- **`_FirstPassResult.all_shutdowns`** — changed type from `list` to `tuple[tuple[int, SessionShutdownData], ...]`
- **`_first_pass()`** — builds a local `_shutdowns` list during iteration, converts to `tuple()` when constructing the result
- **`_detect_resume()`** — updated parameter type from `list` to `tuple`
- **Tests** — added `test_all_shutdowns_is_tuple` to pin the invariant; fixed existing test that passed `[]` to `_detect_resume` (now `()`)

## Verification

All 936 tests pass, pyright reports 0 errors, ruff clean, coverage 99.5%.




> Generated by [Issue Implementer](https://github.com/microsasa/cli-tools/actions/runs/23770487187/agentic_workflow) · [◷](https://github.com/search?q=repo%3Amicrosasa%2Fcli-tools+%22gh-aw-workflow-id%3A+issue-implementer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Issue Implementer, engine: copilot, model: claude-opus-4.6, id: 23770487187, workflow_id: issue-implementer, run: https://github.com/microsasa/cli-tools/actions/runs/23770487187 -->

<!-- gh-aw-workflow-id: issue-implementer -->