### PR TITLE
fix: reset to home on auto-refresh when detail view has no session_id (#577)

### DIFF
--- a/src/copilot_usage/cli.py
+++ b/src/copilot_usage/cli.py
@@ -289,6 +289,12 @@ def _interactive_loop(path: Path | None) -> None:
                             _print_version_header(console)
                             _show_session_by_index(console, sessions, detail_idx + 1)
                             _write_prompt(_BACK_PROMPT)
+                    else:
+                        # detail view with no valid session — reset to home
+                        view = "home"
+                        detail_session_id = None
+                        _draw_home(console, sessions)
+                        _write_prompt(_HOME_PROMPT)
                 except KeyboardInterrupt:
                     raise
                 except Exception:

--- a/tests/copilot_usage/test_cli.py
+++ b/tests/copilot_usage/test_cli.py
@@ -1332,6 +1332,92 @@ def test_auto_refresh_detail_session_id_none(tmp_path: Path, monkeypatch: Any) -
 
 
 # ---------------------------------------------------------------------------
+# Issue #577 — auto-refresh drops prompt when view=detail & session_id=None
+# ---------------------------------------------------------------------------
+
+
+def test_interactive_invalid_number_then_file_change(
+    tmp_path: Path, monkeypatch: Any
+) -> None:
+    """Prompt must be written on file-change when stuck in detail view with no session_id.
+
+    Regression test for #577: entering an out-of-range session number sets
+    view="detail" with detail_session_id=None.  A subsequent file-change event
+    must reset to the home view and write a prompt instead of silently dropping it.
+    """
+    _write_session(tmp_path, "issue577-0000-0000-0000-000000000000", name="Issue577")
+
+    import copilot_usage.cli as cli_mod
+
+    draw_home_calls: list[int] = []
+    orig_draw_home = cli_mod._draw_home  # pyright: ignore[reportPrivateUsage]
+
+    def _tracking_draw_home(console: Console, sessions: list[Any]) -> None:
+        draw_home_calls.append(1)
+        orig_draw_home(console, sessions)
+
+    monkeypatch.setattr(cli_mod, "_draw_home", _tracking_draw_home)
+
+    prompt_calls: list[str] = []
+    orig_write_prompt = cli_mod._write_prompt  # pyright: ignore[reportPrivateUsage]
+
+    def _tracking_prompt(prompt: str) -> None:
+        prompt_calls.append(prompt)
+        orig_write_prompt(prompt)
+
+    monkeypatch.setattr(cli_mod, "_write_prompt", _tracking_prompt)
+
+    captured_event: list[threading.Event] = []
+
+    def _capturing_start(
+        session_path: Path,
+        change_event: threading.Event,  # noqa: ARG001
+    ) -> None:
+        captured_event.append(change_event)
+        return
+
+    monkeypatch.setattr(cli_mod, "_start_observer", _capturing_start)
+
+    call_count = 0
+
+    def _fake_read(timeout: float = 0.5) -> str | None:  # noqa: ARG001
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            return "99"  # invalid session number → view=detail, session_id=None
+        if call_count == 2:
+            # Trigger file-change while in detail view with session_id=None
+            if captured_event:
+                captured_event[0].set()
+            return None
+        if call_count == 3:
+            return None  # let auto-refresh fire
+        return "q"
+
+    monkeypatch.setattr(cli_mod, "_read_line_nonblocking", _fake_read)
+
+    runner = CliRunner()
+    result = runner.invoke(main, ["--path", str(tmp_path)])
+    assert result.exit_code == 0
+
+    # _draw_home must be called after the file-change event resets to home
+    # Calls: initial render + auto-refresh reset = at least 2
+    assert len(draw_home_calls) >= 2
+
+    # A prompt must have been written after the auto-refresh reset
+    # (The last prompt before quit should be _HOME_PROMPT from the reset)
+    home_prompts_after_back = [
+        p
+        for p in prompt_calls
+        if "session #" in p  # _HOME_PROMPT contains "session #"
+    ]
+    assert len(home_prompts_after_back) >= 2, (
+        "Expected _HOME_PROMPT written after auto-refresh reset; "
+        f"got prompts: {prompt_calls}"
+    )
+
+
+# ---------------------------------------------------------------------------
 # Issue #441 — detail view tracks session by ID, not positional index
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Closes #577

## Problem

When a user enters an out-of-range session number in interactive mode (e.g., `99` with only 3 sessions), `view` is set to `"detail"` with `detail_session_id = None`. If a file-change event fires in this state, the auto-refresh handler's three branches all evaluate to `False`:

- `view == "home"` → False
- `view == "cost"` → False  
- `view == "detail" and detail_session_id is not None` → False (session_id **is** None)

No prompt is written, leaving the terminal frozen until the user presses a key.

## Fix

Added an `else` clause after the `detail` branch in the auto-refresh handler that resets to the home view and writes `_HOME_PROMPT`. This is consistent with how user input already handles this invalid state.

## Testing

Added `test_interactive_invalid_number_then_file_change` regression test that:
1. Enters an invalid session number (`99`)
2. Triggers a file-change event while in the broken state
3. Asserts `_draw_home` is called (view resets to home)
4. Asserts `_HOME_PROMPT` is written (terminal stays usable)

All 970 tests pass. Coverage remains at 99%.




> Generated by [Issue Implementer](https://github.com/microsasa/cli-tools/actions/runs/23792315325/agentic_workflow) · [◷](https://github.com/search?q=repo%3Amicrosasa%2Fcli-tools+%22gh-aw-workflow-id%3A+issue-implementer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Issue Implementer, engine: copilot, model: claude-opus-4.6, id: 23792315325, workflow_id: issue-implementer, run: https://github.com/microsasa/cli-tools/actions/runs/23792315325 -->

<!-- gh-aw-workflow-id: issue-implementer -->