### PR TITLE
fix: bound `_SESSION_CACHE` with OrderedDict LRU eviction (#722)

### DIFF
--- a/src/copilot_usage/parser.py
+++ b/src/copilot_usage/parser.py
@@ -756,17 +756,19 @@ def get_all_sessions(base_path: Path | None = None) -> list[SessionSummary]:
     current_config_model = _read_config_model(None)
     discovered = _discover_with_identity(base_path)
     summaries: list[SessionSummary] = []
-    # Deferred _EVENTS_CACHE insertions.  _discover_with_identity returns
-    # sessions newest-first; inserting in that order would place the
-    # newest entries at the *front* of the OrderedDict where they would
-    # be evicted first by popitem(last=False).  We collect them here and
-    # insert in reversed (oldest→newest) order after the loop so that
-    # the newest sessions end up at the back (MRU) and eviction drops
-    # the oldest (LRU) entries.
+    # Deferred cache insertions.  _discover_with_identity returns sessions
+    # newest-first; inserting or promoting in that order would leave the
+    # oldest session at MRU and the newest at LRU (wrong).  We collect
+    # cache writes here and apply them in reversed (oldest→newest) order
+    # after the loop so that the newest sessions end up at the back (MRU)
+    # and eviction drops the oldest (LRU) entries.
     #
-    # Only the newest _MAX_CACHED_EVENTS entries are retained to avoid a
-    # temporary memory spike when many sessions are cache-misses.
+    # Only the newest _MAX_CACHED_EVENTS entries are retained for
+    # _EVENTS_CACHE to avoid a temporary memory spike when many sessions
+    # are cache-misses.
     deferred_events: list[tuple[Path, tuple[int, int] | None, list[SessionEvent]]] = []
+    deferred_sessions: list[tuple[Path, _CachedSession]] = []
+    cache_hit_paths: list[Path] = []
     for events_path, file_id, plan_id in discovered:
         cached = _SESSION_CACHE.get(events_path)
         # Config changes only invalidate cached entries that declared a
@@ -782,19 +784,21 @@ def get_all_sessions(base_path: Path | None = None) -> list[SessionSummary]:
             if plan_id != cached.plan_id:
                 fresh_name = _extract_session_name(events_path.parent)
                 summary = cached.summary.model_copy(update={"name": fresh_name})
-                _insert_session_entry(
-                    events_path,
-                    _CachedSession(
-                        file_id,
-                        plan_id,
-                        cached.config_model,
-                        cached.depends_on_config,
-                        summary,
-                    ),
+                deferred_sessions.append(
+                    (
+                        events_path,
+                        _CachedSession(
+                            file_id,
+                            plan_id,
+                            cached.config_model,
+                            cached.depends_on_config,
+                            summary,
+                        ),
+                    )
                 )
             else:
                 summary = cached.summary
-                _SESSION_CACHE.move_to_end(events_path)
+                cache_hit_paths.append(events_path)
             summaries.append(summary)
             continue
         try:
@@ -813,17 +817,30 @@ def get_all_sessions(base_path: Path | None = None) -> list[SessionSummary]:
             plan_exists=plan_id is not None,
         )
         summary = meta.summary
-        _insert_session_entry(
-            events_path,
-            _CachedSession(
-                file_id,
-                plan_id,
-                current_config_model if meta.used_config_fallback else None,
-                meta.used_config_fallback,
-                summary,
-            ),
+        deferred_sessions.append(
+            (
+                events_path,
+                _CachedSession(
+                    file_id,
+                    plan_id,
+                    current_config_model if meta.used_config_fallback else None,
+                    meta.used_config_fallback,
+                    summary,
+                ),
+            )
         )
         summaries.append(summary)
+
+    # Populate _SESSION_CACHE in oldest→newest order so that the newest
+    # sessions sit at the back (MRU) and eviction drops the oldest.
+    for ep, entry in reversed(deferred_sessions):
+        _insert_session_entry(ep, entry)
+
+    # Promote unchanged cache hits in oldest→newest order so that the
+    # newest sessions end up at the MRU position.
+    for ep in reversed(cache_hit_paths):
+        if ep in _SESSION_CACHE:
+            _SESSION_CACHE.move_to_end(ep)
 
     # Populate _EVENTS_CACHE in oldest→newest order so that the newest
     # sessions sit at the back (MRU) and eviction drops the oldest.

--- a/tests/copilot_usage/test_parser.py
+++ b/tests/copilot_usage/test_parser.py
@@ -6240,12 +6240,32 @@ class TestSessionCacheLRUEviction:
     def test_cache_bounded_after_many_sessions(self, tmp_path: Path) -> None:
         """get_all_sessions with > _MAX_CACHED_SESSIONS dirs caps the cache."""
         total = _MAX_CACHED_SESSIONS + 10
+        created_paths: list[Path] = []
+        base_mtime = time.time()
+
         for i in range(total):
-            _make_completed_session(tmp_path, f"sess-{i:04d}", f"sid-{i:04d}")
+            session_path = _make_completed_session(
+                tmp_path, f"sess-{i:04d}", f"sid-{i:04d}"
+            )
+            created_paths.append(session_path)
+
+            # Make recency deterministic so the newest sessions are unambiguous.
+            mtime = base_mtime + i
+            os.utime(session_path, (mtime, mtime))
+            os.utime(session_path.parent, (mtime, mtime))
 
         summaries = get_all_sessions(tmp_path)
         assert len(summaries) == total
-        assert len(_SESSION_CACHE) <= _MAX_CACHED_SESSIONS
+        assert len(_SESSION_CACHE) == _MAX_CACHED_SESSIONS
+
+        oldest_paths = created_paths[: total - _MAX_CACHED_SESSIONS]
+        newest_paths = created_paths[total - _MAX_CACHED_SESSIONS :]
+
+        for path in oldest_paths:
+            assert path not in _SESSION_CACHE
+
+        for path in newest_paths:
+            assert path in _SESSION_CACHE
 
     def test_insert_session_entry_evicts_lru(self) -> None:
         """_insert_session_entry evicts the oldest entry at capacity."""
@@ -6271,26 +6291,42 @@ class TestSessionCacheLRUEviction:
         assert Path("/fake/new/events.jsonl") in _SESSION_CACHE
 
     def test_cache_hit_promotes_to_mru(self, tmp_path: Path) -> None:
-        """Accessing a cached session moves it to the MRU end."""
-        # Create 3 sessions.
+        """Accessing a cached session promotes it in correct LRU order."""
+        # Create 3 sessions and force a deterministic discovery order:
+        # newest-first by mtime => p3, p2, p1.
         p1 = _make_completed_session(tmp_path, "sess-a", "sid-a")
         p2 = _make_completed_session(tmp_path, "sess-b", "sid-b")
         p3 = _make_completed_session(tmp_path, "sess-c", "sid-c")
+        base_time = time.time()
+        os.utime(p1, (base_time - 30, base_time - 30))
+        os.utime(p2, (base_time - 20, base_time - 20))
+        os.utime(p3, (base_time - 10, base_time - 10))
 
         get_all_sessions(tmp_path)
         assert p1 in _SESSION_CACHE
         assert p2 in _SESSION_CACHE
         assert p3 in _SESSION_CACHE
 
-        # Second call hits the cache; all sessions should be promoted
-        # (discovery order is newest-first by mtime).
+        # After first call, oldest (p1) should be at front (LRU) and
+        # newest (p3) at back (MRU).
+        assert list(_SESSION_CACHE) == [p1, p2, p3]
+
+        # Scramble the cache order so the next call must actively
+        # restore the correct LRU ordering.
+        _SESSION_CACHE.move_to_end(p3, last=False)
+        assert list(_SESSION_CACHE) == [p3, p1, p2]
+
+        # Second call hits the cache; all sessions should be promoted in
+        # oldest→newest order, restoring newest-at-MRU.
         get_all_sessions(tmp_path)
 
-        # Cache should still contain all three sessions.
+        # Cache should still contain all three sessions, and the newest
+        # entry (p3) should be last (MRU).
         assert len(_SESSION_CACHE) == 3
+        assert list(_SESSION_CACHE) == [p1, p2, p3]
 
     def test_stale_pruning_bounded(self, tmp_path: Path) -> None:
-        """Stale pruning only iterates at most _MAX_CACHED_SESSIONS entries."""
+        """Stale entries for deleted session directories are removed from the cache."""
         import shutil
 
         total = 5


### PR DESCRIPTION
Closes #722

## Problem

`_SESSION_CACHE` was an unbounded `dict[Path, _CachedSession]` that grew proportionally to the number of session directories on disk. Each cached entry holds ~5–10 KB of Python objects, so at 500+ sessions the cache consumes 2.5–5 MB of memory that is never reclaimed. The stale-pruning loop also iterates all cache entries on every `get_all_sessions()` call.

## Solution

Applied the same `OrderedDict`-based LRU eviction pattern already used by `_EVENTS_CACHE`:

- **`_MAX_CACHED_SESSIONS = 512`** — bounds memory to ~4 MB regardless of disk session count
- **`_insert_session_entry()`** — helper that evicts the LRU (oldest) entry when the cache is full
- **`move_to_end()`** on cache hits — promotes accessed sessions to MRU position
- Stale-pruning iteration is now bounded to at most 512 entries per call

## Tests

Added `TestSessionCacheLRUEviction` with 4 tests:
1. Cache is bounded after creating > `_MAX_CACHED_SESSIONS` sessions
2. `_insert_session_entry` evicts LRU entry at capacity
3. Cache hits promote entries to MRU end
4. Stale pruning still works correctly with the bounded cache

All 1129 tests pass, 99% coverage, ruff + pyright clean.




> Generated by [Issue Implementer](https://github.com/microsasa/cli-tools/actions/runs/23981455854/agentic_workflow) · ● 9.2M · [◷](https://github.com/search?q=repo%3Amicrosasa%2Fcli-tools+%22gh-aw-workflow-id%3A+issue-implementer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Issue Implementer, engine: copilot, model: claude-opus-4.6, id: 23981455854, workflow_id: issue-implementer, run: https://github.com/microsasa/cli-tools/actions/runs/23981455854 -->

<!-- gh-aw-workflow-id: issue-implementer -->