### PR TITLE
test: cover `_build_event_details` shutdown branch and missing catch-all types (#613)

### DIFF
--- a/tests/copilot_usage/test_report.py
+++ b/tests/copilot_usage/test_report.py
@@ -2959,6 +2959,19 @@ class TestBuildEventDetails:
         )
         assert _build_event_details(ev) == ""
 
+    def test_shutdown_event_nonempty_shutdown_type_shown_in_detail(self) -> None:
+        """SESSION_SHUTDOWN with shutdownType='normal' → _build_event_details returns 'type=normal'."""
+        ev = _make_event(
+            EventType.SESSION_SHUTDOWN,
+            data={
+                "shutdownType": "normal",
+                "totalPremiumRequests": 0,
+                "totalApiDurationMs": 0,
+            },
+            timestamp=None,
+        )
+        assert _build_event_details(ev) == "type=normal"
+
 
 class TestRenderShutdownCyclesEdgeCases:
     """Test _render_shutdown_cycles with edge-case summaries."""
@@ -3600,6 +3613,12 @@ class TestBuildEventDetailsCatchAll:
             EventType.SESSION_START,
             EventType.SESSION_RESUME,
             EventType.ABORT,
+            EventType.SESSION_ERROR,
+            EventType.SESSION_PLAN_CHANGED,
+            EventType.SESSION_WORKSPACE_FILE_CHANGED,
+            EventType.TOOL_EXECUTION_START,
+            EventType.ASSISTANT_TURN_START,
+            EventType.ASSISTANT_TURN_END,
         ],
     )
     def test_catch_all_returns_empty_string(self, event_type: str) -> None:


### PR DESCRIPTION
Closes #613

## Changes

Two test coverage gaps in `_build_event_details()` are addressed:

### 1. `SESSION_SHUTDOWN` with non-empty `shutdownType`

Added `test_shutdown_event_nonempty_shutdown_type_shown_in_detail` to `TestBuildEventDetails` — asserts that `_build_event_details(ev) == "type=normal"` when `shutdownType="normal"`. Previously this truthy branch was only exercised indirectly via the shutdown-cycles table output and a format-string change would go undetected.

### 2. Six missing catch-all event types

Extended the `TestBuildEventDetailsCatchAll` parametrize list from 3 to 9 event types, adding:
- `SESSION_ERROR`
- `SESSION_PLAN_CHANGED`
- `SESSION_WORKSPACE_FILE_CHANGED`
- `TOOL_EXECUTION_START`
- `ASSISTANT_TURN_START`
- `ASSISTANT_TURN_END`

All fall through to the `_:` catch-all and must return `""`.

## Verification

- `ruff check` — 0 errors
- `pyright` — 0 errors
- `pytest --cov --cov-fail-under=80` — 1080 tests passed, 99.42% coverage




> Generated by [Issue Implementer](https://github.com/microsasa/cli-tools/actions/runs/23944667806/agentic_workflow) · [◷](https://github.com/search?q=repo%3Amicrosasa%2Fcli-tools+%22gh-aw-workflow-id%3A+issue-implementer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Issue Implementer, engine: copilot, model: claude-opus-4.6, id: 23944667806, workflow_id: issue-implementer, run: https://github.com/microsasa/cli-tools/actions/runs/23944667806 -->

<!-- gh-aw-workflow-id: issue-implementer -->