### PR TITLE
test: add e2e assertions for Code Changes rendering (#721)

### DIFF
--- a/tests/e2e/test_e2e.py
+++ b/tests/e2e/test_e2e.py
@@ -614,7 +614,7 @@ class TestPureActiveSessionActivityE2E:
         """Pure active session appears in the live view."""
         result = CliRunner().invoke(main, ["live", "--path", str(FIXTURES)])
         assert result.exit_code == 0
-        clean = re.sub(r"\x1b\[[0-9;]*m", "", result.output)
+        clean = _strip_ansi(result.output)
         lines = clean.splitlines()
         active_line = next(line for line in lines if "pure-act" in line)
         # Live table columns: Session ID | Name | Model | Running | Messages | Output Tokens | CWD
@@ -698,7 +698,7 @@ class TestCostDateFilterE2E:
             line for line in result.output.splitlines() if "Grand Total" in line
         )
         columns = [c.strip() for c in grand_total_line.split("│")]
-        premium_cost_col = re.sub(r"\x1b\[[0-9;]*m", "", columns[4])
+        premium_cost_col = _strip_ansi(columns[4])
         assert premium_cost_col == "288"
 
     def test_cost_until_excludes_newer_sessions(self) -> None:
@@ -718,7 +718,7 @@ class TestCostDateFilterE2E:
             line for line in result.output.splitlines() if "Grand Total" in line
         )
         columns = [c.strip() for c in grand_total_line.split("│")]
-        premium_cost_col = re.sub(r"\x1b\[[0-9;]*m", "", columns[4])
+        premium_cost_col = _strip_ansi(columns[4])
         assert premium_cost_col == "537"
 
     def test_cost_inverted_date_range_shows_error(self) -> None:
@@ -736,7 +736,7 @@ class TestCostDateFilterE2E:
             ],
         )
         assert result.exit_code != 0
-        output = re.sub(r"\x1b\[[0-9;]*m", "", result.output)
+        output = _strip_ansi(result.output)
         assert "--since" in output
         assert "after" in output
 


### PR DESCRIPTION
Closes #721

## What

Adds 4 end-to-end tests verifying that the `session` command correctly renders code change data from fixture shutdown events.

## Tests Added

| Class | Test | Assertion |
|---|---|---|
| `TestSessionE2E` | `test_session_detail_shows_code_changes` | "Code Changes" panel present, 1877 added / 71 removed |
| `TestSessionE2E` | `test_session_detail_shows_modified_files` | "files" appears in output |
| `TestMultiShutdownCompletedE2E` | `test_code_changes_aggregated_across_shutdowns` | Cross-cycle sum: 40+120=160 linesAdded |
| `TestMultiShutdownResumedE2E` | `test_code_changes_present_in_active_resumed_session` | Resumed session sum: 20+55=75 linesAdded |

## Regression Scenarios Covered

1. **Deserialization** — If `codeChanges` key or Pydantic alias changed, these e2e tests fail (unit tests construct models directly and wouldn't catch it).
2. **Accumulation** — If multi-shutdown line-count summing broke, only the e2e multi-shutdown tests catch it.
3. **Conditional rendering** — If `_render_code_changes` were gated on a flag, only e2e detects the end-to-end failure.

## Verification

All checks pass locally: `ruff check`, `ruff format`, `pyright` (0 errors), `pytest --cov --cov-fail-under=80` (1125 passed, 99% coverage).




> Generated by [Issue Implementer](https://github.com/microsasa/cli-tools/actions/runs/23980788716/agentic_workflow) · ● 5.2M · [◷](https://github.com/search?q=repo%3Amicrosasa%2Fcli-tools+%22gh-aw-workflow-id%3A+issue-implementer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Issue Implementer, engine: copilot, model: claude-opus-4.6, id: 23980788716, workflow_id: issue-implementer, run: https://github.com/microsasa/cli-tools/actions/runs/23980788716 -->

<!-- gh-aw-workflow-id: issue-implementer -->