### PR TITLE
fix: move vscode deferred imports to module level and add happy-path test (#578)

### DIFF
--- a/src/copilot_usage/cli.py
+++ b/src/copilot_usage/cli.py
@@ -37,6 +37,8 @@ from copilot_usage.report import (
     render_summary,
     session_display_name,
 )
+from copilot_usage.vscode_parser import get_vscode_summary
+from copilot_usage.vscode_report import render_vscode_summary
 
 type _View = Literal["home", "detail", "cost"]
 
@@ -590,9 +592,6 @@ def live(ctx: click.Context, path: Path | None) -> None:
 def vscode(vscode_logs: Path | None) -> None:
     """Show usage from VS Code Copilot Chat logs."""
     _print_version_header()
-    from copilot_usage.vscode_parser import get_vscode_summary
-    from copilot_usage.vscode_report import render_vscode_summary
-
     try:
         summary = get_vscode_summary(vscode_logs)
     except OSError as exc:

--- a/tests/copilot_usage/test_cli.py
+++ b/tests/copilot_usage/test_cli.py
@@ -3042,3 +3042,28 @@ class TestValidateSinceUntil:
         expected_until = dt_before.isoformat(sep=" ", timespec="seconds")
         assert expected_since in msg
         assert expected_until in msg
+
+
+# ---------------------------------------------------------------------------
+# vscode happy-path CLI test
+# ---------------------------------------------------------------------------
+
+
+def test_vscode_command(tmp_path: Path) -> None:
+    """vscode command renders summary for a valid log directory."""
+    log_dir = tmp_path / "session_1" / "window1" / "exthost" / "GitHub.copilot-chat"
+    log_dir.mkdir(parents=True)
+    log_file = log_dir / "GitHub Copilot Chat.log"
+    log_file.write_text(
+        "2026-03-15 10:00:00.123 [info] ccreq:abc.copilotmd | success | "
+        "claude-sonnet-4 | 500ms | [chat]\n",
+    )
+    runner = CliRunner()
+    result = runner.invoke(main, ["vscode", "--vscode-logs", str(tmp_path)])
+    assert result.exit_code == 0
+    output = result.output
+    assert "VS Code Copilot Chat" in output
+    assert "Per-Model Breakdown" in output
+    assert "claude-sonnet-4" in output
+    assert "By Feature" in output
+    assert "Daily Activity" in output

--- a/tests/copilot_usage/test_vscode_parser.py
+++ b/tests/copilot_usage/test_vscode_parser.py
@@ -437,9 +437,7 @@ class TestVscodeCliCommand:
             msg = "Permission denied"
             raise OSError(msg)
 
-        monkeypatch.setattr(
-            "copilot_usage.vscode_parser.get_vscode_summary", _raise_oserror
-        )
+        monkeypatch.setattr("copilot_usage.cli.get_vscode_summary", _raise_oserror)
         runner = CliRunner()
         result = runner.invoke(main, ["vscode", "--vscode-logs", str(tmp_path)])
         assert result.exit_code == 1


### PR DESCRIPTION
Closes #578

## Changes

### 1. Move imports to module level (`src/copilot_usage/cli.py`)

Moved `get_vscode_summary` and `render_vscode_summary` from deferred imports inside the `vscode()` function body to module-level imports, consistent with all other CLI subcommands (`summary`, `session`, `cost`, `live`). Both are first-party modules that are always installed, so there is no startup-time justification for deferring.

### 2. Add happy-path CLI test (`tests/copilot_usage/test_cli.py`)

Added `test_vscode_command` that:
- Creates a minimal VS Code log fixture with a matching `ccreq:` line
- Invokes `main ["vscode", "--vscode-logs", ...]` via `CliRunner`
- Asserts `exit_code == 0`
- Asserts key output sections: `"VS Code Copilot Chat"`, `"Per-Model Breakdown"`, `"claude-sonnet-4"`, `"By Feature"`, `"Daily Activity"`

### 3. Fix monkeypatch target (`tests/copilot_usage/test_vscode_parser.py`)

Updated `test_vscode_oserror_exits_nonzero` to patch `copilot_usage.cli.get_vscode_summary` instead of `copilot_usage.vscode_parser.get_vscode_summary`, since the import now lives at module level in `cli.py`.

## Verification

- `ruff check` ✅
- `ruff format` ✅
- `pyright` ✅ (0 errors)
- `pytest --cov --cov-fail-under=80` ✅ (897 passed, 99.62% coverage)




> Generated by [Issue Implementer](https://github.com/microsasa/cli-tools/actions/runs/23792841891/agentic_workflow) · [◷](https://github.com/search?q=repo%3Amicrosasa%2Fcli-tools+%22gh-aw-workflow-id%3A+issue-implementer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Issue Implementer, engine: copilot, model: claude-opus-4.6, id: 23792841891, workflow_id: issue-implementer, run: https://github.com/microsasa/cli-tools/actions/runs/23792841891 -->

<!-- gh-aw-workflow-id: issue-implementer -->