### PR TITLE
fix: use typed default_factory for AssistantMessageData.toolRequests (#710)

### DIFF
--- a/src/copilot_usage/models.py
+++ b/src/copilot_usage/models.py
@@ -217,7 +217,7 @@ class AssistantMessageData(BaseModel):
     interactionId: str = ""
     reasoningText: str | None = None
     reasoningOpaque: str | None = None
-    toolRequests: list[ToolRequest] = Field(default_factory=list)  # type: ignore[reportUnknownVariableType]  # Pydantic infers element type from annotation
+    toolRequests: list[ToolRequest] = Field(default_factory=list[ToolRequest])
 
 
 class SessionShutdownData(BaseModel):

--- a/tests/copilot_usage/test_models.py
+++ b/tests/copilot_usage/test_models.py
@@ -20,6 +20,7 @@ from copilot_usage.models import (
     SessionSummary,
     TokenUsage,
     ToolExecutionData,
+    ToolRequest,
     UserMessageData,
     add_to_model_metrics,
     copy_model_metrics,
@@ -167,6 +168,20 @@ def test_assistant_message_data() -> None:
     d = AssistantMessageData.model_validate(RAW_ASSISTANT_MESSAGE["data"])
     assert d.outputTokens == 373
     assert d.reasoningText == "..."
+
+
+def test_assistant_message_data_tool_requests_default() -> None:
+    """toolRequests defaults to an empty list when not supplied."""
+    d = AssistantMessageData()
+    assert d.toolRequests == []
+
+
+def test_assistant_message_data_tool_requests_populated() -> None:
+    """toolRequests is populated correctly when provided."""
+    d = AssistantMessageData(toolRequests=[ToolRequest(name="bash", toolCallId="t1")])
+    assert len(d.toolRequests) == 1
+    assert d.toolRequests[0].name == "bash"
+    assert d.toolRequests[0].toolCallId == "t1"
 
 
 def test_session_shutdown_data() -> None:


### PR DESCRIPTION
Closes #710

## Changes

**`src/copilot_usage/models.py`** — Replace the `# type: ignore`-suppressed `default_factory=list` with the typed `default_factory=list[ToolRequest]`, matching the established pattern used by `shutdown_cycles` and other fields.

**`tests/copilot_usage/test_models.py`** — Add two tests:
- `test_assistant_message_data_tool_requests_default` — verifies the field defaults to `[]`
- `test_assistant_message_data_tool_requests_populated` — verifies the field accepts and stores `ToolRequest` instances correctly

## Verification

All CI checks pass locally:
- `ruff check` ✅
- `ruff format` ✅
- `pyright` — 0 errors, no `# type: ignore` needed ✅
- `pytest --cov --cov-fail-under=80` — 1113 tests passed, 99% coverage ✅




> Generated by [Issue Implementer](https://github.com/microsasa/cli-tools/actions/runs/23971242642/agentic_workflow) · [◷](https://github.com/search?q=repo%3Amicrosasa%2Fcli-tools+%22gh-aw-workflow-id%3A+issue-implementer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Issue Implementer, engine: copilot, model: claude-opus-4.6, id: 23971242642, workflow_id: issue-implementer, run: https://github.com/microsasa/cli-tools/actions/runs/23971242642 -->

<!-- gh-aw-workflow-id: issue-implementer -->