### PR TITLE
test: cover three untested branches in `render_vscode_summary` (#588)

### DIFF
--- a/tests/copilot_usage/test_vscode_report.py
+++ b/tests/copilot_usage/test_vscode_report.py
@@ -207,6 +207,70 @@ class TestRenderVscodeSummaryByFeatureTable:
 
 
 # ---------------------------------------------------------------------------
+# By-feature percentage guard with total_requests=0
+# ---------------------------------------------------------------------------
+
+
+class TestRenderVscodeSummaryZeroTotals:
+    def test_by_feature_zero_total_requests_shows_zero_percent(self) -> None:
+        """requests_by_category non-empty but total_requests=0 renders 0.0%."""
+        summary = _make_summary(
+            total_requests=0,
+            requests_by_category={"inline": 5},
+        )
+        output = _capture(summary)
+        assert "By Feature" in output
+        assert "0.0%" in output  # not ZeroDivisionError
+
+
+# ---------------------------------------------------------------------------
+# Partial timestamps
+# ---------------------------------------------------------------------------
+
+
+class TestRenderVscodeSummaryPartialTimestamps:
+    def test_first_set_last_none_shows_dash(self) -> None:
+        summary = _make_summary(
+            total_requests=1,
+            first_timestamp=datetime(2026, 3, 13, 10, 0),
+            last_timestamp=None,
+        )
+        output = _capture(summary)
+        assert "—" in output
+        assert "→" not in output
+
+    def test_last_set_first_none_shows_dash(self) -> None:
+        summary = _make_summary(
+            total_requests=1,
+            first_timestamp=None,
+            last_timestamp=datetime(2026, 3, 13, 10, 0),
+        )
+        output = _capture(summary)
+        assert "—" in output
+        assert "→" not in output
+
+
+# ---------------------------------------------------------------------------
+# Per-model table sort order
+# ---------------------------------------------------------------------------
+
+
+class TestRenderVscodeSummaryModelSortOrder:
+    def test_models_sorted_by_request_count_descending(self) -> None:
+        summary = _make_summary(
+            total_requests=6,
+            requests_by_model={"low-model": 1, "high-model": 5},
+            duration_by_model={"low-model": 100, "high-model": 500},
+        )
+        output = _capture(summary)
+        high_pos = output.index("high-model")
+        low_pos = output.index("low-model")
+        assert high_pos < low_pos, (
+            "high-model (5 reqs) must appear before low-model (1 req)"
+        )
+
+
+# ---------------------------------------------------------------------------
 # Daily activity table
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Closes #588

Adds four tests to `tests/copilot_usage/test_vscode_report.py` covering three previously untested branches in `render_vscode_summary`:

| Gap | Test | Branch exercised |
|-----|------|-----------------|
| 1 | `TestRenderVscodeSummaryZeroTotals::test_by_feature_zero_total_requests_shows_zero_percent` | `pct = … if summary.total_requests else 0` (the `else 0` path) |
| 2 | `TestRenderVscodeSummaryPartialTimestamps::test_first_set_last_none_shows_dash` | `first_timestamp` set, `last_timestamp` None → date range shows `—` |
| 2 | `TestRenderVscodeSummaryPartialTimestamps::test_last_set_first_none_shows_dash` | `first_timestamp` None, `last_timestamp` set → date range shows `—` |
| 3 | `TestRenderVscodeSummaryModelSortOrder::test_models_sorted_by_request_count_descending` | Per-model table row ordering is descending by request count |

All CI checks pass locally (ruff, pyright, pytest 981 passed, coverage 99.62%).




> Generated by [Issue Implementer](https://github.com/microsasa/cli-tools/actions/runs/23811181435/agentic_workflow) · [◷](https://github.com/search?q=repo%3Amicrosasa%2Fcli-tools+%22gh-aw-workflow-id%3A+issue-implementer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Issue Implementer, engine: copilot, model: claude-opus-4.6, id: 23811181435, workflow_id: issue-implementer, run: https://github.com/microsasa/cli-tools/actions/runs/23811181435 -->

<!-- gh-aw-workflow-id: issue-implementer -->