### PR TITLE
docs: add 4 missing modules to README project structure (#590)

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,11 +231,15 @@ cli-tools/
 ├── src/
 │   └── copilot_usage/
 │       ├── cli.py              # Click commands + interactive loop + watchdog auto-refresh
-│       ├── models.py           # Pydantic data models
-│       ├── parser.py           # events.jsonl parsing
-│       ├── pricing.py          # Model cost multipliers
+│       ├── models.py           # Pydantic data models and session-level helpers
+│       ├── parser.py           # events.jsonl parsing and session summary builder
+│       ├── pricing.py          # Model cost multipliers and lookup helpers
+│       ├── report.py           # Rich terminal output (summary, cost, live views)
+│       ├── render_detail.py    # Session-detail rendering (extracted from report.py)
+│       ├── _formatting.py      # Shared pure formatting utilities (tokens, durations)
+│       ├── vscode_parser.py    # VS Code Copilot Chat log parser
+│       ├── vscode_report.py    # Rich rendering for VS Code usage data
 │       ├── logging_config.py   # Loguru configuration
-│       ├── report.py           # Rich terminal output
 │       └── docs/               # Developer docs
 │           ├── architecture.md
 │           ├── changelog.md


### PR DESCRIPTION
Closes #590

The README's **Project Structure** section listed only 6 of the 10 Python modules in `src/copilot_usage/`. This PR adds the 4 missing modules and updates existing descriptions:

| Module | Role |
|---|---|
| `_formatting.py` | Shared pure formatting utilities (`format_duration`, `format_tokens`, `format_timedelta`, `hms`) |
| `render_detail.py` | Session-detail rendering helpers extracted from `report.py` |
| `vscode_parser.py` | VS Code Copilot Chat log parser |
| `vscode_report.py` | Rich rendering for VS Code usage data |

### Verification

- All 984 tests pass (including `test_docs.py`)
- `ruff check`, `ruff format`, and `pyright` all clean
- 99.62% coverage (≥80% threshold met)




> Generated by [Issue Implementer](https://github.com/microsasa/cli-tools/actions/runs/23813159922/agentic_workflow) · [◷](https://github.com/search?q=repo%3Amicrosasa%2Fcli-tools+%22gh-aw-workflow-id%3A+issue-implementer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Issue Implementer, engine: copilot, model: claude-opus-4.6, id: 23813159922, workflow_id: issue-implementer, run: https://github.com/microsasa/cli-tools/actions/runs/23813159922 -->

<!-- gh-aw-workflow-id: issue-implementer -->