### PR TITLE
hotfix: remove keepalive-interval — gateway v0.2.12 rejects it

### DIFF
--- a/.github/workflows/ci-fixer.lock.yml
+++ b/.github/workflows/ci-fixer.lock.yml
@@ -21,7 +21,7 @@
 # For more information: https://github.github.com/gh-aw/introduction/overview/
 #
 #
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"d699425d137c33fe3fc0fe4ae15aec4e95a64fcc61bcc38bd93414ccbbd175e6","compiler_version":"v0.66.1","strict":true,"agent_id":"copilot","agent_model":"claude-opus-4.6"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"758fa9374f179a42496f526b463402eb4a8da6d9989669b7afa121352e870f66","compiler_version":"v0.66.1","strict":true,"agent_id":"copilot","agent_model":"claude-opus-4.6"}
 
 name: "CI Fixer"
 "on":
@@ -138,19 +138,19 @@ jobs:
         run: |
           bash ${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh
           {
-          cat << 'GH_AW_PROMPT_3428c18730ba6511_EOF'
+          cat << 'GH_AW_PROMPT_1e9d580590a02f80_EOF'
           <system>
-          GH_AW_PROMPT_3428c18730ba6511_EOF
+          GH_AW_PROMPT_1e9d580590a02f80_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_3428c18730ba6511_EOF'
+          cat << 'GH_AW_PROMPT_1e9d580590a02f80_EOF'
           <safe-output-tools>
           Tools: add_comment, add_labels, push_to_pull_request_branch, missing_tool, missing_data, noop
-          GH_AW_PROMPT_3428c18730ba6511_EOF
+          GH_AW_PROMPT_1e9d580590a02f80_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_push_to_pr_branch.md"
-          cat << 'GH_AW_PROMPT_3428c18730ba6511_EOF'
+          cat << 'GH_AW_PROMPT_1e9d580590a02f80_EOF'
           </safe-output-tools>
           <github-context>
           The following GitHub context information is available for this workflow:
@@ -183,12 +183,12 @@ jobs:
             - **Note**: If a branch you need is not in the list above and is not listed as an additional fetched ref, it has NOT been checked out. For private repositories you cannot fetch it without proper authentication. If the branch is required and not available, exit with an error and ask the user to add it to the `fetch:` option of the `checkout:` configuration (e.g., `fetch: ["refs/pulls/open/*"]` for all open PR refs, or `fetch: ["main", "feature/my-branch"]` for specific branches).
           </github-context>
           
-          GH_AW_PROMPT_3428c18730ba6511_EOF
+          GH_AW_PROMPT_1e9d580590a02f80_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_3428c18730ba6511_EOF'
+          cat << 'GH_AW_PROMPT_1e9d580590a02f80_EOF'
           </system>
           {{#runtime-import .github/workflows/ci-fixer.md}}
-          GH_AW_PROMPT_3428c18730ba6511_EOF
+          GH_AW_PROMPT_1e9d580590a02f80_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
@@ -356,12 +356,12 @@ jobs:
           mkdir -p ${RUNNER_TEMP}/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_48c60ebbdc3264b0_EOF'
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_02826b21703251da_EOF'
           {"add_comment":{"github-token":"${{ secrets.GH_AW_WRITE_TOKEN }}","max":1},"add_labels":{"github-token":"${{ secrets.GH_AW_WRITE_TOKEN }}"},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"false"},"push_to_pull_request_branch":{"github-token":"${{ secrets.GH_AW_WRITE_TOKEN }}","if_no_changes":"warn","labels":["aw"],"max_patch_size":1024,"protected_files":["package.json","bun.lockb","bunfig.toml","deno.json","deno.jsonc","deno.lock","global.json","NuGet.Config","Directory.Packages.props","mix.exs","mix.lock","go.mod","go.sum","stack.yaml","stack.yaml.lock","pom.xml","build.gradle","build.gradle.kts","settings.gradle","settings.gradle.kts","gradle.properties","package-lock.json","yarn.lock","pnpm-lock.yaml","npm-shrinkwrap.json","requirements.txt","Pipfile","Pipfile.lock","pyproject.toml","setup.py","setup.cfg","Gemfile","Gemfile.lock","uv.lock","CODEOWNERS"],"protected_path_prefixes":[".github/",".agents/"],"target":"*"}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_48c60ebbdc3264b0_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_02826b21703251da_EOF
       - name: Write Safe Outputs Tools
         run: |
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/tools_meta.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_META_aa3d5b76ef18c0a0_EOF'
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/tools_meta.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_META_765e072332fead61_EOF'
           {
             "description_suffixes": {
               "add_comment": " CONSTRAINTS: Maximum 1 comment(s) can be added."
@@ -369,8 +369,8 @@ jobs:
             "repo_params": {},
             "dynamic_tools": []
           }
-          GH_AW_SAFE_OUTPUTS_TOOLS_META_aa3d5b76ef18c0a0_EOF
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/validation.json << 'GH_AW_SAFE_OUTPUTS_VALIDATION_be7614d357cb8279_EOF'
+          GH_AW_SAFE_OUTPUTS_TOOLS_META_765e072332fead61_EOF
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/validation.json << 'GH_AW_SAFE_OUTPUTS_VALIDATION_5c2710c4bc7786d4_EOF'
           {
             "add_comment": {
               "defaultMax": 1,
@@ -487,7 +487,7 @@ jobs:
               }
             }
           }
-          GH_AW_SAFE_OUTPUTS_VALIDATION_be7614d357cb8279_EOF
+          GH_AW_SAFE_OUTPUTS_VALIDATION_5c2710c4bc7786d4_EOF
           node ${RUNNER_TEMP}/gh-aw/actions/generate_safe_outputs_tools.cjs
       - name: Generate Safe Outputs MCP Server Config
         id: safe-outputs-config
@@ -557,7 +557,7 @@ jobs:
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.2.12'
           
           mkdir -p /home/runner/.copilot
-          cat << GH_AW_MCP_CONFIG_6179e1f45a504973_EOF | bash ${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh
+          cat << GH_AW_MCP_CONFIG_c6af875b75d1fe76_EOF | bash ${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh
           {
             "mcpServers": {
               "github": {
@@ -595,11 +595,10 @@ jobs:
               "port": $MCP_GATEWAY_PORT,
               "domain": "${MCP_GATEWAY_DOMAIN}",
               "apiKey": "${MCP_GATEWAY_API_KEY}",
-              "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}",
-              "keepaliveInterval": 120
+              "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_6179e1f45a504973_EOF
+          GH_AW_MCP_CONFIG_c6af875b75d1fe76_EOF
       - name: Download activation artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:

--- a/.github/workflows/ci-fixer.md
+++ b/.github/workflows/ci-fixer.md
@@ -42,10 +42,6 @@ safe-outputs:
   add-comment:
     github-token: ${{ secrets.GH_AW_WRITE_TOKEN }}
 
-
-sandbox:
-  mcp:
-    keepalive-interval: 120
 ---
 
 # CI Fixer

--- a/.github/workflows/code-health.lock.yml
+++ b/.github/workflows/code-health.lock.yml
@@ -21,7 +21,7 @@
 # For more information: https://github.github.com/gh-aw/introduction/overview/
 #
 #
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"01bcf50091deea065935bb9351cc00110870013c302fc60b458a40b546a66cb3","compiler_version":"v0.66.1","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"305d421fb5c4e04389c12f8dc040dec24fd2bead046181143b588ea8fe2e6995","compiler_version":"v0.66.1","strict":true,"agent_id":"copilot"}
 
 name: "Code Health Analysis"
 "on":
@@ -136,14 +136,14 @@ jobs:
         run: |
           bash ${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh
           {
-          cat << 'GH_AW_PROMPT_6c1ea9ee8f582e03_EOF'
+          cat << 'GH_AW_PROMPT_7d6e89bfa955453b_EOF'
           <system>
-          GH_AW_PROMPT_6c1ea9ee8f582e03_EOF
+          GH_AW_PROMPT_7d6e89bfa955453b_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_6c1ea9ee8f582e03_EOF'
+          cat << 'GH_AW_PROMPT_7d6e89bfa955453b_EOF'
           <safe-output-tools>
           Tools: create_issue(max:2), missing_tool, missing_data, noop
           </safe-output-tools>
@@ -175,12 +175,12 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_6c1ea9ee8f582e03_EOF
+          GH_AW_PROMPT_7d6e89bfa955453b_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_6c1ea9ee8f582e03_EOF'
+          cat << 'GH_AW_PROMPT_7d6e89bfa955453b_EOF'
           </system>
           {{#runtime-import .github/workflows/code-health.md}}
-          GH_AW_PROMPT_6c1ea9ee8f582e03_EOF
+          GH_AW_PROMPT_7d6e89bfa955453b_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
@@ -339,12 +339,12 @@ jobs:
           mkdir -p ${RUNNER_TEMP}/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_77db872975768157_EOF'
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_a3011623ef28efcc_EOF'
           {"create_issue":{"github-token":"${{ secrets.GH_AW_WRITE_TOKEN }}","max":2},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"false"}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_77db872975768157_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_a3011623ef28efcc_EOF
       - name: Write Safe Outputs Tools
         run: |
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/tools_meta.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_META_a313889b0d6fc83b_EOF'
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/tools_meta.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_META_f001fb2c1ac364dd_EOF'
           {
             "description_suffixes": {
               "create_issue": " CONSTRAINTS: Maximum 2 issue(s) can be created."
@@ -352,8 +352,8 @@ jobs:
             "repo_params": {},
             "dynamic_tools": []
           }
-          GH_AW_SAFE_OUTPUTS_TOOLS_META_a313889b0d6fc83b_EOF
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/validation.json << 'GH_AW_SAFE_OUTPUTS_VALIDATION_7fb3d648deda06ab_EOF'
+          GH_AW_SAFE_OUTPUTS_TOOLS_META_f001fb2c1ac364dd_EOF
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/validation.json << 'GH_AW_SAFE_OUTPUTS_VALIDATION_93448ee42f5e15d1_EOF'
           {
             "create_issue": {
               "defaultMax": 1,
@@ -446,7 +446,7 @@ jobs:
               }
             }
           }
-          GH_AW_SAFE_OUTPUTS_VALIDATION_7fb3d648deda06ab_EOF
+          GH_AW_SAFE_OUTPUTS_VALIDATION_93448ee42f5e15d1_EOF
           node ${RUNNER_TEMP}/gh-aw/actions/generate_safe_outputs_tools.cjs
       - name: Generate Safe Outputs MCP Server Config
         id: safe-outputs-config
@@ -516,7 +516,7 @@ jobs:
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.2.12'
           
           mkdir -p /home/runner/.copilot
-          cat << GH_AW_MCP_CONFIG_beb4ee5a077726eb_EOF | bash ${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh
+          cat << GH_AW_MCP_CONFIG_ad8c4587623f19f1_EOF | bash ${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh
           {
             "mcpServers": {
               "github": {
@@ -554,11 +554,10 @@ jobs:
               "port": $MCP_GATEWAY_PORT,
               "domain": "${MCP_GATEWAY_DOMAIN}",
               "apiKey": "${MCP_GATEWAY_API_KEY}",
-              "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}",
-              "keepaliveInterval": 120
+              "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_beb4ee5a077726eb_EOF
+          GH_AW_MCP_CONFIG_ad8c4587623f19f1_EOF
       - name: Download activation artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:

--- a/.github/workflows/code-health.md
+++ b/.github/workflows/code-health.md
@@ -24,10 +24,6 @@ safe-outputs:
     max: 2
     github-token: ${{ secrets.GH_AW_WRITE_TOKEN }}
 
-
-sandbox:
-  mcp:
-    keepalive-interval: 120
 ---
 
 # Code Health Analysis

--- a/.github/workflows/feature-planner.lock.yml
+++ b/.github/workflows/feature-planner.lock.yml
@@ -21,7 +21,7 @@
 # For more information: https://github.github.com/gh-aw/introduction/overview/
 #
 #
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"d452f27d7de9c8cc6bab5f277524f44ee6ac1510d0a7710ba21f60715ecfc74c","compiler_version":"v0.66.1","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"e5e7615c70d667982c47348a50817054d0baf2d3520391d52cdadc809c5cb407","compiler_version":"v0.66.1","strict":true,"agent_id":"copilot"}
 
 name: "Feature Planner"
 "on":
@@ -136,14 +136,14 @@ jobs:
         run: |
           bash ${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh
           {
-          cat << 'GH_AW_PROMPT_9b8895af2963fa3f_EOF'
+          cat << 'GH_AW_PROMPT_4a68e86b8168d8c2_EOF'
           <system>
-          GH_AW_PROMPT_9b8895af2963fa3f_EOF
+          GH_AW_PROMPT_4a68e86b8168d8c2_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_9b8895af2963fa3f_EOF'
+          cat << 'GH_AW_PROMPT_4a68e86b8168d8c2_EOF'
           <safe-output-tools>
           Tools: create_issue, missing_tool, missing_data, noop
           </safe-output-tools>
@@ -175,12 +175,12 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_9b8895af2963fa3f_EOF
+          GH_AW_PROMPT_4a68e86b8168d8c2_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_9b8895af2963fa3f_EOF'
+          cat << 'GH_AW_PROMPT_4a68e86b8168d8c2_EOF'
           </system>
           {{#runtime-import .github/workflows/feature-planner.md}}
-          GH_AW_PROMPT_9b8895af2963fa3f_EOF
+          GH_AW_PROMPT_4a68e86b8168d8c2_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
@@ -339,12 +339,12 @@ jobs:
           mkdir -p ${RUNNER_TEMP}/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_a4ae72006eb931e4_EOF'
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_4c3b0ec77a37a4b2_EOF'
           {"create_issue":{"github-token":"${{ secrets.GH_AW_WRITE_TOKEN }}","max":1},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"false"}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_a4ae72006eb931e4_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_4c3b0ec77a37a4b2_EOF
       - name: Write Safe Outputs Tools
         run: |
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/tools_meta.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_META_5817adbc023c1e5b_EOF'
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/tools_meta.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_META_d919baa2e85cd2a3_EOF'
           {
             "description_suffixes": {
               "create_issue": " CONSTRAINTS: Maximum 1 issue(s) can be created."
@@ -352,8 +352,8 @@ jobs:
             "repo_params": {},
             "dynamic_tools": []
           }
-          GH_AW_SAFE_OUTPUTS_TOOLS_META_5817adbc023c1e5b_EOF
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/validation.json << 'GH_AW_SAFE_OUTPUTS_VALIDATION_e17d98eac430066b_EOF'
+          GH_AW_SAFE_OUTPUTS_TOOLS_META_d919baa2e85cd2a3_EOF
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/validation.json << 'GH_AW_SAFE_OUTPUTS_VALIDATION_dfcb7dc0f9485faf_EOF'
           {
             "create_issue": {
               "defaultMax": 1,
@@ -446,7 +446,7 @@ jobs:
               }
             }
           }
-          GH_AW_SAFE_OUTPUTS_VALIDATION_e17d98eac430066b_EOF
+          GH_AW_SAFE_OUTPUTS_VALIDATION_dfcb7dc0f9485faf_EOF
           node ${RUNNER_TEMP}/gh-aw/actions/generate_safe_outputs_tools.cjs
       - name: Generate Safe Outputs MCP Server Config
         id: safe-outputs-config
@@ -516,7 +516,7 @@ jobs:
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.2.12'
           
           mkdir -p /home/runner/.copilot
-          cat << GH_AW_MCP_CONFIG_90db6a5d7149480b_EOF | bash ${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh
+          cat << GH_AW_MCP_CONFIG_13de23ad2ece9792_EOF | bash ${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh
           {
             "mcpServers": {
               "github": {
@@ -554,11 +554,10 @@ jobs:
               "port": $MCP_GATEWAY_PORT,
               "domain": "${MCP_GATEWAY_DOMAIN}",
               "apiKey": "${MCP_GATEWAY_API_KEY}",
-              "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}",
-              "keepaliveInterval": 120
+              "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_90db6a5d7149480b_EOF
+          GH_AW_MCP_CONFIG_13de23ad2ece9792_EOF
       - name: Download activation artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:

--- a/.github/workflows/feature-planner.md
+++ b/.github/workflows/feature-planner.md
@@ -24,10 +24,6 @@ safe-outputs:
     max: 1
     github-token: ${{ secrets.GH_AW_WRITE_TOKEN }}
 
-
-sandbox:
-  mcp:
-    keepalive-interval: 120
 ---
 
 # Feature Planner

--- a/.github/workflows/issue-implementer.lock.yml
+++ b/.github/workflows/issue-implementer.lock.yml
@@ -21,7 +21,7 @@
 # For more information: https://github.github.com/gh-aw/introduction/overview/
 #
 #
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"afe5c4f9cd86f97545ae9b7efc6f02682731f32568c3066973083b5dd48db999","compiler_version":"v0.66.1","strict":true,"agent_id":"copilot","agent_model":"claude-opus-4.6"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"4bf6e6fac4f12e27d69748e222619fbbbb024a06d91ad63b336dff1612286086","compiler_version":"v0.66.1","strict":true,"agent_id":"copilot","agent_model":"claude-opus-4.6"}
 
 name: "Issue Implementer"
 "on":
@@ -138,20 +138,20 @@ jobs:
         run: |
           bash ${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh
           {
-          cat << 'GH_AW_PROMPT_947c4e82c6742643_EOF'
+          cat << 'GH_AW_PROMPT_c402dd2cebdd513b_EOF'
           <system>
-          GH_AW_PROMPT_947c4e82c6742643_EOF
+          GH_AW_PROMPT_c402dd2cebdd513b_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_947c4e82c6742643_EOF'
+          cat << 'GH_AW_PROMPT_c402dd2cebdd513b_EOF'
           <safe-output-tools>
           Tools: create_pull_request, push_to_pull_request_branch, missing_tool, missing_data, noop
-          GH_AW_PROMPT_947c4e82c6742643_EOF
+          GH_AW_PROMPT_c402dd2cebdd513b_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_create_pull_request.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_push_to_pr_branch.md"
-          cat << 'GH_AW_PROMPT_947c4e82c6742643_EOF'
+          cat << 'GH_AW_PROMPT_c402dd2cebdd513b_EOF'
           </safe-output-tools>
           <github-context>
           The following GitHub context information is available for this workflow:
@@ -181,12 +181,12 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_947c4e82c6742643_EOF
+          GH_AW_PROMPT_c402dd2cebdd513b_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_947c4e82c6742643_EOF'
+          cat << 'GH_AW_PROMPT_c402dd2cebdd513b_EOF'
           </system>
           {{#runtime-import .github/workflows/issue-implementer.md}}
-          GH_AW_PROMPT_947c4e82c6742643_EOF
+          GH_AW_PROMPT_c402dd2cebdd513b_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
@@ -346,12 +346,12 @@ jobs:
           mkdir -p ${RUNNER_TEMP}/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_6d25dce05a3c3ea1_EOF'
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_ca1d60c22b8a3ef4_EOF'
           {"create_pull_request":{"auto_merge":true,"draft":false,"github-token":"${{ secrets.GH_AW_WRITE_TOKEN }}","labels":["aw"],"max":1,"max_patch_size":1024,"protected_files":["package.json","bun.lockb","bunfig.toml","deno.json","deno.jsonc","deno.lock","global.json","NuGet.Config","Directory.Packages.props","mix.exs","mix.lock","go.mod","go.sum","stack.yaml","stack.yaml.lock","pom.xml","build.gradle","build.gradle.kts","settings.gradle","settings.gradle.kts","gradle.properties","package-lock.json","yarn.lock","pnpm-lock.yaml","npm-shrinkwrap.json","requirements.txt","Pipfile","Pipfile.lock","pyproject.toml","setup.py","setup.cfg","Gemfile","Gemfile.lock","uv.lock","CODEOWNERS"],"protected_files_policy":"fallback-to-issue","protected_path_prefixes":[".github/",".agents/"]},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"false"},"push_to_pull_request_branch":{"github-token":"${{ secrets.GH_AW_WRITE_TOKEN }}","if_no_changes":"warn","max_patch_size":1024,"protected_files":["package.json","bun.lockb","bunfig.toml","deno.json","deno.jsonc","deno.lock","global.json","NuGet.Config","Directory.Packages.props","mix.exs","mix.lock","go.mod","go.sum","stack.yaml","stack.yaml.lock","pom.xml","build.gradle","build.gradle.kts","settings.gradle","settings.gradle.kts","gradle.properties","package-lock.json","yarn.lock","pnpm-lock.yaml","npm-shrinkwrap.json","requirements.txt","Pipfile","Pipfile.lock","pyproject.toml","setup.py","setup.cfg","Gemfile","Gemfile.lock","uv.lock","CODEOWNERS"],"protected_path_prefixes":[".github/",".agents/"]}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_6d25dce05a3c3ea1_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_ca1d60c22b8a3ef4_EOF
       - name: Write Safe Outputs Tools
         run: |
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/tools_meta.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_META_dc385a0d38815b25_EOF'
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/tools_meta.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_META_4b040552b26d8b96_EOF'
           {
             "description_suffixes": {
               "create_pull_request": " CONSTRAINTS: Maximum 1 pull request(s) can be created. Labels [\"aw\"] will be automatically added."
@@ -359,8 +359,8 @@ jobs:
             "repo_params": {},
             "dynamic_tools": []
           }
-          GH_AW_SAFE_OUTPUTS_TOOLS_META_dc385a0d38815b25_EOF
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/validation.json << 'GH_AW_SAFE_OUTPUTS_VALIDATION_9a5638715c0e0627_EOF'
+          GH_AW_SAFE_OUTPUTS_TOOLS_META_4b040552b26d8b96_EOF
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/validation.json << 'GH_AW_SAFE_OUTPUTS_VALIDATION_f89cf319bf87a3e0_EOF'
           {
             "create_pull_request": {
               "defaultMax": 1,
@@ -476,7 +476,7 @@ jobs:
               }
             }
           }
-          GH_AW_SAFE_OUTPUTS_VALIDATION_9a5638715c0e0627_EOF
+          GH_AW_SAFE_OUTPUTS_VALIDATION_f89cf319bf87a3e0_EOF
           node ${RUNNER_TEMP}/gh-aw/actions/generate_safe_outputs_tools.cjs
       - name: Generate Safe Outputs MCP Server Config
         id: safe-outputs-config
@@ -546,7 +546,7 @@ jobs:
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.2.12'
           
           mkdir -p /home/runner/.copilot
-          cat << GH_AW_MCP_CONFIG_e84dd683e861f8b6_EOF | bash ${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh
+          cat << GH_AW_MCP_CONFIG_4f719e069c32842b_EOF | bash ${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh
           {
             "mcpServers": {
               "github": {
@@ -584,11 +584,10 @@ jobs:
               "port": $MCP_GATEWAY_PORT,
               "domain": "${MCP_GATEWAY_DOMAIN}",
               "apiKey": "${MCP_GATEWAY_API_KEY}",
-              "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}",
-              "keepaliveInterval": 120
+              "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_e84dd683e861f8b6_EOF
+          GH_AW_MCP_CONFIG_4f719e069c32842b_EOF
       - name: Download activation artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:

--- a/.github/workflows/issue-implementer.md
+++ b/.github/workflows/issue-implementer.md
@@ -37,10 +37,6 @@ safe-outputs:
   push-to-pull-request-branch:
     github-token: ${{ secrets.GH_AW_WRITE_TOKEN }}
 
-
-sandbox:
-  mcp:
-    keepalive-interval: 120
 ---
 
 # Issue Implementer

--- a/.github/workflows/perf-analysis.lock.yml
+++ b/.github/workflows/perf-analysis.lock.yml
@@ -21,7 +21,7 @@
 # For more information: https://github.github.com/gh-aw/introduction/overview/
 #
 #
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"9bee56538f6aaffbfcb93fe323676059d34041716a3b3399a506a8fc7a9822b8","compiler_version":"v0.66.1","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"927f9b55c10eb16a8aab5922b406b8fdc0d914868631eb9f4e8c949aff0ea74f","compiler_version":"v0.66.1","strict":true,"agent_id":"copilot"}
 
 name: "Performance Analysis"
 "on":
@@ -136,14 +136,14 @@ jobs:
         run: |
           bash ${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh
           {
-          cat << 'GH_AW_PROMPT_e11b46232c92dd60_EOF'
+          cat << 'GH_AW_PROMPT_aa5d854faa4b1c90_EOF'
           <system>
-          GH_AW_PROMPT_e11b46232c92dd60_EOF
+          GH_AW_PROMPT_aa5d854faa4b1c90_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_e11b46232c92dd60_EOF'
+          cat << 'GH_AW_PROMPT_aa5d854faa4b1c90_EOF'
           <safe-output-tools>
           Tools: create_issue(max:2), missing_tool, missing_data, noop
           </safe-output-tools>
@@ -175,12 +175,12 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_e11b46232c92dd60_EOF
+          GH_AW_PROMPT_aa5d854faa4b1c90_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_e11b46232c92dd60_EOF'
+          cat << 'GH_AW_PROMPT_aa5d854faa4b1c90_EOF'
           </system>
           {{#runtime-import .github/workflows/perf-analysis.md}}
-          GH_AW_PROMPT_e11b46232c92dd60_EOF
+          GH_AW_PROMPT_aa5d854faa4b1c90_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
@@ -339,12 +339,12 @@ jobs:
           mkdir -p ${RUNNER_TEMP}/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_22f07296dab12d8a_EOF'
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_03c0a5d82bc96f11_EOF'
           {"create_issue":{"github-token":"${{ secrets.GH_AW_WRITE_TOKEN }}","max":2},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"false"}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_22f07296dab12d8a_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_03c0a5d82bc96f11_EOF
       - name: Write Safe Outputs Tools
         run: |
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/tools_meta.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_META_02c1545ab1368e53_EOF'
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/tools_meta.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_META_7000136ffb85b04e_EOF'
           {
             "description_suffixes": {
               "create_issue": " CONSTRAINTS: Maximum 2 issue(s) can be created."
@@ -352,8 +352,8 @@ jobs:
             "repo_params": {},
             "dynamic_tools": []
           }
-          GH_AW_SAFE_OUTPUTS_TOOLS_META_02c1545ab1368e53_EOF
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/validation.json << 'GH_AW_SAFE_OUTPUTS_VALIDATION_08df821a019235b7_EOF'
+          GH_AW_SAFE_OUTPUTS_TOOLS_META_7000136ffb85b04e_EOF
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/validation.json << 'GH_AW_SAFE_OUTPUTS_VALIDATION_899bd81da9558287_EOF'
           {
             "create_issue": {
               "defaultMax": 1,
@@ -446,7 +446,7 @@ jobs:
               }
             }
           }
-          GH_AW_SAFE_OUTPUTS_VALIDATION_08df821a019235b7_EOF
+          GH_AW_SAFE_OUTPUTS_VALIDATION_899bd81da9558287_EOF
           node ${RUNNER_TEMP}/gh-aw/actions/generate_safe_outputs_tools.cjs
       - name: Generate Safe Outputs MCP Server Config
         id: safe-outputs-config
@@ -516,7 +516,7 @@ jobs:
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.2.12'
           
           mkdir -p /home/runner/.copilot
-          cat << GH_AW_MCP_CONFIG_229cb33c168be3bc_EOF | bash ${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh
+          cat << GH_AW_MCP_CONFIG_e846a100e295afb9_EOF | bash ${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh
           {
             "mcpServers": {
               "github": {
@@ -554,11 +554,10 @@ jobs:
               "port": $MCP_GATEWAY_PORT,
               "domain": "${MCP_GATEWAY_DOMAIN}",
               "apiKey": "${MCP_GATEWAY_API_KEY}",
-              "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}",
-              "keepaliveInterval": 120
+              "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_229cb33c168be3bc_EOF
+          GH_AW_MCP_CONFIG_e846a100e295afb9_EOF
       - name: Download activation artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:

--- a/.github/workflows/perf-analysis.md
+++ b/.github/workflows/perf-analysis.md
@@ -24,10 +24,6 @@ safe-outputs:
     max: 2
     github-token: ${{ secrets.GH_AW_WRITE_TOKEN }}
 
-
-sandbox:
-  mcp:
-    keepalive-interval: 120
 ---
 
 # Performance Analysis

--- a/.github/workflows/quality-gate.lock.yml
+++ b/.github/workflows/quality-gate.lock.yml
@@ -21,7 +21,7 @@
 # For more information: https://github.github.com/gh-aw/introduction/overview/
 #
 #
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"0e81926970626c4eb831a1c9e01aea65ace06bfd4a3c0034064bd44507a10b8d","compiler_version":"v0.66.1","strict":true,"agent_id":"copilot","agent_model":"claude-opus-4.6"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"9065f7641c6a8a15be280ac5bba1b5ab2bb0013c35a17e4d9c87058357b704da","compiler_version":"v0.66.1","strict":true,"agent_id":"copilot","agent_model":"claude-opus-4.6"}
 
 name: "Quality Gate"
 "on":
@@ -138,14 +138,14 @@ jobs:
         run: |
           bash ${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh
           {
-          cat << 'GH_AW_PROMPT_e8e6929fc21f366a_EOF'
+          cat << 'GH_AW_PROMPT_d8584094e447efdb_EOF'
           <system>
-          GH_AW_PROMPT_e8e6929fc21f366a_EOF
+          GH_AW_PROMPT_d8584094e447efdb_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_e8e6929fc21f366a_EOF'
+          cat << 'GH_AW_PROMPT_d8584094e447efdb_EOF'
           <safe-output-tools>
           Tools: add_comment, close_pull_request, submit_pull_request_review, add_labels, missing_tool, missing_data, noop
           </safe-output-tools>
@@ -177,12 +177,12 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_e8e6929fc21f366a_EOF
+          GH_AW_PROMPT_d8584094e447efdb_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_e8e6929fc21f366a_EOF'
+          cat << 'GH_AW_PROMPT_d8584094e447efdb_EOF'
           </system>
           {{#runtime-import .github/workflows/quality-gate.md}}
-          GH_AW_PROMPT_e8e6929fc21f366a_EOF
+          GH_AW_PROMPT_d8584094e447efdb_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
@@ -343,12 +343,12 @@ jobs:
           mkdir -p ${RUNNER_TEMP}/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_863c9a3ddf88b02a_EOF'
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_5c3c88b1e6a2ec63_EOF'
           {"add_comment":{"github-token":"${{ secrets.GH_AW_WRITE_TOKEN }}","max":1,"target":"${{ inputs.pr_number }}"},"add_labels":{"github-token":"${{ secrets.GH_AW_WRITE_TOKEN }}","target":"*"},"close_pull_request":{"github-token":"${{ secrets.GH_AW_WRITE_TOKEN }}","max":1,"target":"${{ inputs.pr_number }}"},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"false"},"submit_pull_request_review":{"footer":"always","github-token":"${{ secrets.GH_AW_WRITE_TOKEN }}","max":1,"target":"${{ inputs.pr_number }}"}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_863c9a3ddf88b02a_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_5c3c88b1e6a2ec63_EOF
       - name: Write Safe Outputs Tools
         run: |
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/tools_meta.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_META_8c15c3868270acb3_EOF'
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/tools_meta.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_META_ff641ff33766c0fe_EOF'
           {
             "description_suffixes": {
               "add_comment": " CONSTRAINTS: Maximum 1 comment(s) can be added. Target: ${{ inputs.pr_number }}.",
@@ -359,8 +359,8 @@ jobs:
             "repo_params": {},
             "dynamic_tools": []
           }
-          GH_AW_SAFE_OUTPUTS_TOOLS_META_8c15c3868270acb3_EOF
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/validation.json << 'GH_AW_SAFE_OUTPUTS_VALIDATION_12ade51cd1af0f37_EOF'
+          GH_AW_SAFE_OUTPUTS_TOOLS_META_ff641ff33766c0fe_EOF
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/validation.json << 'GH_AW_SAFE_OUTPUTS_VALIDATION_445ad6e8dbf1eb8b_EOF'
           {
             "add_comment": {
               "defaultMax": 1,
@@ -493,7 +493,7 @@ jobs:
               }
             }
           }
-          GH_AW_SAFE_OUTPUTS_VALIDATION_12ade51cd1af0f37_EOF
+          GH_AW_SAFE_OUTPUTS_VALIDATION_445ad6e8dbf1eb8b_EOF
           node ${RUNNER_TEMP}/gh-aw/actions/generate_safe_outputs_tools.cjs
       - name: Generate Safe Outputs MCP Server Config
         id: safe-outputs-config
@@ -563,7 +563,7 @@ jobs:
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.2.12'
           
           mkdir -p /home/runner/.copilot
-          cat << GH_AW_MCP_CONFIG_cb5267b08f22789a_EOF | bash ${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh
+          cat << GH_AW_MCP_CONFIG_5fa302108f7344bd_EOF | bash ${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh
           {
             "mcpServers": {
               "github": {
@@ -601,11 +601,10 @@ jobs:
               "port": $MCP_GATEWAY_PORT,
               "domain": "${MCP_GATEWAY_DOMAIN}",
               "apiKey": "${MCP_GATEWAY_API_KEY}",
-              "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}",
-              "keepaliveInterval": 120
+              "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_cb5267b08f22789a_EOF
+          GH_AW_MCP_CONFIG_5fa302108f7344bd_EOF
       - name: Download activation artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:

--- a/.github/workflows/quality-gate.md
+++ b/.github/workflows/quality-gate.md
@@ -42,10 +42,6 @@ safe-outputs:
     target: "*"
     github-token: ${{ secrets.GH_AW_WRITE_TOKEN }}
 
-
-sandbox:
-  mcp:
-    keepalive-interval: 120
 ---
 
 # Quality Gate

--- a/.github/workflows/review-responder.lock.yml
+++ b/.github/workflows/review-responder.lock.yml
@@ -25,7 +25,7 @@
 #   Imports:
 #     - shared/fetch-review-comments.md
 #
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"fbe02ebc187db11e27ed79267aa423fab9da227fde64a8e0585545474c804870","compiler_version":"v0.66.1","strict":true,"agent_id":"copilot","agent_model":"claude-opus-4.6"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"66aa5af030fe6385d40348b5ee30b6c7f1a44b0b8826d9ad6de1bd92b3cfbc9c","compiler_version":"v0.66.1","strict":true,"agent_id":"copilot","agent_model":"claude-opus-4.6"}
 
 name: "Review Responder"
 "on":
@@ -142,19 +142,19 @@ jobs:
         run: |
           bash ${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh
           {
-          cat << 'GH_AW_PROMPT_cc6178e67389ffa4_EOF'
+          cat << 'GH_AW_PROMPT_793a938b67e2b0b0_EOF'
           <system>
-          GH_AW_PROMPT_cc6178e67389ffa4_EOF
+          GH_AW_PROMPT_793a938b67e2b0b0_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_cc6178e67389ffa4_EOF'
+          cat << 'GH_AW_PROMPT_793a938b67e2b0b0_EOF'
           <safe-output-tools>
           Tools: reply_to_pull_request_review_comment(max:10), add_labels, push_to_pull_request_branch, missing_tool, missing_data, noop
-          GH_AW_PROMPT_cc6178e67389ffa4_EOF
+          GH_AW_PROMPT_793a938b67e2b0b0_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_push_to_pr_branch.md"
-          cat << 'GH_AW_PROMPT_cc6178e67389ffa4_EOF'
+          cat << 'GH_AW_PROMPT_793a938b67e2b0b0_EOF'
           </safe-output-tools>
           <github-context>
           The following GitHub context information is available for this workflow:
@@ -187,13 +187,13 @@ jobs:
             - **Note**: If a branch you need is not in the list above and is not listed as an additional fetched ref, it has NOT been checked out. For private repositories you cannot fetch it without proper authentication. If the branch is required and not available, exit with an error and ask the user to add it to the `fetch:` option of the `checkout:` configuration (e.g., `fetch: ["refs/pulls/open/*"]` for all open PR refs, or `fetch: ["main", "feature/my-branch"]` for specific branches).
           </github-context>
           
-          GH_AW_PROMPT_cc6178e67389ffa4_EOF
+          GH_AW_PROMPT_793a938b67e2b0b0_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_cc6178e67389ffa4_EOF'
+          cat << 'GH_AW_PROMPT_793a938b67e2b0b0_EOF'
           </system>
           {{#runtime-import .github/workflows/shared/fetch-review-comments.md}}
           {{#runtime-import .github/workflows/review-responder.md}}
-          GH_AW_PROMPT_cc6178e67389ffa4_EOF
+          GH_AW_PROMPT_793a938b67e2b0b0_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
@@ -367,12 +367,12 @@ jobs:
           mkdir -p ${RUNNER_TEMP}/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_b6138ed72332b5f0_EOF'
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_c424ae3782670268_EOF'
           {"add_labels":{"github-token":"${{ secrets.GH_AW_WRITE_TOKEN }}"},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"false"},"push_to_pull_request_branch":{"github-token":"${{ secrets.GH_AW_WRITE_TOKEN }}","if_no_changes":"warn","labels":["aw"],"max_patch_size":1024,"protected_files":["package.json","bun.lockb","bunfig.toml","deno.json","deno.jsonc","deno.lock","global.json","NuGet.Config","Directory.Packages.props","mix.exs","mix.lock","go.mod","go.sum","stack.yaml","stack.yaml.lock","pom.xml","build.gradle","build.gradle.kts","settings.gradle","settings.gradle.kts","gradle.properties","package-lock.json","yarn.lock","pnpm-lock.yaml","npm-shrinkwrap.json","requirements.txt","Pipfile","Pipfile.lock","pyproject.toml","setup.py","setup.cfg","Gemfile","Gemfile.lock","uv.lock","CODEOWNERS"],"protected_path_prefixes":[".github/",".agents/"],"target":"*"},"reply_to_pull_request_review_comment":{"github-token":"${{ secrets.GH_AW_WRITE_TOKEN }}","max":10,"target":"*"}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_b6138ed72332b5f0_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_c424ae3782670268_EOF
       - name: Write Safe Outputs Tools
         run: |
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/tools_meta.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_META_22e400484eaf096c_EOF'
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/tools_meta.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_META_005f4c0a01077603_EOF'
           {
             "description_suffixes": {
               "reply_to_pull_request_review_comment": " CONSTRAINTS: Maximum 10 reply/replies can be created."
@@ -380,8 +380,8 @@ jobs:
             "repo_params": {},
             "dynamic_tools": []
           }
-          GH_AW_SAFE_OUTPUTS_TOOLS_META_22e400484eaf096c_EOF
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/validation.json << 'GH_AW_SAFE_OUTPUTS_VALIDATION_3ef18230351d77e9_EOF'
+          GH_AW_SAFE_OUTPUTS_TOOLS_META_005f4c0a01077603_EOF
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/validation.json << 'GH_AW_SAFE_OUTPUTS_VALIDATION_f8eab9d83f6f6189_EOF'
           {
             "add_labels": {
               "defaultMax": 5,
@@ -502,7 +502,7 @@ jobs:
               }
             }
           }
-          GH_AW_SAFE_OUTPUTS_VALIDATION_3ef18230351d77e9_EOF
+          GH_AW_SAFE_OUTPUTS_VALIDATION_f8eab9d83f6f6189_EOF
           node ${RUNNER_TEMP}/gh-aw/actions/generate_safe_outputs_tools.cjs
       - name: Generate Safe Outputs MCP Server Config
         id: safe-outputs-config
@@ -572,7 +572,7 @@ jobs:
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.2.12'
           
           mkdir -p /home/runner/.copilot
-          cat << GH_AW_MCP_CONFIG_670c0febae4a2427_EOF | bash ${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh
+          cat << GH_AW_MCP_CONFIG_f5b5c9a2a2630bdf_EOF | bash ${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh
           {
             "mcpServers": {
               "github": {
@@ -610,11 +610,10 @@ jobs:
               "port": $MCP_GATEWAY_PORT,
               "domain": "${MCP_GATEWAY_DOMAIN}",
               "apiKey": "${MCP_GATEWAY_API_KEY}",
-              "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}",
-              "keepaliveInterval": 120
+              "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_670c0febae4a2427_EOF
+          GH_AW_MCP_CONFIG_f5b5c9a2a2630bdf_EOF
       - name: Download activation artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:

--- a/.github/workflows/review-responder.md
+++ b/.github/workflows/review-responder.md
@@ -46,10 +46,6 @@ safe-outputs:
   add-labels:
     github-token: ${{ secrets.GH_AW_WRITE_TOKEN }}
 
-
-sandbox:
-  mcp:
-    keepalive-interval: 120
 ---
 
 # Review Responder

--- a/.github/workflows/test-analysis.lock.yml
+++ b/.github/workflows/test-analysis.lock.yml
@@ -21,7 +21,7 @@
 # For more information: https://github.github.com/gh-aw/introduction/overview/
 #
 #
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"6f96c600ca20dc622e2f7c0575588ae652c5d65696a50917a4a9ce2615ed972f","compiler_version":"v0.66.1","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"fb3ba76efad5d2eb36aa6647532141853cc339fd21245a061d31c8f3835f67e5","compiler_version":"v0.66.1","strict":true,"agent_id":"copilot"}
 
 name: "Test Suite Analysis"
 "on":
@@ -136,14 +136,14 @@ jobs:
         run: |
           bash ${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh
           {
-          cat << 'GH_AW_PROMPT_d91a35d6edfa4239_EOF'
+          cat << 'GH_AW_PROMPT_5aac1f476bd0e335_EOF'
           <system>
-          GH_AW_PROMPT_d91a35d6edfa4239_EOF
+          GH_AW_PROMPT_5aac1f476bd0e335_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_d91a35d6edfa4239_EOF'
+          cat << 'GH_AW_PROMPT_5aac1f476bd0e335_EOF'
           <safe-output-tools>
           Tools: create_issue(max:2), missing_tool, missing_data, noop
           </safe-output-tools>
@@ -175,12 +175,12 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_d91a35d6edfa4239_EOF
+          GH_AW_PROMPT_5aac1f476bd0e335_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_d91a35d6edfa4239_EOF'
+          cat << 'GH_AW_PROMPT_5aac1f476bd0e335_EOF'
           </system>
           {{#runtime-import .github/workflows/test-analysis.md}}
-          GH_AW_PROMPT_d91a35d6edfa4239_EOF
+          GH_AW_PROMPT_5aac1f476bd0e335_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
@@ -339,12 +339,12 @@ jobs:
           mkdir -p ${RUNNER_TEMP}/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_27135c0ec1f7a47c_EOF'
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_52b70f831c2428f6_EOF'
           {"create_issue":{"github-token":"${{ secrets.GH_AW_WRITE_TOKEN }}","max":2},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"false"}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_27135c0ec1f7a47c_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_52b70f831c2428f6_EOF
       - name: Write Safe Outputs Tools
         run: |
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/tools_meta.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_META_462ad9cf1c9d88c9_EOF'
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/tools_meta.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_META_9c0cac1f6d673abb_EOF'
           {
             "description_suffixes": {
               "create_issue": " CONSTRAINTS: Maximum 2 issue(s) can be created."
@@ -352,8 +352,8 @@ jobs:
             "repo_params": {},
             "dynamic_tools": []
           }
-          GH_AW_SAFE_OUTPUTS_TOOLS_META_462ad9cf1c9d88c9_EOF
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/validation.json << 'GH_AW_SAFE_OUTPUTS_VALIDATION_60dcf8d9c0334e19_EOF'
+          GH_AW_SAFE_OUTPUTS_TOOLS_META_9c0cac1f6d673abb_EOF
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/validation.json << 'GH_AW_SAFE_OUTPUTS_VALIDATION_1b867d27acc16ae8_EOF'
           {
             "create_issue": {
               "defaultMax": 1,
@@ -446,7 +446,7 @@ jobs:
               }
             }
           }
-          GH_AW_SAFE_OUTPUTS_VALIDATION_60dcf8d9c0334e19_EOF
+          GH_AW_SAFE_OUTPUTS_VALIDATION_1b867d27acc16ae8_EOF
           node ${RUNNER_TEMP}/gh-aw/actions/generate_safe_outputs_tools.cjs
       - name: Generate Safe Outputs MCP Server Config
         id: safe-outputs-config
@@ -516,7 +516,7 @@ jobs:
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.2.12'
           
           mkdir -p /home/runner/.copilot
-          cat << GH_AW_MCP_CONFIG_8ce22741bc8564d3_EOF | bash ${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh
+          cat << GH_AW_MCP_CONFIG_703d3b4583811ec4_EOF | bash ${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh
           {
             "mcpServers": {
               "github": {
@@ -554,11 +554,10 @@ jobs:
               "port": $MCP_GATEWAY_PORT,
               "domain": "${MCP_GATEWAY_DOMAIN}",
               "apiKey": "${MCP_GATEWAY_API_KEY}",
-              "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}",
-              "keepaliveInterval": 120
+              "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_8ce22741bc8564d3_EOF
+          GH_AW_MCP_CONFIG_703d3b4583811ec4_EOF
       - name: Download activation artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:

--- a/.github/workflows/test-analysis.md
+++ b/.github/workflows/test-analysis.md
@@ -24,10 +24,6 @@ safe-outputs:
     max: 2
     github-token: ${{ secrets.GH_AW_WRITE_TOKEN }}
 
-
-sandbox:
-  mcp:
-    keepalive-interval: 120
 ---
 
 # Test Suite Analysis


### PR DESCRIPTION
Emergency fix. The keepaliveInterval config added in PR #709 is rejected by MCP Gateway v0.2.12 schema validation. Every agent workflow has been failing since the upgrade.

Removes sandbox.mcp.keepalive-interval from all 8 workflow frontmatters and recompiles. The v0.66.1 upgrade itself is fine.

The 5-minute MCP timeout (#707) remains open — we need a gateway version that actually supports the keepalive field before we can configure it.

Fixes #718