### PR TITLE
fix(parser): replace FIFO eviction with LRU in `_EVENTS_CACHE` (#658)

### DIFF
--- a/src/copilot_usage/parser.py
+++ b/src/copilot_usage/parser.py
@@ -7,6 +7,7 @@ aggregates.
 
 import dataclasses
 import json
+from collections import OrderedDict
 from datetime import datetime
 from functools import lru_cache
 from pathlib import Path
@@ -81,8 +82,10 @@ class _CachedEvents:
 
 # Module-level parsed-events cache: events_path → _CachedEvents.
 # Avoids re-parsing the raw event list on every detail-view render.
+# Uses OrderedDict for LRU eviction: most-recently-used entries are at
+# the back, least-recently-used at the front.
 _MAX_CACHED_EVENTS: Final[int] = 8
-_EVENTS_CACHE: dict[Path, _CachedEvents] = {}
+_EVENTS_CACHE: OrderedDict[Path, _CachedEvents] = OrderedDict()
 
 
 def get_cached_events(events_path: Path) -> list[SessionEvent]:
@@ -90,8 +93,8 @@ def get_cached_events(events_path: Path) -> list[SessionEvent]:
 
     Delegates to :func:`parse_events` on a cache miss and stores the
     result keyed by ``(events_path, file_identity)``.  The cache is
-    bounded to :data:`_MAX_CACHED_EVENTS` entries; the least-recently
-    inserted entry is evicted when the limit is reached.
+    bounded to :data:`_MAX_CACHED_EVENTS` entries; the **least-recently
+    used** entry is evicted when the limit is reached.
 
     Raises:
         OSError: Propagated from :func:`parse_events` when the file
@@ -100,12 +103,14 @@ def get_cached_events(events_path: Path) -> list[SessionEvent]:
     file_id = _safe_file_identity(events_path)
     cached = _EVENTS_CACHE.get(events_path)
     if cached is not None and cached.file_id == file_id:
+        _EVENTS_CACHE.move_to_end(events_path)
         return cached.events
     events = parse_events(events_path)
-    # Evict oldest entry when cache is full
-    if len(_EVENTS_CACHE) >= _MAX_CACHED_EVENTS and events_path not in _EVENTS_CACHE:
-        oldest_key = next(iter(_EVENTS_CACHE))
-        del _EVENTS_CACHE[oldest_key]
+    # Remove stale entry (changed file_id) before reinserting
+    if events_path in _EVENTS_CACHE:
+        del _EVENTS_CACHE[events_path]
+    elif len(_EVENTS_CACHE) >= _MAX_CACHED_EVENTS:
+        _EVENTS_CACHE.popitem(last=False)  # evict LRU (front)
     _EVENTS_CACHE[events_path] = _CachedEvents(file_id=file_id, events=events)
     return events
 

--- a/tests/copilot_usage/test_parser.py
+++ b/tests/copilot_usage/test_parser.py
@@ -5332,7 +5332,7 @@ class TestGetCachedEvents:
         assert second is first
 
     def test_cache_eviction_bounds_memory(self, tmp_path: Path) -> None:
-        """Cache evicts oldest entry when _MAX_CACHED_EVENTS is exceeded."""
+        """Cache evicts LRU entry when _MAX_CACHED_EVENTS is exceeded."""
         paths: list[Path] = []
         for i in range(_MAX_CACHED_EVENTS + 1):
             p = tmp_path / f"s{i}" / "events.jsonl"
@@ -5341,10 +5341,34 @@ class TestGetCachedEvents:
             paths.append(p)
 
         assert len(_EVENTS_CACHE) == _MAX_CACHED_EVENTS
-        # The first path should have been evicted
+        # The first path should have been evicted (LRU)
         assert paths[0] not in _EVENTS_CACHE
         # The last path should still be cached
         assert paths[-1] in _EVENTS_CACHE
+
+    def test_lru_eviction_protects_recently_accessed(self, tmp_path: Path) -> None:
+        """Recently accessed entry survives eviction; true LRU is evicted."""
+        paths: list[Path] = []
+        for i in range(_MAX_CACHED_EVENTS):
+            p = tmp_path / f"s{i}" / "events.jsonl"
+            _write_events(p, _START_EVENT, _USER_MSG)
+            get_cached_events(p)
+            paths.append(p)
+
+        assert len(_EVENTS_CACHE) == _MAX_CACHED_EVENTS
+
+        # Re-access session 0 to promote it to most-recently-used
+        get_cached_events(paths[0])
+
+        # Insert a 9th session — should evict session 1 (now LRU), not 0
+        p_new = tmp_path / "s_new" / "events.jsonl"
+        _write_events(p_new, _START_EVENT, _USER_MSG)
+        get_cached_events(p_new)
+
+        assert len(_EVENTS_CACHE) == _MAX_CACHED_EVENTS
+        assert paths[0] in _EVENTS_CACHE, "Recently accessed entry was evicted"
+        assert paths[1] not in _EVENTS_CACHE, "LRU entry should have been evicted"
+        assert p_new in _EVENTS_CACHE
 
     def test_cache_populates_entry(self, tmp_path: Path) -> None:
         """After a call, _EVENTS_CACHE contains a _CachedEvents entry."""


### PR DESCRIPTION
Closes #658

## Problem

`_EVENTS_CACHE` used a plain `dict` with FIFO eviction — the oldest-**inserted** entry was evicted when the cache was full. Users navigating back to a previously viewed session would find it already evicted, triggering an expensive full re-parse of `events.jsonl`.

## Solution

- Replace `dict` with `OrderedDict` for `_EVENTS_CACHE`
- Call `move_to_end()` on cache hits to promote recently-accessed entries
- Evict from the front (`popitem(last=False)`) so only the **least-recently-used** entry is removed
- Handle stale entries (changed `file_id`) by deleting before reinserting

## Testing

- Updated existing `test_cache_eviction_bounds_memory` to reflect LRU semantics
- Added `test_lru_eviction_protects_recently_accessed` that:
  1. Fills the cache to capacity (8 sessions)
  2. Re-accesses session 0 (simulating return visit)
  3. Inserts a 9th session
  4. Asserts session 0 is still cached and session 1 (true LRU) was evicted

All 1042 tests pass. Coverage: 99.37%.




> Generated by [Issue Implementer](https://github.com/microsasa/cli-tools/actions/runs/23908499508/agentic_workflow) · [◷](https://github.com/search?q=repo%3Amicrosasa%2Fcli-tools+%22gh-aw-workflow-id%3A+issue-implementer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Issue Implementer, engine: copilot, model: claude-opus-4.6, id: 23908499508, workflow_id: issue-implementer, run: https://github.com/microsasa/cli-tools/actions/runs/23908499508 -->

<!-- gh-aw-workflow-id: issue-implementer -->