### PR TITLE
test: add regression test for config model real→None cache invalidation (#634)

### DIFF
--- a/tests/copilot_usage/test_parser.py
+++ b/tests/copilot_usage/test_parser.py
@@ -5125,6 +5125,35 @@ class TestActiveSessionCaching:
                 assert result2[0].model == "claude-sonnet-4"
                 assert spy.call_count == 0
 
+    def test_active_session_real_model_to_none_invalidates(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Cache invalidates when config model transitions from a real value to None (file deleted)."""
+        config = tmp_path / "config.json"
+        config.write_text('{"model": "gpt-5.1"}', encoding="utf-8")
+
+        p = tmp_path / "sessions" / "s1" / "events.jsonl"
+        _write_events(p, _START_EVENT, _USER_MSG, _ASSISTANT_MSG)
+
+        with patch("copilot_usage.parser._CONFIG_PATH", config):
+            result1 = get_all_sessions(tmp_path / "sessions")
+            assert len(result1) == 1
+            assert result1[0].model == "gpt-5.1"
+
+            entry = _SESSION_CACHE[p]
+            assert entry.depends_on_config is True
+            assert entry.config_model == "gpt-5.1"
+
+            # Delete the config file — config_model should now be None
+            config.unlink()
+
+            with patch("copilot_usage.parser.parse_events", wraps=parse_events) as spy:
+                result2 = get_all_sessions(tmp_path / "sessions")
+                assert len(result2) == 1
+                assert result2[0].model is None  # config-sourced model gone
+                assert spy.call_count == 1  # re-parsed due to staleness
+
 
 # ---------------------------------------------------------------------------
 # get_cached_events — parsed-events cache


### PR DESCRIPTION
Closes #634

Adds `test_active_session_real_model_to_none_invalidates` to the `TestActiveSessionCaching` class in `tests/copilot_usage/test_parser.py`.

## What

This covers the missing "real → None" config model transition: when `config.json` is **deleted** after a session was cached with a real model string (e.g. `"gpt-5.1"`), the cache must invalidate and the session's `model` field must become `None`.

## Why

The existing tests cover three transitions (`None → real`, `real → different real`, `real → same real`) but not the fourth (`real → None`). While the current code handles this correctly (`"gpt-5.1" != None` evaluates `True`), there was no regression test protecting this path from future refactors.

## Test details

The new test:
1. Creates a `config.json` with `{"model": "gpt-5.1"}` and an active session
2. Calls `get_all_sessions()` — asserts model is `"gpt-5.1"` and cache entry has `depends_on_config=True`
3. Deletes `config.json`
4. Calls `get_all_sessions()` again — asserts model is `None` and `parse_events` was called exactly once (re-parsed due to staleness)

## Verification

- All 1017 tests pass
- Coverage: 99.37% (≥80% threshold met)
- `ruff check`, `ruff format`, and `pyright` all clean




> Generated by [Issue Implementer](https://github.com/microsasa/cli-tools/actions/runs/23869117340/agentic_workflow) · [◷](https://github.com/search?q=repo%3Amicrosasa%2Fcli-tools+%22gh-aw-workflow-id%3A+issue-implementer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Issue Implementer, engine: copilot, model: claude-opus-4.6, id: 23869117340, workflow_id: issue-implementer, run: https://github.com/microsasa/cli-tools/actions/runs/23869117340 -->

<!-- gh-aw-workflow-id: issue-implementer -->