### PR TITLE
fix: add missing `Final` annotations and remove string annotation `"loguru.Record"` (#555)

### DIFF
--- a/src/copilot_usage/logging_config.py
+++ b/src/copilot_usage/logging_config.py
@@ -1,5 +1,7 @@
 """Logging configuration — console-only for CLI tool."""
 
+from __future__ import annotations
+
 import sys
 from typing import Final
 
@@ -24,7 +26,7 @@ CONSOLE_FORMAT: Final[str] = (
 )
 
 
-def _emoji_patcher(record: "loguru.Record") -> None:
+def _emoji_patcher(record: loguru.Record) -> None:
     """Inject a level-specific emoji into the log record's extras."""
     record["extra"]["emoji"] = LEVEL_EMOJI.get(record["level"].name, "  ")
 

--- a/src/copilot_usage/pricing.py
+++ b/src/copilot_usage/pricing.py
@@ -16,7 +16,7 @@ from typing import Final
 
 from pydantic import BaseModel
 
-__all__: list[str] = [
+__all__: Final[list[str]] = [
     "ModelPricing",
     "PricingTier",
     "KNOWN_PRICING",

--- a/src/copilot_usage/render_detail.py
+++ b/src/copilot_usage/render_detail.py
@@ -10,6 +10,7 @@ that external callers see no change.
 
 from collections.abc import Callable
 from datetime import UTC, datetime, timedelta
+from typing import Final
 
 from loguru import logger
 from pydantic import ValidationError
@@ -36,7 +37,7 @@ from copilot_usage.models import (
     total_output_tokens,
 )
 
-__all__ = ["render_session_detail"]
+__all__: Final[list[str]] = ["render_session_detail"]
 
 # ---------------------------------------------------------------------------
 # Session detail helpers

--- a/src/copilot_usage/report.py
+++ b/src/copilot_usage/report.py
@@ -12,6 +12,7 @@ import warnings
 from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import UTC, datetime
+from typing import Final
 
 from rich.console import Console
 from rich.panel import Panel
@@ -36,7 +37,7 @@ from copilot_usage.models import (
 from copilot_usage.pricing import lookup_model_pricing
 from copilot_usage.render_detail import render_session_detail
 
-__all__ = [
+__all__: Final[list[str]] = [
     "format_duration",
     "format_tokens",
     "render_cost_view",

--- a/src/copilot_usage/vscode_parser.py
+++ b/src/copilot_usage/vscode_parser.py
@@ -7,10 +7,11 @@ from collections import defaultdict
 from dataclasses import dataclass, field
 from datetime import date, datetime
 from pathlib import Path
+from typing import Final
 
 from loguru import logger
 
-__all__ = [
+__all__: Final[list[str]] = [
     "CCREQ_RE",
     "VSCodeLogSummary",
     "VSCodeRequest",
@@ -20,7 +21,7 @@ __all__ = [
     "parse_vscode_log",
 ]
 
-CCREQ_RE = re.compile(
+CCREQ_RE: Final[re.Pattern[str]] = re.compile(
     r"^(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d+) \[info\] "
     r"ccreq:(\w+)\.copilotmd \| success \| "
     r"(\S+?)(?:\s*->\s*\S+)? \| "

--- a/src/copilot_usage/vscode_report.py
+++ b/src/copilot_usage/vscode_report.py
@@ -11,7 +11,7 @@ from copilot_usage._formatting import format_duration
 from copilot_usage.pricing import lookup_model_pricing
 from copilot_usage.vscode_parser import VSCodeLogSummary
 
-__all__ = ["render_vscode_summary"]
+__all__: Final[list[str]] = ["render_vscode_summary"]
 
 _DAILY_ACTIVITY_LIMIT: Final[int] = 14
 


### PR DESCRIPTION
Closes #555

## Changes

Addresses coding guideline violations for `Final` annotations and string annotations:

### 1. `logging_config.py` — Remove string annotation `"loguru.Record"`
Replaced `"loguru.Record"` with `loguru.Record` (unquoted). Since `loguru.Record` is a stub-only `TypedDict` not available at runtime, added `from __future__ import annotations` to defer annotation evaluation. The `import loguru` remains a real runtime import — only the evaluation of the annotation is deferred.

### 2. `vscode_parser.py` — `CCREQ_RE` missing `Final`
Added `Final[re.Pattern[str]]` annotation to the module-level compiled regex constant.

### 3. `__all__` declarations — Add `Final` across 5 modules
Added `Final[list[str]]` to `__all__` in:
- `pricing.py` (was typed but not `Final`)
- `render_detail.py` (was untyped)
- `report.py` (was untyped)
- `vscode_parser.py` (was untyped)
- `vscode_report.py` (was untyped)

## Verification

All checks pass locally:
- `ruff check` — 0 errors
- `ruff format` — no changes needed
- `pyright` — 0 errors, 3 pre-existing warnings
- `pytest --cov --cov-fail-under=80` — 936 passed, 99.50% coverage




> Generated by [Issue Implementer](https://github.com/microsasa/cli-tools/actions/runs/23770995098/agentic_workflow) · [◷](https://github.com/search?q=repo%3Amicrosasa%2Fcli-tools+%22gh-aw-workflow-id%3A+issue-implementer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Issue Implementer, engine: copilot, model: claude-opus-4.6, id: 23770995098, workflow_id: issue-implementer, run: https://github.com/microsasa/cli-tools/actions/runs/23770995098 -->

<!-- gh-aw-workflow-id: issue-implementer -->