### PR TITLE
fix: add `log_files_found` to `VSCodeLogSummary`, remove redundant discover call (#677)

### DIFF
--- a/src/copilot_usage/cli.py
+++ b/src/copilot_usage/cli.py
@@ -35,7 +35,7 @@ from copilot_usage.report import (
     render_summary,
     session_display_name,
 )
-from copilot_usage.vscode_parser import discover_vscode_logs, get_vscode_summary
+from copilot_usage.vscode_parser import get_vscode_summary
 from copilot_usage.vscode_report import render_vscode_summary
 
 type _View = Literal["home", "detail", "cost"]
@@ -610,7 +610,7 @@ def vscode(vscode_logs: Path | None) -> None:
     _print_version_header()
     summary = get_vscode_summary(vscode_logs)
     if summary.total_requests == 0:
-        if summary.log_files_parsed == 0 and discover_vscode_logs(vscode_logs):
+        if summary.log_files_found > 0 and summary.log_files_parsed == 0:
             click.echo("Error: log files were found but could not be read.", err=True)
         else:
             click.echo("No VS Code Copilot Chat requests found.", err=True)

--- a/src/copilot_usage/vscode_parser.py
+++ b/src/copilot_usage/vscode_parser.py
@@ -62,6 +62,7 @@ class VSCodeLogSummary:
     # Latest timestamp seen (tail of the last batch).
     last_timestamp: datetime | None = None
     log_files_parsed: int = 0
+    log_files_found: int = 0
 
 
 def discover_vscode_logs(base_path: Path | None = None) -> list[Path]:
@@ -154,6 +155,7 @@ class _SummaryAccumulator:
     first_timestamp: datetime | None = None
     last_timestamp: datetime | None = None
     log_files_parsed: int = 0
+    log_files_found: int = 0
 
 
 def _update_vscode_summary(
@@ -198,6 +200,7 @@ def _finalize_summary(acc: _SummaryAccumulator) -> VSCodeLogSummary:
         first_timestamp=acc.first_timestamp,
         last_timestamp=acc.last_timestamp,
         log_files_parsed=acc.log_files_parsed,
+        log_files_found=acc.log_files_found,
     )
 
 
@@ -205,6 +208,7 @@ def build_vscode_summary(
     requests: list[VSCodeRequest],
     *,
     log_files_parsed: int = 0,
+    log_files_found: int = 0,
 ) -> VSCodeLogSummary:
     """Aggregate a list of parsed requests into a summary.
 
@@ -213,7 +217,10 @@ def build_vscode_summary(
     min/max scan, so out-of-order inputs will produce incorrect
     ``first_timestamp`` / ``last_timestamp`` values.
     """
-    acc = _SummaryAccumulator(log_files_parsed=log_files_parsed)
+    acc = _SummaryAccumulator(
+        log_files_parsed=log_files_parsed,
+        log_files_found=log_files_found,
+    )
     _update_vscode_summary(acc, requests)
     return _finalize_summary(acc)
 
@@ -221,7 +228,7 @@ def build_vscode_summary(
 def get_vscode_summary(base_path: Path | None = None) -> VSCodeLogSummary:
     """Discover, parse, and aggregate all VS Code Copilot Chat logs."""
     logs = discover_vscode_logs(base_path)
-    acc = _SummaryAccumulator()
+    acc = _SummaryAccumulator(log_files_found=len(logs))
     for log_path in logs:
         try:
             result = parse_vscode_log(log_path)

--- a/tests/copilot_usage/test_vscode_parser.py
+++ b/tests/copilot_usage/test_vscode_parser.py
@@ -12,6 +12,7 @@ from loguru import logger
 from copilot_usage.cli import main
 from copilot_usage.vscode_parser import (
     CCREQ_RE,
+    VSCodeLogSummary,
     VSCodeRequest,
     _SummaryAccumulator,  # pyright: ignore[reportPrivateUsage]
     _update_vscode_summary,  # pyright: ignore[reportPrivateUsage]
@@ -219,6 +220,13 @@ class TestBuildVscodeSummary:
         summary = build_vscode_summary(self._make_requests(), log_files_parsed=3)
         assert summary.log_files_parsed == 3
 
+    def test_log_files_found_param(self) -> None:
+        summary = build_vscode_summary(
+            self._make_requests(), log_files_parsed=2, log_files_found=5
+        )
+        assert summary.log_files_found == 5
+        assert summary.log_files_parsed == 2
+
 
 # ---------------------------------------------------------------------------
 # discover_vscode_logs — platform defaults
@@ -290,12 +298,14 @@ class TestGetVscodeSummary:
         summary = get_vscode_summary(tmp_path)
         assert summary.total_requests == 3
         assert summary.log_files_parsed == 1
+        assert summary.log_files_found == 1
         assert "claude-opus-4.6" in summary.requests_by_model
 
     def test_no_logs(self, tmp_path: Path) -> None:
         summary = get_vscode_summary(tmp_path)
         assert summary.total_requests == 0
         assert summary.log_files_parsed == 0
+        assert summary.log_files_found == 0
 
     def test_all_invalid_timestamps_still_counted_in_log_files_parsed(
         self, tmp_path: Path
@@ -422,6 +432,68 @@ class TestGetVscodeSummary:
         assert summary.total_requests == 1
         assert summary.requests_by_model["claude-sonnet-4"] == 1
 
+    def test_log_files_found_equals_discovered(self) -> None:
+        """log_files_found equals the number of paths from discover_vscode_logs."""
+        from datetime import datetime
+
+        paths = [Path(f"/fake/log_{i}.log") for i in range(3)]
+        req = VSCodeRequest(
+            timestamp=datetime(2026, 3, 13, 10, 0, 0),
+            request_id="a1",
+            model="gpt-4o",
+            duration_ms=100,
+            category="panel",
+        )
+
+        with (
+            patch(
+                "copilot_usage.vscode_parser.discover_vscode_logs",
+                return_value=paths,
+            ),
+            patch(
+                "copilot_usage.vscode_parser.parse_vscode_log",
+                return_value=[req],
+            ),
+        ):
+            summary = get_vscode_summary()
+
+        assert summary.log_files_found == 3
+        assert summary.log_files_parsed == 3
+
+    def test_log_files_found_vs_parsed_on_oserror(self) -> None:
+        """log_files_found counts all discovered; log_files_parsed only successes."""
+        from datetime import datetime
+
+        path1 = Path("/fake/log_1.log")
+        path2 = Path("/fake/log_2.log")
+        req = VSCodeRequest(
+            timestamp=datetime(2026, 3, 14, 12, 0, 0),
+            request_id="b1",
+            model="claude-sonnet-4",
+            duration_ms=300,
+            category="inline",
+        )
+
+        def _fake_parse(path: Path) -> list[VSCodeRequest]:
+            if path == path1:
+                raise OSError("Permission denied")
+            return [req]
+
+        with (
+            patch(
+                "copilot_usage.vscode_parser.discover_vscode_logs",
+                return_value=[path1, path2],
+            ),
+            patch(
+                "copilot_usage.vscode_parser.parse_vscode_log",
+                side_effect=_fake_parse,
+            ),
+        ):
+            summary = get_vscode_summary()
+
+        assert summary.log_files_found == 2
+        assert summary.log_files_parsed == 1
+
 
 # ---------------------------------------------------------------------------
 # CLI: vscode subcommand
@@ -514,6 +586,28 @@ class TestVscodeCliCommand:
         result = runner.invoke(main, ["vscode", "--vscode-logs", str(tmp_path)])
         assert result.exit_code == 0
         assert "VS Code Copilot Chat" in result.output
+
+    def test_all_files_error_shows_correct_message(self) -> None:
+        """Mock-only: log_files_found>0, log_files_parsed==0 → I/O error."""
+        summary = VSCodeLogSummary(
+            log_files_found=2, log_files_parsed=0, total_requests=0
+        )
+        with patch("copilot_usage.cli.get_vscode_summary", return_value=summary):
+            runner = CliRunner()
+            result = runner.invoke(main, ["vscode"])
+        assert result.exit_code == 1
+        assert "could not be read" in result.output
+
+    def test_no_files_shows_no_requests_message(self) -> None:
+        """Mock-only: log_files_found==0 → no-requests message."""
+        summary = VSCodeLogSummary(
+            log_files_found=0, log_files_parsed=0, total_requests=0
+        )
+        with patch("copilot_usage.cli.get_vscode_summary", return_value=summary):
+            runner = CliRunner()
+            result = runner.invoke(main, ["vscode"])
+        assert result.exit_code == 1
+        assert "No VS Code" in result.output
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #677

## Changes

1. **Added `log_files_found: int = 0` field** to both `VSCodeLogSummary` (frozen dataclass) and `_SummaryAccumulator` (mutable accumulator).

2. **Populated `log_files_found` in `get_vscode_summary`** — set to `len(logs)` before the parsing loop, so the information is captured atomically.

3. **Added `log_files_found` keyword to `build_vscode_summary`** — backward-compatible optional parameter, defaults to 0.

4. **Simplified `vscode` CLI command** — replaced the redundant second `discover_vscode_logs()` call with a check on `summary.log_files_found > 0`. This eliminates the TOCTOU race and the redundant filesystem scan. Removed the now-unused `discover_vscode_logs` import from `cli.py`.

5. **Updated `_finalize_summary`** to propagate `log_files_found` from accumulator to the frozen summary.

## Tests Added

- `test_log_files_found_equals_discovered` — mocks discover → N paths, all succeed; asserts `log_files_found == N`
- `test_log_files_found_vs_parsed_on_oserror` — one file raises OSError, one succeeds; asserts `found == 2`, `parsed == 1`
- `test_all_files_error_shows_correct_message` — mock-only CLI test: `log_files_found > 0, parsed == 0` → "could not be read"
- `test_no_files_shows_no_requests_message` — mock-only CLI test: `log_files_found == 0` → "No VS Code"
- `test_log_files_found_param` — verifies `build_vscode_summary(log_files_found=...)` passes through

All 1071 tests pass, coverage at 99.42%.




> Generated by [Issue Implementer](https://github.com/microsasa/cli-tools/actions/runs/23935500317/agentic_workflow) · [◷](https://github.com/search?q=repo%3Amicrosasa%2Fcli-tools+%22gh-aw-workflow-id%3A+issue-implementer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Issue Implementer, engine: copilot, model: claude-opus-4.6, id: 23935500317, workflow_id: issue-implementer, run: https://github.com/microsasa/cli-tools/actions/runs/23935500317 -->

<!-- gh-aw-workflow-id: issue-implementer -->