### PR TITLE
fix: validate active_user_messages <= user_messages in SessionSummary (#651)

### DIFF
--- a/src/copilot_usage/models.py
+++ b/src/copilot_usage/models.py
@@ -417,11 +417,16 @@ class SessionSummary(BaseModel):
     active_output_tokens: int = 0
 
     @model_validator(mode="after")
-    def _check_call_counts(self) -> Self:
+    def _check_active_counters(self) -> Self:
         if self.active_model_calls > self.model_calls:
             raise ValueError(
                 f"active_model_calls ({self.active_model_calls}) must be <= "
                 f"model_calls ({self.model_calls})"
+            )
+        if self.active_user_messages > self.user_messages:
+            raise ValueError(
+                f"active_user_messages ({self.active_user_messages}) must be <= "
+                f"user_messages ({self.user_messages})"
             )
         return self
 

--- a/tests/copilot_usage/test_models.py
+++ b/tests/copilot_usage/test_models.py
@@ -864,6 +864,43 @@ class TestSessionSummaryCallCountInvariant:
         assert s.active_model_calls == 0
 
 
+class TestSessionSummaryUserMessageInvariant:
+    """Tests for the user_messages >= active_user_messages invariant."""
+
+    def test_rejects_active_messages_exceeding_total(self) -> None:
+        """SessionSummary must reject active_user_messages > user_messages."""
+        with pytest.raises(ValidationError):
+            SessionSummary(
+                session_id="inv",
+                user_messages=3,
+                active_user_messages=5,
+            )
+
+    def test_accepts_active_messages_equal_to_total(self) -> None:
+        """SessionSummary allows active_user_messages == user_messages."""
+        s = SessionSummary(
+            session_id="eq",
+            user_messages=5,
+            active_user_messages=5,
+        )
+        assert s.active_user_messages == s.user_messages
+
+    def test_accepts_active_messages_less_than_total(self) -> None:
+        """SessionSummary allows active_user_messages < user_messages."""
+        s = SessionSummary(
+            session_id="lt",
+            user_messages=10,
+            active_user_messages=3,
+        )
+        assert s.active_user_messages < s.user_messages
+
+    def test_accepts_zero_messages(self) -> None:
+        """SessionSummary allows both counts at zero (defaults)."""
+        s = SessionSummary(session_id="zero")
+        assert s.user_messages == 0
+        assert s.active_user_messages == 0
+
+
 # ---------------------------------------------------------------------------
 # shutdown_output_tokens
 # ---------------------------------------------------------------------------
@@ -954,6 +991,7 @@ class TestTotalOutputTokens:
             has_shutdown_metrics=False,
             active_output_tokens=50,
             active_user_messages=1,
+            user_messages=1,
             model_calls=1,
         )
         assert total_output_tokens(session) == 100
@@ -1021,9 +1059,11 @@ class TestHasActivePeriodStats:
             "active_model_calls": 0,
             field: value,
         }
-        # active_model_calls must be <= model_calls
+        # active counters must be <= their totals
         if field == "active_model_calls":
             kwargs["model_calls"] = value
+        if field == "active_user_messages":
+            kwargs["user_messages"] = value
         session = SessionSummary(**kwargs)  # type: ignore[arg-type]
         assert has_active_period_stats(session) is True
 

--- a/tests/copilot_usage/test_report.py
+++ b/tests/copilot_usage/test_report.py
@@ -1692,6 +1692,7 @@ class TestRenderFullSummary:
             model_calls=1,
             active_model_calls=1,
             active_user_messages=1,
+            user_messages=1,
             active_output_tokens=100,
         )
         output = _capture_full_summary([session])
@@ -3630,6 +3631,7 @@ class TestHasActivePeriodStats:
             session_id="active-msgs-1234",
             is_active=True,
             active_user_messages=5,
+            user_messages=5,
             active_output_tokens=0,
             active_model_calls=0,
         )


### PR DESCRIPTION
Closes #651

## Problem

`SessionSummary._check_call_counts` enforced `active_model_calls <= model_calls` but did **not** enforce the symmetric invariant `active_user_messages <= user_messages`. This meant a future refactor could silently introduce an inconsistency where the active-period user message count exceeds the session total — causing misleading data in the rendered report panels.

## Changes

### `src/copilot_usage/models.py`
- Added `active_user_messages <= user_messages` validation to the model validator
- Renamed `_check_call_counts` → `_check_active_counters` to reflect its broader scope

### `tests/copilot_usage/test_models.py`
- Added `TestSessionSummaryUserMessageInvariant` test class with 4 tests mirroring `TestSessionSummaryCallCountInvariant`:
  - `active_user_messages > user_messages` → `ValidationError`
  - `active_user_messages == user_messages` → accepted
  - `active_user_messages < user_messages` → accepted
  - Both at zero (default) → accepted
- Fixed existing `TestTotalOutputTokens` and `TestHasActivePeriodStats` tests to satisfy the new invariant

### `tests/copilot_usage/test_report.py`
- Fixed two tests that constructed `SessionSummary` with `active_user_messages > 0` without setting a corresponding `user_messages`

## Verification

All 1040 tests pass. Coverage: 99.37% (≥ 80% threshold). `ruff check`, `ruff format`, and `pyright` all pass cleanly.




> Generated by [Issue Implementer](https://github.com/microsasa/cli-tools/actions/runs/23895622400/agentic_workflow) · [◷](https://github.com/search?q=repo%3Amicrosasa%2Fcli-tools+%22gh-aw-workflow-id%3A+issue-implementer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Issue Implementer, engine: copilot, model: claude-opus-4.6, id: 23895622400, workflow_id: issue-implementer, run: https://github.com/microsasa/cli-tools/actions/runs/23895622400 -->

<!-- gh-aw-workflow-id: issue-implementer -->