### PR TITLE
docs: add vscode command to architecture, implementation, and changelog

### DIFF
--- a/src/copilot_usage/docs/architecture.md
+++ b/src/copilot_usage/docs/architecture.md
@@ -41,6 +41,8 @@ Monorepo containing Python CLI utilities that share tooling, CI, and common depe
 | `_formatting.py` | Shared formatting utilities — `format_duration()` and `format_tokens()` with doctest-verified examples. Used by report.py and render_detail.py. |
 | `pricing.py` | Model pricing registry — multiplier lookup, tier categorization. Multipliers are used for `~`-prefixed cost estimates in live/active views (`render_live_sessions`, `render_cost_view`); historical post-shutdown views use exact API-provided numbers exclusively. |
 | `logging_config.py` | Loguru setup — stderr warnings only, no file output. Runtime `import loguru` for pyright to resolve the `"loguru.Record"` string annotation. Called once from CLI entry point. |
+| `vscode_parser.py` | VS Code Copilot Chat log parser — discovers log files per platform (macOS/Windows/Linux), parses `ccreq:` lines with regex, aggregates into `VSCodeLogSummary`. |
+| `vscode_report.py` | Rich rendering for VS Code usage data — totals panel, per-model table, feature breakdown, daily activity. Accepts optional `target_console` for testing. |
 
 ### Event Processing Pipeline
 
@@ -78,7 +80,9 @@ tests/
 │   ├── test_report.py          Rich output & session-detail rendering
 │   ├── test_formatting.py      Formatting helpers and string utilities
 │   ├── test_logging_config.py  Loguru configuration
-│   └── test_cli.py             Click command invocation via CliRunner
+│   ├── test_cli.py             Click command invocation via CliRunner
+│   ├── test_vscode_parser.py   VS Code log parsing, discovery, aggregation
+│   └── test_vscode_report.py   VS Code report rendering
 ├── test_packaging.py           Wheel build test — verifies docs excluded from distribution
 ├── test_docs.py                Documentation tests
 └── e2e/                        E2e tests — real CLI commands against fixture data

--- a/src/copilot_usage/docs/changelog.md
+++ b/src/copilot_usage/docs/changelog.md
@@ -5,6 +5,19 @@ Manual work only — autonomous agent pipeline PRs are not tracked here.
 
 ---
 
+## feat: add vscode command for VS Code Copilot Chat logs — 2026-03-30
+
+**PR**: #319 (by @AshleyF) — External contribution
+
+**Done**:
+- New `copilot-usage vscode` subcommand parses local VS Code Copilot Chat logs
+- `vscode_parser.py`: log discovery (macOS/Windows/Linux), `ccreq:` regex parsing, `VSCodeLogSummary` aggregation
+- `vscode_report.py`: Rich rendering — totals, per-model table, feature breakdown, daily activity
+- `pricing.py`: added VS Code models (`gpt-4o-mini`, `copilot-nes-oct`, `copilot-suggestions-himalia-001`)
+- 24+ unit tests covering regex, parsing, aggregation, discovery, CLI, and report rendering
+
+---
+
 ## refactor: split build_session_summary into focused helpers — 2026-03-28
 
 **PR**: #451 — Closes #224

--- a/src/copilot_usage/docs/implementation.md
+++ b/src/copilot_usage/docs/implementation.md
@@ -435,3 +435,43 @@ When no shutdown data exists, the model is resolved in `_build_active_summary()`
 
 1. Scan `tool.execution_complete` events for a `model` field
 2. Fall back to `~/.copilot/config.json` → `data.model` field (`_read_config_model()` in `parser.py`)
+
+---
+
+## VS Code Copilot Chat Logs
+
+### Overview
+
+The `vscode` subcommand parses VS Code Copilot Chat log files to show request counts, latency, and model usage. VS Code logs don't include token counts — only request-level data is available locally.
+
+### Log Discovery
+
+`discover_vscode_logs()` finds `GitHub Copilot Chat.log` files under platform-specific directories:
+
+- **macOS:** `~/Library/Application Support/Code/logs/`
+- **Windows:** `%APPDATA%/Code/logs/`
+- **Linux:** `~/.config/Code/logs/`
+
+It globs into date-stamped subdirectories (`*/window*/exthost/GitHub.copilot-chat/GitHub Copilot Chat.log`).
+
+### Log Format
+
+Each successful API request is logged as a `ccreq:` line:
+
+```
+2026-03-13 22:10:24.523 [info] ccreq:c0c8885e.copilotmd | success | claude-opus-4.6 | 8003ms | [panel/editAgent]
+```
+
+The `CCREQ_RE` regex in `vscode_parser.py` extracts: timestamp, request ID, model name, duration (ms), and feature category. Model redirects (e.g., `gpt-4o-mini -> gpt-4o-mini-2024-07-18`) are handled by capturing only the requested model name.
+
+### Aggregation
+
+`get_vscode_summary()` orchestrates: discover → parse each file → aggregate into `VSCodeLogSummary`. The summary tracks:
+
+- Total requests, total API duration, date range
+- Per-model request counts and durations
+- Per-category (feature) request counts
+- Daily request counts (last 14 days shown in report)
+- Log files discovered vs successfully parsed
+
+`parse_vscode_log()` raises `OSError` if a file can't be read. `get_vscode_summary()` catches it and skips unreadable files, so only successfully read files are counted in `log_files_parsed`.


### PR DESCRIPTION
Updates docs for the vscode command (PR #319 by @AshleyF).

- **architecture.md**: added `vscode_parser.py`, `vscode_report.py` to components table and test listing
- **implementation.md**: added VS Code section — log discovery, log format, `ccreq:` regex, aggregation pipeline
- **changelog.md**: added entry for the vscode command feature

README was already updated by Ashley in PR #319.

Closes #468