### PR TITLE
fix(cli): defer watchdog imports to reduce startup latency (#624)

### DIFF
--- a/src/copilot_usage/cli.py
+++ b/src/copilot_usage/cli.py
@@ -10,7 +10,7 @@ import threading
 import time
 from datetime import datetime, time as dt_time
 from pathlib import Path
-from typing import Any, Final, Literal, Protocol, cast
+from typing import Final, Literal, Protocol, cast
 
 import click
 from loguru import logger
@@ -176,12 +176,18 @@ def _read_line_nonblocking(timeout: float = 0.5) -> str | None:
     return None
 
 
+class _FileChangeEventHandler(Protocol):
+    """Protocol for minimal filesystem event handlers used with watchdog."""
+
+    def dispatch(self, event: object) -> None:
+        """Handle a filesystem event."""
+
+
 class _FileChangeHandler:
     """Watchdog-compatible handler that triggers refresh on session-state changes.
 
-    Implements the ``dispatch(event)`` interface expected by watchdog's
-    ``Observer.schedule`` via duck typing — no inheritance from
-    ``FileSystemEventHandler`` needed.  This avoids importing the heavy
+    Implements the :class:`_FileChangeEventHandler` ``dispatch(event)``
+    Protocol expected by watchdog observers, without importing the heavy
     ``watchdog`` package at module level.
     """
 
@@ -216,9 +222,9 @@ def _start_observer(
     """
     from watchdog.observers import Observer  # type: ignore[import-untyped]
 
-    handler = _FileChangeHandler(change_event)
+    handler: _FileChangeEventHandler = _FileChangeHandler(change_event)
     observer = Observer()
-    observer.schedule(cast(Any, handler), str(session_path), recursive=True)
+    observer.schedule(handler, str(session_path), recursive=True)  # type: ignore[arg-type]
     observer.daemon = True
     try:
         observer.start()

--- a/tests/copilot_usage/test_cli.py
+++ b/tests/copilot_usage/test_cli.py
@@ -1,5 +1,6 @@
 """Tests for copilot_usage.cli — wired-up CLI commands."""
 
+import contextlib
 import json
 import os
 import re
@@ -935,8 +936,8 @@ class TestFileChangeHandler:
         handler.dispatch(object())
         assert event.is_set()
 
-    def test_duck_typed_dispatch_interface(self) -> None:
-        """_FileChangeHandler provides a dispatch(event) interface (duck typing)."""
+    def test_dispatch_interface(self) -> None:
+        """_FileChangeHandler provides a dispatch(event) interface compatible with watchdog handlers."""
         from copilot_usage.cli import (
             _FileChangeHandler,  # pyright: ignore[reportPrivateUsage]
         )
@@ -3084,7 +3085,12 @@ def test_watchdog_not_imported_at_module_level() -> None:
     # and ``sys.modules.update`` alone does not undo that side-effect.
     import copilot_usage as _pkg
 
-    saved_cli_attr = getattr(_pkg, "cli", None)
+    try:
+        saved_cli_attr = _pkg.cli  # pyright: ignore[reportUnknownVariableType,reportUnknownMemberType,reportAttributeAccessIssue]
+        _had_cli_attr = True
+    except AttributeError:
+        saved_cli_attr = None
+        _had_cli_attr = False
 
     # Only remove the specific modules we need to re-import: the CLI module
     # (and its submodules) plus watchdog, so we can observe a fresh import.
@@ -3112,10 +3118,10 @@ def test_watchdog_not_imported_at_module_level() -> None:
         sys.modules.update(saved_modules)
 
         # Restore the parent-package attribute to the original module object.
-        if saved_cli_attr is not None:
+        if _had_cli_attr:
             _pkg.cli = saved_cli_attr  # pyright: ignore[reportAttributeAccessIssue]
         else:
             # If the attribute did not exist before, remove any attribute that
             # was added as a side-effect of importing copilot_usage.cli.
-            if hasattr(_pkg, "cli"):
-                delattr(_pkg, "cli")
+            with contextlib.suppress(AttributeError):
+                del _pkg.cli  # pyright: ignore[reportAttributeAccessIssue]


### PR DESCRIPTION
Closes #624

## What

Defers the `watchdog.observers` import from module level into `_start_observer()` so it only executes when interactive mode is actually entered. The `_FileChangeHandler` class no longer inherits from `FileSystemEventHandler` — it uses duck typing via `dispatch()`, which avoids needing to import `watchdog.events` at module level.

## Why

`watchdog.observers` auto-detects and imports the platform-specific backend (`InotifyObserver` on Linux, `FSEventsObserver` on macOS, etc.), adding measurable startup latency to **every** CLI invocation. Since watchdog is only used in interactive mode, this cost is unnecessary for the common subcommands (`summary`, `session`, `cost`, `live`, `vscode`).

## Changes

- **`src/copilot_usage/cli.py`**: Removed top-level `watchdog` imports; moved `from watchdog.observers import Observer` into `_start_observer()`; converted `_FileChangeHandler` from inheriting `FileSystemEventHandler` to a standalone class with a duck-typed `dispatch()` interface.
- **`tests/copilot_usage/test_cli.py`**: Updated observer mock paths from `copilot_usage.cli.Observer.*` to `watchdog.observers.Observer.*`; replaced `test_inherits_from_filesystemeventhandler` with `test_duck_typed_dispatch_interface`; added `test_watchdog_not_imported_at_module_level` to enforce the lazy-import invariant.

## Testing

All 123 CLI tests pass. The new `test_watchdog_not_imported_at_module_level` verifies that importing `copilot_usage.cli` does not trigger loading of `watchdog.observers` or `watchdog.events`.




> Generated by [Issue Implementer](https://github.com/microsasa/cli-tools/actions/runs/23864384112/agentic_workflow) · [◷](https://github.com/search?q=repo%3Amicrosasa%2Fcli-tools+%22gh-aw-workflow-id%3A+issue-implementer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Issue Implementer, engine: copilot, model: claude-opus-4.6, id: 23864384112, workflow_id: issue-implementer, run: https://github.com/microsasa/cli-tools/actions/runs/23864384112 -->

<!-- gh-aw-workflow-id: issue-implementer -->