### PR TITLE
fix(parser): prune stale `_SESSION_CACHE` entries for deleted sessions (#641)

### DIFF
--- a/src/copilot_usage/parser.py
+++ b/src/copilot_usage/parser.py
@@ -721,5 +721,11 @@ def get_all_sessions(base_path: Path | None = None) -> list[SessionSummary]:
         )
         summaries.append(summary)
 
+    # Prune stale cache entries for sessions no longer on disk.
+    discovered_paths = {p for p, _, _ in discovered}
+    stale = [p for p in _SESSION_CACHE if p not in discovered_paths]
+    for p in stale:
+        del _SESSION_CACHE[p]
+
     summaries.sort(key=session_sort_key, reverse=True)
     return summaries

--- a/tests/copilot_usage/test_parser.py
+++ b/tests/copilot_usage/test_parser.py
@@ -4949,6 +4949,34 @@ class TestSessionCacheMtime:
             # no additional stat calls in the main loop.
             assert spy.call_count == 2 * n
 
+    def test_stale_cache_entries_evicted_on_session_delete(
+        self, tmp_path: Path
+    ) -> None:
+        """Cache entries for deleted session directories are pruned."""
+        import shutil
+
+        p1 = self._make_session(tmp_path, "sess-a", "a")
+        p2 = self._make_session(tmp_path, "sess-b", "b")
+        p3 = self._make_session(tmp_path, "sess-c", "c")
+
+        # First call populates cache for all three sessions.
+        result1 = get_all_sessions(tmp_path)
+        assert len(result1) == 3
+        assert p1 in _SESSION_CACHE
+        assert p2 in _SESSION_CACHE
+        assert p3 in _SESSION_CACHE
+
+        # Delete sess-b from disk.
+        shutil.rmtree(p2.parent)
+
+        # Second call should discover only sess-a and sess-c; sess-b
+        # must be evicted from the cache.
+        result2 = get_all_sessions(tmp_path)
+        assert len(result2) == 2
+        assert p1 in _SESSION_CACHE
+        assert p2 not in _SESSION_CACHE
+        assert p3 in _SESSION_CACHE
+
 
 # ---------------------------------------------------------------------------
 # Issue #552 — active sessions cached in _SESSION_CACHE


### PR DESCRIPTION
Closes #641

## Problem

`_SESSION_CACHE` entries are never removed when session directories are deleted from disk. Over the lifetime of a long-running interactive session, this causes unbounded memory growth proportional to every session ID ever observed.

## Fix

After the discovery loop in `get_all_sessions`, compute the set of discovered paths and delete any cache entry whose key is no longer in that set:

```python
discovered_paths = {p for p, _, _ in discovered}
stale = [p for p in _SESSION_CACHE if p not in discovered_paths]
for p in stale:
    del _SESSION_CACHE[p]
```

This is O(|cache|) per call — the same order as the existing discovery loop — and keeps memory bounded to the current live session count.

## Test

Added `test_stale_cache_entries_evicted_on_session_delete` in `TestSessionCacheMtime` that:
1. Creates three sessions and populates the cache.
2. Deletes one session directory from disk.
3. Asserts only the two remaining sessions stay in `_SESSION_CACHE`.

All 1024 tests pass, coverage at 99.37%.




> Generated by [Issue Implementer](https://github.com/microsasa/cli-tools/actions/runs/23885861369/agentic_workflow) · [◷](https://github.com/search?q=repo%3Amicrosasa%2Fcli-tools+%22gh-aw-workflow-id%3A+issue-implementer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Issue Implementer, engine: copilot, model: claude-opus-4.6, id: 23885861369, workflow_id: issue-implementer, run: https://github.com/microsasa/cli-tools/actions/runs/23885861369 -->

<!-- gh-aw-workflow-id: issue-implementer -->