### PR TITLE
fix(parser): use in-place accumulation in _build_completed_summary (#598)

### DIFF
--- a/src/copilot_usage/docs/implementation.md
+++ b/src/copilot_usage/docs/implementation.md
@@ -115,13 +115,17 @@ for _idx, sd in fp.all_shutdowns:
 
 ### Model metrics merging
 
-When two shutdowns reference the **same model**, their `ModelMetrics` are summed field-by-field. The merging is delegated to `merge_model_metrics()` (in `models.py`):
+When two shutdowns reference the **same model**, their `ModelMetrics` are summed field-by-field. Accumulation is done **in-place** using `add_to_model_metrics()` and `copy_model_metrics()` (in `models.py`):
 
 ```python
-merged_metrics = merge_model_metrics(merged_metrics, sd.modelMetrics)
+for model_name, mm in sd.modelMetrics.items():
+    if model_name in merged_metrics:
+        add_to_model_metrics(merged_metrics[model_name], mm)
+    else:
+        merged_metrics[model_name] = copy_model_metrics(mm)
 ```
 
-`merge_model_metrics()` returns a new dict without mutating the inputs. For each model name present in both dicts, it sums all metric fields (`requests.count`, `requests.cost`, and all `TokenUsage` fields). When they reference **different models**, separate entries are kept in the result dict.
+Each model is copied exactly once (on first encounter) and accumulated in-place thereafter, yielding O(M) `copy_model_metrics` calls regardless of the number of shutdown cycles K. When two shutdowns reference **different models**, separate entries are kept in the result dict.
 
 ### Model resolution for shutdowns
 

--- a/src/copilot_usage/parser.py
+++ b/src/copilot_usage/parser.py
@@ -24,7 +24,8 @@ from copilot_usage.models import (
     SessionShutdownData,
     SessionSummary,
     TokenUsage,
-    merge_model_metrics,
+    add_to_model_metrics,
+    copy_model_metrics,
     session_sort_key,
 )
 
@@ -477,7 +478,11 @@ def _build_completed_summary(
         total_api_duration += sd.totalApiDurationMs
         if sd.codeChanges is not None:
             last_code_changes = sd.codeChanges
-        merged_metrics = merge_model_metrics(merged_metrics, sd.modelMetrics)
+        for model_name, mm in sd.modelMetrics.items():
+            if model_name in merged_metrics:
+                add_to_model_metrics(merged_metrics[model_name], mm)
+            else:
+                merged_metrics[model_name] = copy_model_metrics(mm)
 
     return SessionSummary(
         session_id=fp.session_id,

--- a/tests/copilot_usage/test_parser.py
+++ b/tests/copilot_usage/test_parser.py
@@ -3679,6 +3679,100 @@ class TestThreeShutdownCyclesMergeModelMetrics:
 
 
 # ---------------------------------------------------------------------------
+# Issue #598 — _build_completed_summary uses O(M) copy_model_metrics calls
+# ---------------------------------------------------------------------------
+
+
+class TestBuildCompletedSummaryInPlaceMetrics:
+    """Verify _build_completed_summary copies each model exactly once (O(M)),
+    not once per shutdown cycle (O(K × M))."""
+
+    def test_copy_model_metrics_called_exactly_m_times(self, tmp_path: Path) -> None:
+        """K=5 shutdowns, M=2 models → copy_model_metrics called exactly 2 times."""
+        from copilot_usage.models import copy_model_metrics
+
+        shutdowns: list[str] = []
+        resumes: list[str] = []
+        for k in range(5):
+            sd = json.dumps(
+                {
+                    "type": "session.shutdown",
+                    "data": {
+                        "shutdownType": "routine",
+                        "totalPremiumRequests": k + 1,
+                        "totalApiDurationMs": 1000 * (k + 1),
+                        "sessionStartTime": 0,
+                        "modelMetrics": {
+                            "model-a": {
+                                "requests": {"count": 1, "cost": 1},
+                                "usage": {
+                                    "inputTokens": 100,
+                                    "outputTokens": 50,
+                                    "cacheReadTokens": 10,
+                                    "cacheWriteTokens": 5,
+                                },
+                            },
+                            "model-b": {
+                                "requests": {"count": 2, "cost": 2},
+                                "usage": {
+                                    "inputTokens": 200,
+                                    "outputTokens": 100,
+                                    "cacheReadTokens": 20,
+                                    "cacheWriteTokens": 10,
+                                },
+                            },
+                        },
+                        "currentModel": "model-a",
+                    },
+                    "id": f"ev-sd-{k}",
+                    "timestamp": f"2026-03-07T{10 + k}:00:00.000Z",
+                    "currentModel": "model-a",
+                }
+            )
+            shutdowns.append(sd)
+            if k < 4:
+                resumes.append(
+                    json.dumps(
+                        {
+                            "type": "session.resume",
+                            "data": {},
+                            "id": f"ev-resume-{k}",
+                            "timestamp": f"2026-03-07T{10 + k}:30:00.000Z",
+                        }
+                    )
+                )
+
+        # Interleave: start, user, [shutdown, resume]×4, shutdown (last)
+        lines: list[str] = [_START_EVENT, _USER_MSG]
+        for k in range(5):
+            lines.append(shutdowns[k])
+            if k < 4:
+                lines.append(resumes[k])
+
+        p = tmp_path / "s" / "events.jsonl"
+        _write_events(p, *lines)
+        events = parse_events(p)
+
+        with patch(
+            "copilot_usage.parser.copy_model_metrics",
+            wraps=copy_model_metrics,
+        ) as spy:
+            summary = build_session_summary(events)
+
+        # M = 2 distinct models → exactly 2 copy calls
+        assert spy.call_count == 2
+
+        # Verify correctness: metrics summed across all 5 shutdowns
+        assert "model-a" in summary.model_metrics
+        assert "model-b" in summary.model_metrics
+        assert summary.model_metrics["model-a"].requests.count == 5
+        assert summary.model_metrics["model-a"].usage.outputTokens == 250
+        assert summary.model_metrics["model-b"].requests.count == 10
+        assert summary.model_metrics["model-b"].usage.outputTokens == 500
+        assert summary.total_premium_requests == 1 + 2 + 3 + 4 + 5
+
+
+# ---------------------------------------------------------------------------
 # _read_config_model — direct unit tests for every branch
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Closes #598

## Problem

`_build_completed_summary` called `merge_model_metrics` inside a loop over shutdown cycles. `merge_model_metrics` copies **all** accumulated entries on every iteration, yielding O(K × M) `copy_model_metrics` calls for K shutdowns and M models.

## Fix

Replace the `merge_model_metrics` call with the in-place `add_to_model_metrics` / `copy_model_metrics` pattern (already used by `report.py`'s `_aggregate_model_metrics`). Each model is now copied exactly once on first encounter and accumulated in-place thereafter — O(M) total copies.

### Changes

- **`src/copilot_usage/parser.py`**: Replace `merge_model_metrics` import with `add_to_model_metrics` + `copy_model_metrics`; replace the single `merge_model_metrics` call with an in-place accumulation loop
- **`tests/copilot_usage/test_parser.py`**: Add `TestBuildCompletedSummaryInPlaceMetrics` — builds a session with K=5 shutdowns and M=2 models, patches `copy_model_metrics` to count invocations, and asserts exactly 2 calls (not 10)
- **`src/copilot_usage/docs/implementation.md`**: Update the model metrics merging section to reflect the new pattern

All 986 tests pass, 99.46% coverage, pyright/ruff clean.




> Generated by [Issue Implementer](https://github.com/microsasa/cli-tools/actions/runs/23818107780/agentic_workflow) · [◷](https://github.com/search?q=repo%3Amicrosasa%2Fcli-tools+%22gh-aw-workflow-id%3A+issue-implementer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Issue Implementer, engine: copilot, model: claude-opus-4.6, id: 23818107780, workflow_id: issue-implementer, run: https://github.com/microsasa/cli-tools/actions/runs/23818107780 -->

<!-- gh-aw-workflow-id: issue-implementer -->