### PR TITLE
fix(cli): skip redundant `get_all_sessions()` on back-navigation (#650)

### DIFF
--- a/src/copilot_usage/cli.py
+++ b/src/copilot_usage/cli.py
@@ -340,7 +340,9 @@ def _interactive_loop(path: Path | None) -> None:
             if view in ("detail", "cost"):
                 view = "home"
                 detail_session_id = None
-                sessions = get_all_sessions(path)
+                if change_event.is_set():
+                    change_event.clear()
+                    sessions = get_all_sessions(path)
                 _draw_home(console, sessions)
                 _write_prompt(_HOME_PROMPT)
                 continue

--- a/tests/copilot_usage/test_cli.py
+++ b/tests/copilot_usage/test_cli.py
@@ -2441,6 +2441,114 @@ def test_interactive_loop_observer_none_no_auto_refresh(
 
 
 # ---------------------------------------------------------------------------
+# Issue #650 — redundant get_all_sessions on back-navigation
+# ---------------------------------------------------------------------------
+
+
+def test_back_navigation_skips_get_all_sessions_when_no_change(
+    tmp_path: Path, monkeypatch: Any
+) -> None:
+    """Returning from detail view should NOT call get_all_sessions when
+    change_event is not set (no file changes detected)."""
+    _write_session(
+        tmp_path, "bk_noref-0000-0000-0000-000000000000", name="BackNoRefresh"
+    )
+
+    import copilot_usage.cli as cli_mod
+
+    # Track get_all_sessions calls after the initial load.
+    gas_calls: list[int] = []
+    orig_gas = cli_mod.get_all_sessions
+
+    def _tracking_gas(*args: Any, **kwargs: Any) -> list[Any]:
+        gas_calls.append(1)
+        return orig_gas(*args, **kwargs)
+
+    monkeypatch.setattr(cli_mod, "get_all_sessions", _tracking_gas)
+
+    # Use a no-op observer so file-system events never fire.
+    def _noop_start(session_path: Path, change_event: threading.Event) -> None:  # noqa: ARG001
+        return None
+
+    monkeypatch.setattr(cli_mod, "_start_observer", _noop_start)
+
+    call_count = 0
+
+    def _fake_read(timeout: float = 0.5) -> str | None:  # noqa: ARG001
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            return "1"  # navigate to detail view
+        if call_count == 2:
+            return ""  # back-navigation (any input returns home)
+        return "q"
+
+    monkeypatch.setattr(cli_mod, "_read_line_nonblocking", _fake_read)
+
+    runner = CliRunner()
+    result = runner.invoke(main, ["--path", str(tmp_path)])
+    assert result.exit_code == 0
+
+    # The initial load calls get_all_sessions once; the back-navigation
+    # must NOT trigger an additional call because change_event was never set.
+    assert len(gas_calls) == 1
+
+
+def test_back_navigation_calls_get_all_sessions_when_change_event_set(
+    tmp_path: Path, monkeypatch: Any
+) -> None:
+    """Returning from detail view SHOULD call get_all_sessions exactly once
+    when change_event is set (file changes detected)."""
+    _write_session(
+        tmp_path, "bk_chg00-0000-0000-0000-000000000000", name="BackWithChange"
+    )
+
+    import copilot_usage.cli as cli_mod
+
+    # Track get_all_sessions calls after the initial load.
+    gas_calls: list[int] = []
+    orig_gas = cli_mod.get_all_sessions
+
+    def _tracking_gas(*args: Any, **kwargs: Any) -> list[Any]:
+        gas_calls.append(1)
+        return orig_gas(*args, **kwargs)
+
+    monkeypatch.setattr(cli_mod, "get_all_sessions", _tracking_gas)
+
+    # Capture change_event via a no-op observer (no real file watching).
+    captured_event: list[threading.Event] = []
+
+    def _capturing_start(session_path: Path, change_event: threading.Event) -> None:  # noqa: ARG001
+        captured_event.append(change_event)
+        return
+
+    monkeypatch.setattr(cli_mod, "_start_observer", _capturing_start)
+
+    call_count = 0
+
+    def _fake_read(timeout: float = 0.5) -> str | None:  # noqa: ARG001
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            return "1"  # navigate to detail view
+        if call_count == 2:
+            # Set change_event before back-navigation
+            if captured_event:
+                captured_event[0].set()
+            return ""  # back-navigation triggers refresh because event is set
+        return "q"
+
+    monkeypatch.setattr(cli_mod, "_read_line_nonblocking", _fake_read)
+
+    runner = CliRunner()
+    result = runner.invoke(main, ["--path", str(tmp_path)])
+    assert result.exit_code == 0
+
+    # Initial load (1) + back-navigation with change_event set (1) = 2 calls
+    assert len(gas_calls) == 2
+
+
+# ---------------------------------------------------------------------------
 # Issue #307 — version header on initial entry to cost / detail views
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Closes #650

## Problem

Every keypress that returns to the home screen from detail or cost view unconditionally called `get_all_sessions(path)`, even when no session files had changed. For a workspace with N sessions, each redundant call performed ~2N stat syscalls plus directory traversal — adding 50–200 ms of avoidable latency per back-navigation.

## Fix

Only call `get_all_sessions` during back-navigation when `change_event` is set (i.e., the file watcher detected changes). Otherwise, reuse the existing `sessions` list which is already current from either the initial load or the auto-refresh handler at the top of the loop.

```python
if view in ("detail", "cost"):
    view = "home"
    detail_session_id = None
    if change_event.is_set():
        change_event.clear()
        sessions = get_all_sessions(path)
    _draw_home(console, sessions)
    _write_prompt(_HOME_PROMPT)
    continue
```

The explicit `[r]` refresh command remains unchanged.

## Tests

Two new tests in `tests/copilot_usage/test_cli.py`:
- **`test_back_navigation_skips_get_all_sessions_when_no_change`** — verifies `get_all_sessions` is NOT called on back-navigation when `change_event` is not set
- **`test_back_navigation_calls_get_all_sessions_when_change_event_set`** — verifies `get_all_sessions` IS called exactly once when `change_event` is set

All 1036 tests pass, 99.37% coverage.




> Generated by [Issue Implementer](https://github.com/microsasa/cli-tools/actions/runs/23895016889/agentic_workflow) · [◷](https://github.com/search?q=repo%3Amicrosasa%2Fcli-tools+%22gh-aw-workflow-id%3A+issue-implementer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Issue Implementer, engine: copilot, model: claude-opus-4.6, id: 23895016889, workflow_id: issue-implementer, run: https://github.com/microsasa/cli-tools/actions/runs/23895016889 -->

<!-- gh-aw-workflow-id: issue-implementer -->