### PR TITLE
test: add deferred-events cache overflow tests for get_all_sessions (#676)

### DIFF
--- a/tests/copilot_usage/test_parser.py
+++ b/tests/copilot_usage/test_parser.py
@@ -299,6 +299,60 @@ def _write_events(path: Path, *lines: str) -> Path:
     return path
 
 
+def _make_completed_session(base: Path, name: str, sid: str) -> Path:
+    """Create a completed session directory and return the events.jsonl path.
+
+    Writes start, user-message, and shutdown events — the minimal set
+    required to produce a valid completed ``SessionSummary``.
+    """
+    start = json.dumps(
+        {
+            "type": "session.start",
+            "data": {
+                "sessionId": sid,
+                "version": 1,
+                "startTime": "2026-03-07T10:00:00.000Z",
+                "context": {"cwd": "/"},
+            },
+            "id": f"ev-{sid}",
+            "timestamp": "2026-03-07T10:00:00.000Z",
+        }
+    )
+    user = json.dumps(
+        {
+            "type": "user.message",
+            "data": {
+                "content": "hi",
+                "transformedContent": "hi",
+                "attachments": [],
+                "interactionId": "int-1",
+            },
+            "id": f"ev-u-{sid}",
+            "timestamp": "2026-03-07T10:01:00.000Z",
+        }
+    )
+    shutdown = json.dumps(
+        {
+            "type": "session.shutdown",
+            "data": {
+                "shutdownType": "routine",
+                "totalPremiumRequests": 1,
+                "totalApiDurationMs": 500,
+                "sessionStartTime": 1772895600000,
+                "modelMetrics": {
+                    "gpt-5.1": {
+                        "requests": {"count": 1, "cost": 1},
+                        "usage": {"outputTokens": 50},
+                    }
+                },
+            },
+            "id": f"ev-sd-{sid}",
+            "timestamp": "2026-03-07T10:05:00.000Z",
+        }
+    )
+    return _write_events(base / name / "events.jsonl", start, user, shutdown)
+
+
 def _completed_events(
     tmp_path: Path,
 ) -> tuple[list[SessionEvent], Path]:
@@ -4855,54 +4909,10 @@ class TestFirstPassToolModel:
 class TestSessionCacheMtime:
     """get_all_sessions skips parse_events for files whose mtime is unchanged."""
 
-    def _make_session(self, base: Path, name: str, sid: str) -> Path:
-        """Create a completed session (with shutdown) and return events_path."""
-        start = json.dumps(
-            {
-                "type": "session.start",
-                "data": {
-                    "sessionId": sid,
-                    "version": 1,
-                    "startTime": "2026-03-07T10:00:00.000Z",
-                    "context": {"cwd": "/"},
-                },
-                "id": f"ev-{sid}",
-                "timestamp": "2026-03-07T10:00:00.000Z",
-            }
-        )
-        user = json.dumps(
-            {
-                "type": "user.message",
-                "data": {
-                    "content": "hi",
-                    "transformedContent": "hi",
-                    "attachments": [],
-                    "interactionId": "int-1",
-                },
-                "id": f"ev-u-{sid}",
-                "timestamp": "2026-03-07T10:01:00.000Z",
-            }
-        )
-        shutdown = json.dumps(
-            {
-                "type": "session.shutdown",
-                "data": {
-                    "shutdownType": "routine",
-                    "totalPremiumRequests": 1,
-                    "totalApiDurationMs": 500,
-                    "sessionStartTime": 1772895600000,
-                    "modelMetrics": {
-                        "gpt-5.1": {
-                            "requests": {"count": 1, "cost": 1},
-                            "usage": {"outputTokens": 50},
-                        }
-                    },
-                },
-                "id": f"ev-sd-{sid}",
-                "timestamp": "2026-03-07T10:05:00.000Z",
-            }
-        )
-        return _write_events(base / name / "events.jsonl", start, user, shutdown)
+    @staticmethod
+    def _make_session(base: Path, name: str, sid: str) -> Path:
+        """Create a completed session and return the events.jsonl path."""
+        return _make_completed_session(base, name, sid)
 
     def test_unchanged_file_not_reparsed(self, tmp_path: Path) -> None:
         """Only the file with a bumped mtime is re-parsed on the second call."""
@@ -5543,54 +5553,10 @@ class TestGetAllSessionsPopulatesEventsCache:
     subsequent get_cached_events calls avoid a redundant file re-read.
     """
 
-    def _make_session(self, base: Path, name: str, sid: str) -> Path:
+    @staticmethod
+    def _make_session(base: Path, name: str, sid: str) -> Path:
         """Create a completed session and return the events.jsonl path."""
-        start = json.dumps(
-            {
-                "type": "session.start",
-                "data": {
-                    "sessionId": sid,
-                    "version": 1,
-                    "startTime": "2026-03-07T10:00:00.000Z",
-                    "context": {"cwd": "/"},
-                },
-                "id": f"ev-{sid}",
-                "timestamp": "2026-03-07T10:00:00.000Z",
-            }
-        )
-        user = json.dumps(
-            {
-                "type": "user.message",
-                "data": {
-                    "content": "hi",
-                    "transformedContent": "hi",
-                    "attachments": [],
-                    "interactionId": "int-1",
-                },
-                "id": f"ev-u-{sid}",
-                "timestamp": "2026-03-07T10:01:00.000Z",
-            }
-        )
-        shutdown = json.dumps(
-            {
-                "type": "session.shutdown",
-                "data": {
-                    "shutdownType": "routine",
-                    "totalPremiumRequests": 1,
-                    "totalApiDurationMs": 500,
-                    "sessionStartTime": 1772895600000,
-                    "modelMetrics": {
-                        "gpt-5.1": {
-                            "requests": {"count": 1, "cost": 1},
-                            "usage": {"outputTokens": 50},
-                        }
-                    },
-                },
-                "id": f"ev-sd-{sid}",
-                "timestamp": "2026-03-07T10:05:00.000Z",
-            }
-        )
-        return _write_events(base / name / "events.jsonl", start, user, shutdown)
+        return _make_completed_session(base, name, sid)
 
     def test_cold_cache_populates_events_cache(self, tmp_path: Path) -> None:
         """After a cold get_all_sessions call, _EVENTS_CACHE contains entries."""
@@ -5633,59 +5599,15 @@ class TestGetAllSessionsEventsCacheOverflow:
     """Verify deferred-events overflow logic in get_all_sessions.
 
     When more than ``_MAX_CACHED_EVENTS`` sessions are discovered, only
-    the newest 8 are retained in ``_EVENTS_CACHE`` and the oldest are
-    excluded.  The insertion order ensures newest entries sit at the
-    MRU (back) of the ``OrderedDict``.
+    the newest ``_MAX_CACHED_EVENTS`` are retained in ``_EVENTS_CACHE``
+    and the oldest are excluded.  The insertion order ensures newest
+    entries sit at the MRU (back) of the ``OrderedDict``.
     """
 
-    def _make_session(self, base: Path, name: str, sid: str) -> Path:
+    @staticmethod
+    def _make_session(base: Path, name: str, sid: str) -> Path:
         """Create a completed session and return the events.jsonl path."""
-        start = json.dumps(
-            {
-                "type": "session.start",
-                "data": {
-                    "sessionId": sid,
-                    "version": 1,
-                    "startTime": "2026-03-07T10:00:00.000Z",
-                    "context": {"cwd": "/"},
-                },
-                "id": f"ev-{sid}",
-                "timestamp": "2026-03-07T10:00:00.000Z",
-            }
-        )
-        user = json.dumps(
-            {
-                "type": "user.message",
-                "data": {
-                    "content": "hi",
-                    "transformedContent": "hi",
-                    "attachments": [],
-                    "interactionId": "int-1",
-                },
-                "id": f"ev-u-{sid}",
-                "timestamp": "2026-03-07T10:01:00.000Z",
-            }
-        )
-        shutdown = json.dumps(
-            {
-                "type": "session.shutdown",
-                "data": {
-                    "shutdownType": "routine",
-                    "totalPremiumRequests": 1,
-                    "totalApiDurationMs": 500,
-                    "sessionStartTime": 1772895600000,
-                    "modelMetrics": {
-                        "gpt-5.1": {
-                            "requests": {"count": 1, "cost": 1},
-                            "usage": {"outputTokens": 50},
-                        }
-                    },
-                },
-                "id": f"ev-sd-{sid}",
-                "timestamp": "2026-03-07T10:05:00.000Z",
-            }
-        )
-        return _write_events(base / name / "events.jsonl", start, user, shutdown)
+        return _make_completed_session(base, name, sid)
 
     def _make_sessions_with_distinct_mtimes(self, base: Path, count: int) -> list[Path]:
         """Create *count* sessions with ascending mtimes (oldest first).
@@ -5707,14 +5629,14 @@ class TestGetAllSessionsEventsCacheOverflow:
         return paths
 
     def test_only_newest_max_sessions_cached(self, tmp_path: Path) -> None:
-        """With _MAX_CACHED_EVENTS + 1 sessions, only the 8 newest have
-        events cached."""
+        """With _MAX_CACHED_EVENTS + 1 sessions, only the newest
+        _MAX_CACHED_EVENTS have events cached."""
         total = _MAX_CACHED_EVENTS + 1
         paths = self._make_sessions_with_distinct_mtimes(tmp_path, total)
 
         get_all_sessions(tmp_path)
 
-        # The newest 8 sessions should be in _EVENTS_CACHE.
+        # The newest _MAX_CACHED_EVENTS sessions should be in _EVENTS_CACHE.
         for p in paths[-_MAX_CACHED_EVENTS:]:
             assert p in _EVENTS_CACHE, f"expected {p.parent.name} in cache"
         # The oldest session should NOT be in _EVENTS_CACHE.
@@ -5740,15 +5662,16 @@ class TestGetAllSessionsEventsCacheOverflow:
         assert len(events) == 3  # start + user + shutdown
 
     def test_newest_session_survives_subsequent_eviction(self, tmp_path: Path) -> None:
-        """After get_all_sessions with 8 sessions, adding a 9th via
-        get_cached_events evicts the oldest (LRU), not the newest (MRU)."""
+        """After get_all_sessions with _MAX_CACHED_EVENTS sessions, adding
+        one more via get_cached_events evicts the oldest (LRU), not the
+        newest (MRU)."""
         paths = self._make_sessions_with_distinct_mtimes(tmp_path, _MAX_CACHED_EVENTS)
         oldest_path = paths[0]
         newest_path = paths[-1]
 
         get_all_sessions(tmp_path)
 
-        # Confirm all 8 are cached.
+        # Confirm all _MAX_CACHED_EVENTS entries are cached.
         assert len(_EVENTS_CACHE) == _MAX_CACHED_EVENTS
         # Newest is at the back of _EVENTS_CACHE (MRU position).
         assert list(_EVENTS_CACHE.keys())[-1] == newest_path


### PR DESCRIPTION
Closes #676

Adds `TestGetAllSessionsEventsCacheOverflow` with three tests that exercise the `>8`-session deferred-events mechanism in `get_all_sessions`:

| Test | What it verifies |
|---|---|
| `test_only_newest_max_sessions_cached` | With 9 sessions, only the 8 newest have entries in `_EVENTS_CACHE`; the oldest is excluded |
| `test_excluded_session_reparses_on_get_cached_events` | The excluded (oldest) session triggers a re-parse when accessed via `get_cached_events` |
| `test_newest_session_survives_subsequent_eviction` | MRU ordering is correct — newest session sits at the back of the `OrderedDict` and survives when a 9th entry evicts the oldest (LRU) from the front |

All tests use explicit `os.utime` to guarantee deterministic mtime ordering regardless of filesystem timer resolution. The existing `autouse` fixture clears all caches between tests.

### Verification

- `ruff check` / `ruff format` — clean
- `pyright` — 0 errors
- `pytest --cov --cov-fail-under=80` — 1065 passed, 99.42% coverage




> Generated by [Issue Implementer](https://github.com/microsasa/cli-tools/actions/runs/23934600593/agentic_workflow) · [◷](https://github.com/search?q=repo%3Amicrosasa%2Fcli-tools+%22gh-aw-workflow-id%3A+issue-implementer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Issue Implementer, engine: copilot, model: claude-opus-4.6, id: 23934600593, workflow_id: issue-implementer, run: https://github.com/microsasa/cli-tools/actions/runs/23934600593 -->

<!-- gh-aw-workflow-id: issue-implementer -->