### PR TITLE
test: add direct unit tests for `get_cached_events` OSError and `_render_recent_events` negative max_events (#614)

### DIFF
--- a/tests/copilot_usage/test_parser.py
+++ b/tests/copilot_usage/test_parser.py
@@ -5244,3 +5244,9 @@ class TestGetCachedEvents:
         # All reads return the exact same cached list object
         assert second is first
         assert third is first
+
+    def test_oserror_propagated_on_missing_file(self, tmp_path: Path) -> None:
+        """get_cached_events raises OSError when the file does not exist."""
+        missing = tmp_path / "ghost" / "events.jsonl"
+        with pytest.raises(OSError):
+            get_cached_events(missing)

--- a/tests/copilot_usage/test_report.py
+++ b/tests/copilot_usage/test_report.py
@@ -4955,6 +4955,20 @@ class TestRenderRecentEventsMaxEventsBoundary:
             assert f"m-{i}" not in output
         assert output.count("user message") == 1
 
+    def test_max_events_negative_shows_none(self) -> None:
+        """max_events=-1 produces 'No events to display' — covers the negative branch of the <= 0 guard."""
+        start = datetime(2025, 1, 1, 0, 0, 0, tzinfo=UTC)
+        events = [
+            _make_event(
+                EventType.USER_MESSAGE,
+                data={"content": "visible?"},
+                timestamp=start + timedelta(seconds=1),
+            )
+        ]
+        output = _capture_console(_render_recent_events, events, start, max_events=-1)
+        assert "No events to display" in output
+        assert "visible?" not in output
+
 
 # ---------------------------------------------------------------------------
 # Issue #472 — Cleanup: callers guard against empty sessions


### PR DESCRIPTION
Closes #614

## Summary

Adds two missing unit tests for documented defensive contracts that previously only had indirect integration-level coverage.

### Tests Added

1. **`TestGetCachedEvents.test_oserror_propagated_on_missing_file`** (`test_parser.py`)
   — Calls `get_cached_events` with a non-existent path and asserts `OSError` is raised, directly exercising the documented propagation contract.

2. **`TestRenderRecentEventsMaxEventsBoundary.test_max_events_negative_shows_none`** (`test_report.py`)
   — Passes `max_events=-1` and asserts the "No events to display" message is rendered and no event content leaks through, covering the negative branch of the `<= 0` guard.

### Verification

- All 990 tests pass
- Coverage: 99.46% (well above the 80% threshold)
- `ruff check`, `ruff format`, and `pyright` all clean




> Generated by [Issue Implementer](https://github.com/microsasa/cli-tools/actions/runs/23850603644/agentic_workflow) · [◷](https://github.com/search?q=repo%3Amicrosasa%2Fcli-tools+%22gh-aw-workflow-id%3A+issue-implementer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Issue Implementer, engine: copilot, model: claude-opus-4.6, id: 23850603644, workflow_id: issue-implementer, run: https://github.com/microsasa/cli-tools/actions/runs/23850603644 -->

<!-- gh-aw-workflow-id: issue-implementer -->