### PR TITLE
fix: remove cargo-cult type assertions and isolate shared mutable fixtures (#601)

### DIFF
--- a/tests/copilot_usage/test_models.py
+++ b/tests/copilot_usage/test_models.py
@@ -604,9 +604,8 @@ class TestAsSessionStart:
 
     def test_invalid_data_raises_validation_error(self) -> None:
         ev = SessionEvent(type=EventType.SESSION_START, data={})
-        with pytest.raises(ValidationError) as exc_info:
+        with pytest.raises(ValidationError):
             ev.as_session_start()
-        assert type(exc_info.value) is not ValueError
 
 
 class TestAsSessionShutdown:
@@ -628,9 +627,8 @@ class TestAsSessionShutdown:
             type=EventType.SESSION_SHUTDOWN,
             data={"totalPremiumRequests": "not-an-int"},
         )
-        with pytest.raises(ValidationError) as exc_info:
+        with pytest.raises(ValidationError):
             ev.as_session_shutdown()
-        assert type(exc_info.value) is not ValueError
 
 
 class TestAsAssistantMessage:
@@ -652,9 +650,8 @@ class TestAsAssistantMessage:
             type=EventType.ASSISTANT_MESSAGE,
             data={"outputTokens": [1, 2, 3]},
         )
-        with pytest.raises(ValidationError) as exc_info:
+        with pytest.raises(ValidationError):
             ev.as_assistant_message()
-        assert type(exc_info.value) is not ValueError
 
 
 class TestAsUserMessage:
@@ -676,9 +673,8 @@ class TestAsUserMessage:
             type=EventType.USER_MESSAGE,
             data={"attachments": 99},
         )
-        with pytest.raises(ValidationError) as exc_info:
+        with pytest.raises(ValidationError):
             ev.as_user_message()
-        assert type(exc_info.value) is not ValueError
 
 
 class TestAsToolExecution:
@@ -701,9 +697,8 @@ class TestAsToolExecution:
             type=EventType.TOOL_EXECUTION_COMPLETE,
             data={"success": "maybe"},
         )
-        with pytest.raises(ValidationError) as exc_info:
+        with pytest.raises(ValidationError):
             ev.as_tool_execution()
-        assert type(exc_info.value) is not ValueError
 
 
 # ---------------------------------------------------------------------------

--- a/tests/copilot_usage/test_report.py
+++ b/tests/copilot_usage/test_report.py
@@ -1036,7 +1036,7 @@ def _make_summary_session(
         total_api_duration_ms=duration_ms,
         model_metrics=metrics
         if metrics is not None
-        else {"claude-opus-4.6-1m": _OPUS_METRICS},
+        else {"claude-opus-4.6-1m": copy_model_metrics(_OPUS_METRICS)},
         user_messages=user_messages,
         model_calls=model_calls,
         is_active=is_active,
@@ -1090,8 +1090,8 @@ class TestRenderSummary:
     def test_multiple_models(self) -> None:
         session = _make_summary_session(
             metrics={
-                "claude-opus-4.6-1m": _OPUS_METRICS,
-                "claude-sonnet-4.5": _SONNET_METRICS,
+                "claude-opus-4.6-1m": copy_model_metrics(_OPUS_METRICS),
+                "claude-sonnet-4.5": copy_model_metrics(_SONNET_METRICS),
             }
         )
         output = _capture_summary([session])
@@ -1103,6 +1103,13 @@ class TestRenderSummary:
         output = _capture_summary([session])
         assert "Copilot Usage Summary" in output
         assert "0" in output
+
+    def test_make_summary_session_returns_isolated_metrics(self) -> None:
+        """Two default sessions must not share the same ModelMetrics object."""
+        s1 = _make_summary_session()
+        s2 = _make_summary_session()
+        opus_key = "claude-opus-4.6-1m"
+        assert s1.model_metrics[opus_key] is not s2.model_metrics[opus_key]
 
     def test_since_filter(self) -> None:
         old = _make_summary_session(


### PR DESCRIPTION
Closes #601

## Changes

### `test_models.py` — Remove redundant type assertions
Removed 5 `assert type(exc_info.value) is not ValueError` lines from the typed-accessor tests (`as_session_start`, `as_session_shutdown`, `as_assistant_message`, `as_user_message`, `as_tool_execution`). These were vacuously true since `pytest.raises(ValidationError)` already guarantees the exception type.

### `test_report.py` — Isolate shared mutable fixtures
Wrapped `_OPUS_METRICS` and `_SONNET_METRICS` with `copy_model_metrics()` in `_make_summary_session` and in the `test_multiple_models` inline dict, so each session gets its own `ModelMetrics` instance instead of sharing a reference to the module-level object.

### New test
Added `test_make_summary_session_returns_isolated_metrics` that creates two default sessions and asserts their `ModelMetrics` objects are distinct (`is not`), verifying fixture isolation.

## Verification
All 987 tests pass, 99.46% coverage (≥80% threshold met). ruff, pyright clean.




> Generated by [Issue Implementer](https://github.com/microsasa/cli-tools/actions/runs/23818828415/agentic_workflow) · [◷](https://github.com/search?q=repo%3Amicrosasa%2Fcli-tools+%22gh-aw-workflow-id%3A+issue-implementer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Issue Implementer, engine: copilot, model: claude-opus-4.6, id: 23818828415, workflow_id: issue-implementer, run: https://github.com/microsasa/cli-tools/actions/runs/23818828415 -->

<!-- gh-aw-workflow-id: issue-implementer -->