### PR TITLE
fix: address three code quality issues (#566)

### DIFF
--- a/src/copilot_usage/logging_config.py
+++ b/src/copilot_usage/logging_config.py
@@ -1,7 +1,5 @@
 """Logging configuration — console-only for CLI tool."""
 
-from __future__ import annotations
-
 import sys
 from typing import Final
 
@@ -26,7 +24,7 @@ CONSOLE_FORMAT: Final[str] = (
 )
 
 
-def _emoji_patcher(record: loguru.Record) -> None:
+def _emoji_patcher(record: "loguru.Record") -> None:
     """Inject a level-specific emoji into the log record's extras."""
     record["extra"]["emoji"] = LEVEL_EMOJI.get(record["level"].name, "  ")
 

--- a/src/copilot_usage/models.py
+++ b/src/copilot_usage/models.py
@@ -5,17 +5,13 @@ These models provide typed parsing for all known event types plus a
 flexible fallback for unknown ones.
 """
 
+import builtins
 from datetime import UTC, datetime
 from enum import StrEnum
 from pathlib import Path
 from typing import Final
 
 from pydantic import BaseModel, Field, model_validator
-
-# Defensive alias for the built-in ``type`` to avoid shadowing by the
-# Pydantic field ``type: str`` defined on SessionEvent (and any future
-# class in this module that follows the same pattern).
-_type = type
 
 # ---------------------------------------------------------------------------
 # Shared datetime utilities
@@ -273,7 +269,9 @@ class SessionEvent(BaseModel):
             case _:
                 return GenericEventData.model_validate(self.data)
 
-    def _as[T: BaseModel](self, expected_type: EventType, model_cls: _type[T]) -> T:
+    def _as[T: BaseModel](
+        self, expected_type: EventType, model_cls: builtins.type[T]
+    ) -> T:
         """Validate event type and return parsed data.
 
         Raises:

--- a/src/copilot_usage/vscode_parser.py
+++ b/src/copilot_usage/vscode_parser.py
@@ -190,9 +190,13 @@ def _finalize_summary(acc: _SummaryAccumulator) -> VSCodeLogSummary:
     )
 
 
-def build_vscode_summary(requests: list[VSCodeRequest]) -> VSCodeLogSummary:
+def build_vscode_summary(
+    requests: list[VSCodeRequest],
+    *,
+    log_files_parsed: int = 0,
+) -> VSCodeLogSummary:
     """Aggregate a list of parsed requests into a summary."""
-    acc = _SummaryAccumulator()
+    acc = _SummaryAccumulator(log_files_parsed=log_files_parsed)
     _update_vscode_summary(acc, requests)
     return _finalize_summary(acc)
 

--- a/tests/copilot_usage/test_vscode_parser.py
+++ b/tests/copilot_usage/test_vscode_parser.py
@@ -207,6 +207,14 @@ class TestBuildVscodeSummary:
         assert summary.first_timestamp is None
         assert summary.last_timestamp is None
 
+    def test_log_files_parsed_default_is_zero(self) -> None:
+        summary = build_vscode_summary(self._make_requests())
+        assert summary.log_files_parsed == 0
+
+    def test_log_files_parsed_keyword(self) -> None:
+        summary = build_vscode_summary(self._make_requests(), log_files_parsed=3)
+        assert summary.log_files_parsed == 3
+
 
 # ---------------------------------------------------------------------------
 # discover_vscode_logs — platform defaults


### PR DESCRIPTION
Closes #566

Three independent code quality fixes:

### 1. Remove `from __future__ import annotations` from `logging_config.py`

The `from __future__ import annotations` import (PEP 563) postpones annotation evaluation, violating the coding guideline that bans `TYPE_CHECKING` guards for the same reason. Removed the future import and switched the `loguru.Record` annotation to a string literal since `Record` is a type-only export not available at runtime.

### 2. Replace dead `_type = type` alias in `models.py`

The `_type = type` alias worked around class-level `type: str` shadowing the builtin `type` in method signatures. Instead of the ad-hoc alias, the method now uses `builtins.type[T]` which is explicit and standard. The `import builtins` is a stdlib import with no overhead.

### 3. Add `log_files_parsed` keyword to `build_vscode_summary`

`build_vscode_summary()` always returned `log_files_parsed=0` because it had no way to receive that count. Added an optional `log_files_parsed` keyword parameter (default `0`) to preserve backward compatibility while allowing callers to pass the correct count.

### Testing

- All 957 existing tests pass
- Added two new tests: `test_log_files_parsed_default_is_zero` and `test_log_files_parsed_keyword`
- Coverage: 99.39% (well above 80% threshold)
- `ruff check`, `ruff format`, and `pyright` all pass cleanly




> Generated by [Issue Implementer](https://github.com/microsasa/cli-tools/actions/runs/23784214456/agentic_workflow) · [◷](https://github.com/search?q=repo%3Amicrosasa%2Fcli-tools+%22gh-aw-workflow-id%3A+issue-implementer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Issue Implementer, engine: copilot, model: claude-opus-4.6, id: 23784214456, workflow_id: issue-implementer, run: https://github.com/microsasa/cli-tools/actions/runs/23784214456 -->

<!-- gh-aw-workflow-id: issue-implementer -->