### PR TITLE
test: add direct unit tests for copy_model_metrics (#561)

### DIFF
--- a/tests/copilot_usage/test_models.py
+++ b/tests/copilot_usage/test_models.py
@@ -293,22 +293,21 @@ class TestCopyModelMetrics:
     """Unit tests for the copy_model_metrics helper."""
 
     def test_returns_equal_value(self) -> None:
+        """All fields are faithfully copied, including any future additions."""
+        # Build kwargs with non-default values for every field so newly-added
+        # fields are automatically covered by the model_dump() comparison.
+        req_kwargs = {
+            name: idx + 1 for idx, name in enumerate(RequestMetrics.model_fields)
+        }
+        usage_kwargs = {
+            name: (idx + 1) * 100 for idx, name in enumerate(TokenUsage.model_fields)
+        }
         mm = ModelMetrics(
-            requests=RequestMetrics(count=5, cost=3),
-            usage=TokenUsage(
-                inputTokens=100,
-                outputTokens=50,
-                cacheReadTokens=20,
-                cacheWriteTokens=10,
-            ),
+            requests=RequestMetrics(**req_kwargs),
+            usage=TokenUsage(**usage_kwargs),
         )
         result = copy_model_metrics(mm)
-        assert result.requests.count == 5
-        assert result.requests.cost == 3
-        assert result.usage.inputTokens == 100
-        assert result.usage.outputTokens == 50
-        assert result.usage.cacheReadTokens == 20
-        assert result.usage.cacheWriteTokens == 10
+        assert result.model_dump() == mm.model_dump()
 
     def test_requests_copy_is_independent(self) -> None:
         """Mutating the copy's requests must not affect the original."""
@@ -347,15 +346,11 @@ class TestCopyModelMetrics:
         assert copy.requests.count == 5
 
     def test_defaults_copied_correctly(self) -> None:
-        """Default (zero) values are preserved in the copy."""
+        """Default (zero) values are preserved in the copy for all fields."""
         mm = ModelMetrics()
         copy = copy_model_metrics(mm)
-        assert copy.requests.count == 0
-        assert copy.requests.cost == 0
-        assert copy.usage.inputTokens == 0
-        assert copy.usage.outputTokens == 0
-        assert copy.usage.cacheReadTokens == 0
-        assert copy.usage.cacheWriteTokens == 0
+        # Ensure *all* default values (including any future fields) are preserved
+        assert copy.model_dump() == mm.model_dump()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #561

## What

Adds a `TestCopyModelMetrics` class in `tests/copilot_usage/test_models.py` with five focused tests for the `copy_model_metrics()` helper:

| Test | What it asserts |
|---|---|
| `test_returns_equal_value` | All fields are faithfully copied |
| `test_requests_copy_is_independent` | Mutating the copy's `RequestMetrics` doesn't affect the original |
| `test_usage_copy_is_independent` | Mutating the copy's `TokenUsage` doesn't affect the original |
| `test_original_is_independent_of_copy_mutations` | Mutating the original doesn't affect the copy |
| `test_defaults_copied_correctly` | Default (zero) values are preserved |

## Why

`copy_model_metrics()` is a performance-critical public helper used in `merge_model_metrics`, `_aggregate_model_metrics`, and the caching layer. Its correctness contract — that the returned instance is entirely independent of the input — was never directly asserted. These tests catch silent field-omission bugs when `TokenUsage` or `RequestMetrics` gain new fields.

## Verification

All CI checks pass locally:
- `ruff check` ✅
- `ruff format` ✅
- `pyright` ✅ (0 errors)
- `pytest --cov --cov-fail-under=80` ✅ (941 passed, 99.50% coverage)




> Generated by [Issue Implementer](https://github.com/microsasa/cli-tools/actions/runs/23781224454/agentic_workflow) · [◷](https://github.com/search?q=repo%3Amicrosasa%2Fcli-tools+%22gh-aw-workflow-id%3A+issue-implementer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Issue Implementer, engine: copilot, model: claude-opus-4.6, id: 23781224454, workflow_id: issue-implementer, run: https://github.com/microsasa/cli-tools/actions/runs/23781224454 -->

<!-- gh-aw-workflow-id: issue-implementer -->