### PR TITLE
fix: format_duration renders sub-second values as milliseconds

### DIFF
--- a/src/copilot_usage/_formatting.py
+++ b/src/copilot_usage/_formatting.py
@@ -28,16 +28,23 @@ def hms(total_seconds: int) -> tuple[int, int, int]:
 
 
 def format_timedelta(td: timedelta) -> str:
-    """Format a timedelta to human-readable duration (e.g. '1h 5m 30s')."""
-    total_seconds = max(int(td.total_seconds()), 0)
+    """Format a timedelta to human-readable duration (e.g. '1h 5m 30s 481ms').
+
+    Always includes milliseconds when present.
+    """
+    total_ms = max(int(td.total_seconds() * 1000), 0)
+    remainder_ms = total_ms % 1000
+    total_seconds = total_ms // 1000
     hours, minutes, seconds = hms(total_seconds)
     parts: list[str] = []
     if hours:
         parts.append(f"{hours}h")
     if minutes:
         parts.append(f"{minutes}m")
-    if seconds or not parts:
+    if seconds:
         parts.append(f"{seconds}s")
+    if remainder_ms or not parts:
+        parts.append(f"{remainder_ms}ms")
     return " ".join(parts)
 
 
@@ -48,15 +55,21 @@ def format_duration(ms: int) -> str:
     ``"1h 1m 1s"``.
 
     >>> format_duration(389114)
-    '6m 29s'
+    '6m 29s 114ms'
     >>> format_duration(5000)
     '5s'
     >>> format_duration(0)
-    '0s'
+    '0ms'
     >>> format_duration(3661000)
     '1h 1m 1s'
     >>> format_duration(60000)
     '1m'
+    >>> format_duration(481)
+    '481ms'
+    >>> format_duration(50)
+    '50ms'
+    >>> format_duration(1500)
+    '1s 500ms'
     """
     return format_timedelta(timedelta(milliseconds=ms))
 

--- a/tests/copilot_usage/test_formatting.py
+++ b/tests/copilot_usage/test_formatting.py
@@ -155,3 +155,96 @@ class TestMaxContentLenSingleDefinition:
                         f"at line {node.lineno}; "
                         "it must be imported from _formatting"
                     )
+
+
+class TestFormatDuration:
+    """Tests for format_duration — millisecond to human-readable conversion."""
+
+    def test_sub_second_shows_milliseconds(self) -> None:
+        from copilot_usage._formatting import format_duration
+
+        assert format_duration(481) == "481ms"
+
+    def test_zero_shows_zero_ms(self) -> None:
+        from copilot_usage._formatting import format_duration
+
+        assert format_duration(0) == "0ms"
+
+    def test_one_ms(self) -> None:
+        from copilot_usage._formatting import format_duration
+
+        assert format_duration(1) == "1ms"
+
+    def test_999_ms(self) -> None:
+        from copilot_usage._formatting import format_duration
+
+        assert format_duration(999) == "999ms"
+
+    def test_exactly_one_second(self) -> None:
+        from copilot_usage._formatting import format_duration
+
+        assert format_duration(1000) == "1s"
+
+    def test_seconds_truncates_ms(self) -> None:
+        from copilot_usage._formatting import format_duration
+
+        assert format_duration(1500) == "1s 500ms"
+
+    def test_minutes_and_seconds(self) -> None:
+        from copilot_usage._formatting import format_duration
+
+        assert format_duration(389114) == "6m 29s 114ms"
+
+    def test_hours_minutes_seconds(self) -> None:
+        from copilot_usage._formatting import format_duration
+
+        assert format_duration(3661000) == "1h 1m 1s"
+
+    def test_exact_minute(self) -> None:
+        from copilot_usage._formatting import format_duration
+
+        assert format_duration(60000) == "1m"
+
+    def test_negative_clamped_to_zero(self) -> None:
+        from copilot_usage._formatting import format_duration
+
+        assert format_duration(-500) == "0ms"
+
+    def test_negative_one_clamped_to_zero(self) -> None:
+        from copilot_usage._formatting import format_duration
+
+        assert format_duration(-1) == "0ms"
+
+
+class TestFormatTimedelta:
+    """Tests for format_timedelta — timedelta to human-readable conversion."""
+
+    def test_sub_second_timedelta(self) -> None:
+        from datetime import timedelta
+
+        from copilot_usage._formatting import format_timedelta
+
+        assert format_timedelta(timedelta(milliseconds=481)) == "481ms"
+
+    def test_zero_timedelta(self) -> None:
+        from datetime import timedelta
+
+        from copilot_usage._formatting import format_timedelta
+
+        assert format_timedelta(timedelta(0)) == "0ms"
+
+    def test_seconds_timedelta(self) -> None:
+        from datetime import timedelta
+
+        from copilot_usage._formatting import format_timedelta
+
+        assert format_timedelta(timedelta(seconds=5)) == "5s"
+
+    def test_mixed_timedelta(self) -> None:
+        from datetime import timedelta
+
+        from copilot_usage._formatting import format_timedelta
+
+        assert (
+            format_timedelta(timedelta(hours=1, minutes=5, seconds=30)) == "1h 5m 30s"
+        )

--- a/tests/copilot_usage/test_report.py
+++ b/tests/copilot_usage/test_report.py
@@ -975,7 +975,7 @@ def test_format_tokens_exact_boundary_thousand() -> None:
 
 
 def test_format_duration_minutes_seconds() -> None:
-    assert format_duration(389_114) == "6m 29s"
+    assert format_duration(389_114) == "6m 29s 114ms"
 
 
 def test_format_duration_seconds_only() -> None:
@@ -983,11 +983,11 @@ def test_format_duration_seconds_only() -> None:
 
 
 def test_format_duration_zero() -> None:
-    assert format_duration(0) == "0s"
+    assert format_duration(0) == "0ms"
 
 
 def test_format_duration_negative() -> None:
-    assert format_duration(-100) == "0s"
+    assert format_duration(-100) == "0ms"
 
 
 def test_format_duration_hours() -> None:
@@ -1198,7 +1198,7 @@ class TestRenderSummary:
         )
         output = _capture_summary([session])
         assert "Copilot Usage Summary" in output
-        assert "0s" in output
+        assert "0ms" in output
 
     def test_summary_header_single_session_same_date_both_ends(self) -> None:
         """With a single session, earliest and latest are the same date."""
@@ -3897,12 +3897,12 @@ class TestFormatElapsedSince:
         assert result == "5m 30s"
 
     def test_zero_elapsed(self) -> None:
-        """When start == now, format is '0s'."""
+        """When start == now, format is '0ms'."""
         now = datetime(2025, 6, 1, 12, 0, 0, tzinfo=UTC)
         with patch("copilot_usage.report.datetime", wraps=datetime) as mock_dt:
             mock_dt.now.return_value = now
             result = _format_elapsed_since(now)
-        assert result == "0s"
+        assert result == "0ms"
 
 
 # ---------------------------------------------------------------------------
@@ -3939,7 +3939,7 @@ class TestFormatDetailDurationBoundaries:
 
 class TestFormatTimedelta:
     def test_zero(self) -> None:
-        assert format_timedelta(timedelta(0)) == "0s"
+        assert format_timedelta(timedelta(0)) == "0ms"
 
     def test_seconds_only(self) -> None:
         assert format_timedelta(timedelta(seconds=5)) == "5s"
@@ -3960,7 +3960,7 @@ class TestFormatTimedelta:
         assert format_timedelta(timedelta(hours=2, minutes=30)) == "2h 30m"
 
     def test_negative_clamped_to_zero(self) -> None:
-        assert format_timedelta(timedelta(seconds=-10)) == "0s"
+        assert format_timedelta(timedelta(seconds=-10)) == "0ms"
 
     def test_large_duration(self) -> None:
         assert (


### PR DESCRIPTION
Milliseconds are now shown everywhere in duration formatting, not just for sub-second values.

### Problem
`format_timedelta` called `int(td.total_seconds())` which threw away all sub-second precision. The vscode command showed `0s` for any API call under 1 second, and durations like `6m 29.114s` lost the `.114`.

### Fix
`format_timedelta` now always includes a millisecond component when there's a non-zero remainder:
- `481` → `481ms`
- `1500` → `1s 500ms`
- `389114` → `6m 29s 114ms`
- `5000` → `5s` (no ms when remainder is 0)
- `0` → `0ms`

### Tests
15 new unit tests covering sub-second, boundary, negative, and mixed cases. 7 existing tests updated.

Closes #467