### PR TITLE
test: add direct unit tests for add_to_model_metrics (#587)

### DIFF
--- a/tests/copilot_usage/test_models.py
+++ b/tests/copilot_usage/test_models.py
@@ -294,11 +294,19 @@ class TestAddToModelMetrics:
     """Unit tests for the add_to_model_metrics helper."""
 
     def test_all_fields_accumulated(self) -> None:
-        # Use model_fields so any new numeric fields are automatically covered.
-        target_requests_kwargs = dict.fromkeys(RequestMetrics.model_fields, 1)
-        target_usage_kwargs = dict.fromkeys(TokenUsage.model_fields, 10)
-        source_requests_kwargs = dict.fromkeys(RequestMetrics.model_fields, 2)
-        source_usage_kwargs = dict.fromkeys(TokenUsage.model_fields, 20)
+        # Assign distinct values per field so mis-mapped fields will fail the test.
+        target_requests_kwargs = {
+            name: idx + 1 for idx, name in enumerate(RequestMetrics.model_fields)
+        }
+        source_requests_kwargs = {
+            name: (idx + 1) * 10 for idx, name in enumerate(RequestMetrics.model_fields)
+        }
+        target_usage_kwargs = {
+            name: idx + 100 for idx, name in enumerate(TokenUsage.model_fields)
+        }
+        source_usage_kwargs = {
+            name: (idx + 1) * 1000 for idx, name in enumerate(TokenUsage.model_fields)
+        }
 
         target = ModelMetrics(
             requests=RequestMetrics(**target_requests_kwargs),


### PR DESCRIPTION
Closes #587

## Summary

Adds a `TestAddToModelMetrics` class in `tests/copilot_usage/test_models.py` with four dedicated unit tests for the `add_to_model_metrics` helper:

| Test | What it covers |
|---|---|
| `test_all_six_fields_accumulated` | Direct call asserting all 6 fields (`requests.count`, `requests.cost`, `usage.inputTokens`, `usage.outputTokens`, `usage.cacheReadTokens`, `usage.cacheWriteTokens`) |
| `test_zero_source_is_identity` | Adding a default `ModelMetrics()` (all zeros) leaves target unchanged |
| `test_source_not_mutated` | Source argument is not modified by the call |
| `test_accumulates_incrementally` | Three sequential calls accumulate correctly |

All CI checks pass (ruff, pyright strict, pytest 977 tests, 99.62% coverage).




> Generated by [Issue Implementer](https://github.com/microsasa/cli-tools/actions/runs/23809846721/agentic_workflow) · [◷](https://github.com/search?q=repo%3Amicrosasa%2Fcli-tools+%22gh-aw-workflow-id%3A+issue-implementer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Issue Implementer, engine: copilot, model: claude-opus-4.6, id: 23809846721, workflow_id: issue-implementer, run: https://github.com/microsasa/cli-tools/actions/runs/23809846721 -->

<!-- gh-aw-workflow-id: issue-implementer -->