### PR TITLE
fix: use plain `list` as default_factory for toolRequests (#611)

### DIFF
--- a/src/copilot_usage/models.py
+++ b/src/copilot_usage/models.py
@@ -217,7 +217,7 @@ class AssistantMessageData(BaseModel):
     interactionId: str = ""
     reasoningText: str | None = None
     reasoningOpaque: str | None = None
-    toolRequests: list[ToolRequest] = Field(default_factory=list[ToolRequest])
+    toolRequests: list[ToolRequest] = Field(default_factory=list)  # type: ignore[reportUnknownVariableType]  # Pydantic infers element type from annotation
 
 
 class SessionShutdownData(BaseModel):


### PR DESCRIPTION
Closes #611

## Changes

Replaces `default_factory=list[ToolRequest]` with `default_factory=list` on
`AssistantMessageData.toolRequests`, aligning with the Pydantic convention
stated in `CODING_GUIDELINES.md` ("In Pydantic `Field`, `default_factory=list`
is fine").

`list[ToolRequest]` is a `types.GenericAlias` whose type parameter is silently
discarded at runtime — calling it produces an ordinary empty `list`, identical
to `list()`. The old form was misleading and inconsistent with other list fields
in the same file.

A targeted `# type: ignore[reportUnknownVariableType]` suppression is added
because pyright strict infers `list[Unknown]` from the bare `list` factory for
non-builtin element types, while Pydantic correctly derives the element type
from the field annotation.

## Verification

- `ruff check` / `ruff format` — clean
- `pyright` — 0 errors
- `pytest --cov --cov-fail-under=80` — 1073 passed, 99.42% coverage
- Existing `test_tool_requests_default_factory_isolation` passes (verifies
  instance isolation)




> Generated by [Issue Implementer](https://github.com/microsasa/cli-tools/actions/runs/23944192334/agentic_workflow) · [◷](https://github.com/search?q=repo%3Amicrosasa%2Fcli-tools+%22gh-aw-workflow-id%3A+issue-implementer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Issue Implementer, engine: copilot, model: claude-opus-4.6, id: 23944192334, workflow_id: issue-implementer, run: https://github.com/microsasa/cli-tools/actions/runs/23944192334 -->

<!-- gh-aw-workflow-id: issue-implementer -->