### PR TITLE
perf: single-pass date range in _render_summary_header (#574)

### DIFF
--- a/src/copilot_usage/report.py
+++ b/src/copilot_usage/report.py
@@ -266,13 +266,19 @@ def _render_summary_header(
     *sessions* must be non-empty — callers are responsible for the
     empty-list check.
     """
-    start_times = [
-        ensure_aware(s.start_time) for s in sessions if s.start_time is not None
-    ]
-    if start_times:
-        earliest = min(start_times).strftime("%Y-%m-%d")
-        latest = max(start_times).strftime("%Y-%m-%d")
-        subtitle = f"{earliest}  →  {latest}"
+    earliest: datetime | None = None
+    latest: datetime | None = None
+    for s in sessions:
+        if s.start_time is None:
+            continue
+        aware = ensure_aware(s.start_time)
+        if earliest is None or aware < earliest:
+            earliest = aware
+        if latest is None or aware > latest:
+            latest = aware
+
+    if earliest is not None and latest is not None:
+        subtitle = f"{earliest.strftime('%Y-%m-%d')}  →  {latest.strftime('%Y-%m-%d')}"
     else:
         subtitle = "dates unavailable"
     console.print()

--- a/tests/copilot_usage/test_report.py
+++ b/tests/copilot_usage/test_report.py
@@ -5108,3 +5108,77 @@ class TestMergeAndAggregateConsistency:
             a = aggregated[model_name]
             # Compare full ModelMetrics contents to catch any future field additions
             assert m.model_dump() == a.model_dump()
+
+
+# ---------------------------------------------------------------------------
+# Issue #574 — _render_summary_header single-pass date range
+# ---------------------------------------------------------------------------
+
+
+class TestRenderSummaryHeaderSinglePass:
+    """Single-pass _render_summary_header finds correct earliest/latest dates."""
+
+    def test_large_random_order_sessions(self) -> None:
+        """≥100 sessions in random order produce the correct date range."""
+        import random
+
+        rng = random.Random(42)  # noqa: S311
+        base = datetime(2024, 1, 1, tzinfo=UTC)
+        days = list(range(365))
+        rng.shuffle(days)
+        selected = days[:120]
+
+        sessions = [
+            _make_summary_session(
+                session_id=f"s-{i}",
+                start_time=base + timedelta(days=d),
+            )
+            for i, d in enumerate(selected)
+        ]
+
+        expected_earliest = (base + timedelta(days=min(selected))).strftime("%Y-%m-%d")
+        expected_latest = (base + timedelta(days=max(selected))).strftime("%Y-%m-%d")
+
+        output = _capture_summary(sessions)
+        assert f"{expected_earliest}  →  {expected_latest}" in output
+
+    def test_none_start_times_interspersed(self) -> None:
+        """None start_time entries mixed in still yield correct range."""
+        sessions = [
+            SessionSummary(session_id="none-1", start_time=None),
+            _make_summary_session(
+                session_id="mid",
+                start_time=datetime(2025, 6, 15, tzinfo=UTC),
+            ),
+            SessionSummary(session_id="none-2", start_time=None),
+            _make_summary_session(
+                session_id="early",
+                start_time=datetime(2025, 1, 10, tzinfo=UTC),
+            ),
+            SessionSummary(session_id="none-3", start_time=None),
+            _make_summary_session(
+                session_id="late",
+                start_time=datetime(2025, 12, 25, tzinfo=UTC),
+            ),
+        ]
+        output = _capture_summary(sessions)
+        assert "2025-01-10  →  2025-12-25" in output
+
+    def test_all_none_start_times(self) -> None:
+        """All-None start_time produces 'dates unavailable'."""
+        sessions = [
+            SessionSummary(session_id=f"none-{i}", start_time=None) for i in range(5)
+        ]
+        output = _capture_summary(sessions)
+        assert "dates unavailable" in output
+
+    def test_single_session_same_earliest_latest(self) -> None:
+        """Single session shows same date for both endpoints."""
+        sessions = [
+            _make_summary_session(
+                session_id="only",
+                start_time=datetime(2025, 7, 4, tzinfo=UTC),
+            ),
+        ]
+        output = _capture_summary(sessions)
+        assert "2025-07-04  →  2025-07-04" in output


### PR DESCRIPTION
Closes #574

## What changed

Replaced the three-pass list traversal in `_render_summary_header` (build list → `min()` → `max()`) with a single-pass accumulator that tracks both `earliest` and `latest` timestamps without allocating an intermediate list.

**Before (3 passes):**
```python
start_times = [ensure_aware(s.start_time) for s in sessions if s.start_time is not None]
if start_times:
    earliest = min(start_times).strftime("%Y-%m-%d")
    latest = max(start_times).strftime("%Y-%m-%d")
```

**After (1 pass):**
```python
earliest: datetime | None = None
latest: datetime | None = None
for s in sessions:
    if s.start_time is None:
        continue
    aware = ensure_aware(s.start_time)
    if earliest is None or aware < earliest:
        earliest = aware
    if latest is None or aware > latest:
        latest = aware
```

## Tests added

New `TestRenderSummaryHeaderSinglePass` class with 4 tests:
- **random order** — 120 sessions with shuffled dates, asserts correct min/max
- **interspersed None** — `None` start_times mixed with valid dates
- **all None** — verifies "dates unavailable" fallback
- **single session** — same date for both endpoints

All 962 tests pass, coverage at 99.4%.




> Generated by [Issue Implementer](https://github.com/microsasa/cli-tools/actions/runs/23790127687/agentic_workflow) · [◷](https://github.com/search?q=repo%3Amicrosasa%2Fcli-tools+%22gh-aw-workflow-id%3A+issue-implementer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Issue Implementer, engine: copilot, model: claude-opus-4.6, id: 23790127687, workflow_id: issue-implementer, run: https://github.com/microsasa/cli-tools/actions/runs/23790127687 -->

<!-- gh-aw-workflow-id: issue-implementer -->