### PR TITLE
fix: remove dead OSError handler in vscode CLI and improve no-data diagnostic (#660)

### DIFF
--- a/src/copilot_usage/cli.py
+++ b/src/copilot_usage/cli.py
@@ -35,7 +35,7 @@ from copilot_usage.report import (
     render_summary,
     session_display_name,
 )
-from copilot_usage.vscode_parser import get_vscode_summary
+from copilot_usage.vscode_parser import discover_vscode_logs, get_vscode_summary
 from copilot_usage.vscode_report import render_vscode_summary
 
 type _View = Literal["home", "detail", "cost"]
@@ -606,12 +606,11 @@ def live(ctx: click.Context, path: Path | None) -> None:
 def vscode(vscode_logs: Path | None) -> None:
     """Show usage from VS Code Copilot Chat logs."""
     _print_version_header()
-    try:
-        summary = get_vscode_summary(vscode_logs)
-    except OSError as exc:
-        click.echo(f"Error reading VS Code logs: {exc}", err=True)
-        sys.exit(1)
+    summary = get_vscode_summary(vscode_logs)
     if summary.total_requests == 0:
-        click.echo("No VS Code Copilot Chat requests found.", err=True)
+        if summary.log_files_parsed == 0 and discover_vscode_logs(vscode_logs):
+            click.echo("Error: log files were found but could not be read.", err=True)
+        else:
+            click.echo("No VS Code Copilot Chat requests found.", err=True)
         sys.exit(1)
     render_vscode_summary(summary)

--- a/tests/copilot_usage/test_vscode_parser.py
+++ b/tests/copilot_usage/test_vscode_parser.py
@@ -7,6 +7,7 @@ from unittest.mock import patch
 
 import pytest
 from click.testing import CliRunner
+from loguru import logger
 
 from copilot_usage.cli import main
 from copilot_usage.vscode_parser import (
@@ -437,22 +438,70 @@ class TestVscodeCliCommand:
         assert result.exit_code == 1
         assert "No VS Code Copilot Chat requests found" in result.output
 
-    def test_vscode_oserror_exits_nonzero(
+    def test_vscode_single_file_oserror_logs_warning(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """OSError in get_vscode_summary produces a friendly error and exit 1."""
+        """OSError on one file logs a warning; remaining files still parsed."""
+        # Create two valid log files.
+        for session in ("s1", "s2"):
+            log_dir = tmp_path / session / "window1" / "exthost" / "GitHub.copilot-chat"
+            log_dir.mkdir(parents=True)
+            (log_dir / "GitHub Copilot Chat.log").write_text(
+                _LOG_OPUS + "\n", encoding="utf-8"
+            )
 
-        def _raise_oserror(*_a: object, **_kw: object) -> object:
+        # Make parse_vscode_log raise OSError only on the first call.
+        call_count = 0
+        _real_parse = parse_vscode_log
+
+        def _failing_once(path: Path) -> list[VSCodeRequest]:
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                msg = "Permission denied"
+                raise OSError(msg)
+            return _real_parse(path)
+
+        monkeypatch.setattr(
+            "copilot_usage.vscode_parser.parse_vscode_log", _failing_once
+        )
+
+        warnings: list[str] = []
+
+        def _sink(message: object) -> None:
+            warnings.append(str(message))
+
+        handler_id = logger.add(_sink, level="WARNING")
+        try:
+            summary = get_vscode_summary(tmp_path)
+        finally:
+            logger.remove(handler_id)
+
+        assert summary.log_files_parsed == 1
+        assert summary.total_requests == 1
+        assert any("Could not read log file" in w for w in warnings)
+
+    def test_vscode_all_files_oserror_shows_io_failure(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """When all discovered files fail, the CLI reports an I/O failure."""
+        log_dir = tmp_path / "s1" / "window1" / "exthost" / "GitHub.copilot-chat"
+        log_dir.mkdir(parents=True)
+        (log_dir / "GitHub Copilot Chat.log").write_text(
+            _LOG_OPUS + "\n", encoding="utf-8"
+        )
+
+        def _always_raise(*_a: object, **_kw: object) -> object:
             msg = "Permission denied"
             raise OSError(msg)
 
-        monkeypatch.setattr("copilot_usage.cli.get_vscode_summary", _raise_oserror)
+        monkeypatch.setattr(
+            "copilot_usage.vscode_parser.parse_vscode_log", _always_raise
+        )
         runner = CliRunner()
         result = runner.invoke(main, ["vscode", "--vscode-logs", str(tmp_path)])
         assert result.exit_code == 1
-        assert "Error reading VS Code logs" in result.output
-        assert "Permission denied" in result.output
-        assert "Traceback" not in (result.output or "")
+        assert "log files were found but could not be read" in result.output
 
     def test_vscode_logs_option_passed(self, tmp_path: Path) -> None:
         log_dir = tmp_path / "20260313" / "window1" / "exthost" / "GitHub.copilot-chat"


### PR DESCRIPTION
## Summary

`get_vscode_summary` catches `OSError` per-file internally and never propagates it, making the `except OSError` block in the `vscode` CLI command dead code. This PR removes the dead handler and improves the "no data" diagnostic.

## Changes

### `src/copilot_usage/cli.py`
- **Removed** the unreachable `except OSError` block from the `vscode` command.
- **Added** `discover_vscode_logs` import.
- **Improved** the zero-results diagnostic: when `log_files_parsed == 0` but `discover_vscode_logs()` finds files, the CLI now reports `"Error: log files were found but could not be read."` instead of the misleading `"No VS Code Copilot Chat requests found."`.

### `tests/copilot_usage/test_vscode_parser.py`
- **Removed** `test_vscode_oserror_exits_nonzero` which fabricated an impossible scenario (mocking `get_vscode_summary` to raise `OSError`).
- **Added** `test_vscode_single_file_oserror_logs_warning` — injects `OSError` on one file via monkeypatch, verifies the warning is logged and remaining files still produce a partial summary.
- **Added** `test_vscode_all_files_oserror_shows_io_failure` — injects `OSError` on all discovered files, verifies the CLI exits with a meaningful I/O-failure message.

## Verification

All 1044 tests pass. Coverage: 99.42% (well above 80% threshold). `ruff check`, `ruff format`, and `pyright` all clean.

Closes #660




> Generated by [Issue Implementer](https://github.com/microsasa/cli-tools/actions/runs/23910128812/agentic_workflow) · [◷](https://github.com/search?q=repo%3Amicrosasa%2Fcli-tools+%22gh-aw-workflow-id%3A+issue-implementer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Issue Implementer, engine: copilot, model: claude-opus-4.6, id: 23910128812, workflow_id: issue-implementer, run: https://github.com/microsasa/cli-tools/actions/runs/23910128812 -->

<!-- gh-aw-workflow-id: issue-implementer -->