### PR TITLE
test: cover parse_data() generic fallback for known-but-unmodeled EventTypes (#633)

### DIFF
--- a/tests/copilot_usage/test_models.py
+++ b/tests/copilot_usage/test_models.py
@@ -12,6 +12,7 @@ from copilot_usage.models import (
     AssistantMessageData,
     CodeChanges,
     EventType,
+    GenericEventData,
     ModelMetrics,
     RequestMetrics,
     SessionEvent,
@@ -245,7 +246,28 @@ def test_session_event_unknown_type() -> None:
     raw = {"type": "some.future.event", "data": {"foo": "bar"}, "id": "x"}
     ev = SessionEvent.model_validate(raw)
     data = ev.parse_data()
-    assert data is not None
+    assert isinstance(data, GenericEventData)
+
+
+@pytest.mark.parametrize(
+    "event_type",
+    [
+        EventType.SESSION_RESUME,
+        EventType.SESSION_ERROR,
+        EventType.SESSION_PLAN_CHANGED,
+        EventType.SESSION_WORKSPACE_FILE_CHANGED,
+        EventType.ASSISTANT_TURN_START,
+        EventType.ASSISTANT_TURN_END,
+        EventType.TOOL_EXECUTION_START,
+        EventType.ABORT,
+    ],
+)
+def test_parse_data_known_unmodeled_types_return_generic(
+    event_type: EventType,
+) -> None:
+    ev = SessionEvent(type=event_type, data={"foo": "bar"}, id="x")
+    data = ev.parse_data()
+    assert isinstance(data, GenericEventData)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #633

## What

Adds test coverage for the `SessionEvent.parse_data()` generic fallback path for all 8 known `EventType` members that have no explicit `case` arm:

- `SESSION_RESUME`, `SESSION_ERROR`, `SESSION_PLAN_CHANGED`, `SESSION_WORKSPACE_FILE_CHANGED`
- `ASSISTANT_TURN_START`, `ASSISTANT_TURN_END`, `TOOL_EXECUTION_START`, `ABORT`

## Changes

- **New parametrized test** `test_parse_data_known_unmodeled_types_return_generic` — exercises each of the 8 unmodeled `EventType` values through `parse_data()` and asserts the result is `GenericEventData`.
- **Strengthened** `test_session_event_unknown_type` — now asserts `isinstance(data, GenericEventData)` instead of just `data is not None`.

## Verification

All checks pass locally:
- `ruff check` ✅
- `ruff format` ✅
- `pyright` ✅ (0 errors)
- `pytest --cov --cov-fail-under=80` ✅ (1016 passed, 99.37% coverage)




> Generated by [Issue Implementer](https://github.com/microsasa/cli-tools/actions/runs/23868619102/agentic_workflow) · [◷](https://github.com/search?q=repo%3Amicrosasa%2Fcli-tools+%22gh-aw-workflow-id%3A+issue-implementer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Issue Implementer, engine: copilot, model: claude-opus-4.6, id: 23868619102, workflow_id: issue-implementer, run: https://github.com/microsasa/cli-tools/actions/runs/23868619102 -->

<!-- gh-aw-workflow-id: issue-implementer -->