### PR TITLE
fix: API-surface cleanup — private CCREQ_RE, prune _EVENTS_CACHE, drop _formatting from _PUBLIC_MODULES (#725)

### DIFF
--- a/src/copilot_usage/parser.py
+++ b/src/copilot_usage/parser.py
@@ -870,5 +870,9 @@ def get_all_sessions(base_path: Path | None = None) -> list[SessionSummary]:
     for p in stale:
         del _SESSION_CACHE[p]
 
+    stale_events = [p for p in _EVENTS_CACHE if p not in discovered_paths]
+    for p in stale_events:
+        del _EVENTS_CACHE[p]
+
     summaries.sort(key=session_sort_key, reverse=True)
     return summaries

--- a/src/copilot_usage/vscode_parser.py
+++ b/src/copilot_usage/vscode_parser.py
@@ -12,7 +12,6 @@ from typing import Final
 from loguru import logger
 
 __all__: Final[list[str]] = [
-    "CCREQ_RE",
     "VSCodeLogSummary",
     "VSCodeRequest",
     "build_vscode_summary",
@@ -21,7 +20,7 @@ __all__: Final[list[str]] = [
     "parse_vscode_log",
 ]
 
-CCREQ_RE: Final[re.Pattern[str]] = re.compile(
+_CCREQ_RE: Final[re.Pattern[str]] = re.compile(
     r"^(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d+) \[info\] "
     r"ccreq:(\w+)\.copilotmd \| success \| "
     r"(\S+?)(?:\s*->\s*\S+)? \| "
@@ -134,7 +133,7 @@ def parse_vscode_log(log_path: Path) -> list[VSCodeRequest]:
             # Fast pre-filter: only ~1–5% of lines contain "ccreq:"
             if "ccreq:" not in line:
                 continue
-            m = CCREQ_RE.match(line)
+            m = _CCREQ_RE.match(line)
             if m is None:
                 continue
             ts_str, req_id, model, duration_str, category = m.groups()

--- a/tests/copilot_usage/test_parser.py
+++ b/tests/copilot_usage/test_parser.py
@@ -6349,6 +6349,30 @@ class TestSessionCacheLRUEviction:
         assert paths[3] not in _SESSION_CACHE
         assert len(_SESSION_CACHE) == total - 2
 
+    def test_stale_events_cache_pruned_on_session_delete(self, tmp_path: Path) -> None:
+        """_EVENTS_CACHE entries for deleted sessions are pruned alongside _SESSION_CACHE."""
+        import shutil
+
+        total = 3
+        paths: list[Path] = []
+        for i in range(total):
+            ep = _make_completed_session(tmp_path, f"sess-{i}", f"sid-{i}")
+            paths.append(ep)
+
+        get_all_sessions(tmp_path)
+        assert len(_SESSION_CACHE) == total
+        # _EVENTS_CACHE is populated for at least the newest sessions.
+        cached_events_before = [p for p in paths if p in _EVENTS_CACHE]
+        assert len(cached_events_before) > 0
+
+        # Delete the middle session from disk.
+        shutil.rmtree(paths[1].parent)
+
+        summaries = get_all_sessions(tmp_path)
+        assert len(summaries) == total - 1
+        assert paths[1] not in _SESSION_CACHE
+        assert paths[1] not in _EVENTS_CACHE
+
 
 # ---------------------------------------------------------------------------
 # Issue #723 — _first_pass frozenset pre-filter performance

--- a/tests/copilot_usage/test_vscode_parser.py
+++ b/tests/copilot_usage/test_vscode_parser.py
@@ -11,7 +11,7 @@ from loguru import logger
 
 from copilot_usage.cli import main
 from copilot_usage.vscode_parser import (
-    CCREQ_RE,
+    _CCREQ_RE,  # pyright: ignore[reportPrivateUsage]
     VSCodeLogSummary,
     VSCodeRequest,
     _default_log_candidates,  # pyright: ignore[reportPrivateUsage]
@@ -47,13 +47,13 @@ _LOG_NOISE = (
 
 
 # ---------------------------------------------------------------------------
-# CCREQ_RE regex
+# _CCREQ_RE regex
 # ---------------------------------------------------------------------------
 
 
 class TestCcreqRegex:
     def test_normal_line(self) -> None:
-        m = CCREQ_RE.match(_LOG_OPUS)
+        m = _CCREQ_RE.match(_LOG_OPUS)
         assert m is not None
         ts, req_id, model, dur, cat = m.groups()
         assert ts == "2026-03-13 22:10:24.523"
@@ -63,7 +63,7 @@ class TestCcreqRegex:
         assert cat == "panel/editAgent"
 
     def test_redirect_line(self) -> None:
-        m = CCREQ_RE.match(_LOG_REDIRECT)
+        m = _CCREQ_RE.match(_LOG_REDIRECT)
         assert m is not None
         _, _, model, dur, cat = m.groups()
         assert model == "gpt-4o-mini"
@@ -71,7 +71,7 @@ class TestCcreqRegex:
         assert cat == "copilotLanguageModelWrapper"
 
     def test_plain_model_line(self) -> None:
-        m = CCREQ_RE.match(_LOG_GPT4O)
+        m = _CCREQ_RE.match(_LOG_GPT4O)
         assert m is not None
         _, _, model, dur, cat = m.groups()
         assert model == "gpt-4o-mini-2024-07-18"
@@ -79,10 +79,10 @@ class TestCcreqRegex:
         assert cat == "title"
 
     def test_noise_line_does_not_match(self) -> None:
-        assert CCREQ_RE.match(_LOG_NOISE) is None
+        assert _CCREQ_RE.match(_LOG_NOISE) is None
 
     def test_empty_line_does_not_match(self) -> None:
-        assert CCREQ_RE.match("") is None
+        assert _CCREQ_RE.match("") is None
 
 
 # ---------------------------------------------------------------------------
@@ -121,9 +121,9 @@ class TestParseVscodeLog:
             f"{bad_ts} [info] ccreq:abc123.copilotmd"
             " | success | claude-sonnet-4 | 100ms | [panel]"
         )
-        # Ensure the constructed line still matches the CCREQ_RE regex; otherwise
+        # Ensure the constructed line still matches the _CCREQ_RE regex; otherwise
         # this test would no longer exercise the ValueError timestamp branch.
-        assert CCREQ_RE.match(bad_line) is not None
+        assert _CCREQ_RE.match(bad_line) is not None
         good_line = _LOG_OPUS  # a valid known-good line
         log_file = tmp_path / "test.log"
         log_file.write_text(f"{bad_line}\n{good_line}", encoding="utf-8")
@@ -134,13 +134,13 @@ class TestParseVscodeLog:
     def test_all_lines_invalid_timestamp_returns_empty_list(
         self, tmp_path: Path
     ) -> None:
-        """All lines match CCREQ_RE but have invalid timestamps → returns [], not None."""
+        """All lines match _CCREQ_RE but have invalid timestamps → returns [], not None."""
         bad_ts = "9999-99-99 99:99:99.000"
         bad_line = (
             f"{bad_ts} [info] ccreq:abc123.copilotmd"
             " | success | claude-sonnet-4 | 100ms | [panel]"
         )
-        assert CCREQ_RE.match(bad_line) is not None  # regex matches
+        assert _CCREQ_RE.match(bad_line) is not None  # regex matches
         log_file = tmp_path / "all_bad.log"
         log_file.write_text(f"{bad_line}\n{bad_line}\n", encoding="utf-8")
         result = parse_vscode_log(log_file)
@@ -1105,10 +1105,10 @@ class TestParseVscodeLogPreFilter:
     def test_synthetic_log_prefilter_uses_regex_only_for_matching_lines(
         self, tmp_path: Path
     ) -> None:
-        """parse_vscode_log only applies CCREQ_RE to lines containing 'ccreq:'."""
+        """parse_vscode_log only applies _CCREQ_RE to lines containing 'ccreq:'."""
 
         class _SpyRegex:
-            """Spy wrapper around the real CCREQ_RE to verify pre-filtering."""
+            """Spy wrapper around the real _CCREQ_RE to verify pre-filtering."""
 
             def __init__(self, real_re: re.Pattern[str]) -> None:
                 self._real_re = real_re
@@ -1126,8 +1126,8 @@ class TestParseVscodeLogPreFilter:
             tmp_path, total_lines=total, matching_lines=expected_matches
         )
 
-        spy = _SpyRegex(CCREQ_RE)
-        with patch("copilot_usage.vscode_parser.CCREQ_RE", spy):
+        spy = _SpyRegex(_CCREQ_RE)
+        with patch("copilot_usage.vscode_parser._CCREQ_RE", spy):
             requests = parse_vscode_log(log_file)
 
         # We still parse the expected number of requests.

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -10,7 +10,6 @@ import pytest
 
 # Modules that declare __all__ and the expected public names.
 _PUBLIC_MODULES: list[str] = [
-    "copilot_usage._formatting",
     "copilot_usage.logging_config",
     "copilot_usage.models",
     "copilot_usage.parser",
@@ -69,3 +68,15 @@ def test_parse_data_and_event_data_removed_from_public_api() -> None:
     assert not hasattr(models_mod.SessionEvent, "parse_data"), (  # noqa: B009
         "SessionEvent.parse_data() must not exist — use as_*() accessors"
     )
+
+
+def test_ccreq_re_not_in_vscode_parser_all() -> None:
+    """``CCREQ_RE`` must not appear in ``vscode_parser.__all__``.
+
+    Regression guard for issue #725: the compiled regex is an
+    implementation detail and should not be part of the public API.
+    """
+    import copilot_usage.vscode_parser as vscode_mod
+
+    dunder_all = vscode_mod.__all__
+    assert "CCREQ_RE" not in dunder_all, "CCREQ_RE must not be in vscode_parser.__all__"


### PR DESCRIPTION
Closes #725

Three API-surface inconsistencies addressed:

### 1. `CCREQ_RE` → `_CCREQ_RE`
- Renamed the compiled regex constant to use the private `_` prefix convention
- Removed from `vscode_parser.__all__` — it's an implementation detail, not a public contract
- Updated all call sites in `vscode_parser.py` and `test_vscode_parser.py`
- Added regression test in `test_packaging.py` asserting `CCREQ_RE` is absent from `__all__`

### 2. `_EVENTS_CACHE` pruning in `get_all_sessions`
- Added a symmetric prune loop for `_EVENTS_CACHE` immediately after the existing `_SESSION_CACHE` prune, using the same `discovered_paths` set
- Added test verifying deleted session paths are removed from both caches

### 3. `_formatting` removed from `_PUBLIC_MODULES`
- Dropped `copilot_usage._formatting` from the `_PUBLIC_MODULES` list in `test_packaging.py` — underscore-prefixed modules are internal per coding guidelines
- The module's `__all__` is left intact for internal documentation

All 1135 tests pass, 99% coverage, pyright and ruff clean.




> Generated by [Issue Implementer](https://github.com/microsasa/cli-tools/actions/runs/23982783274/agentic_workflow) · ● 11.5M · [◷](https://github.com/search?q=repo%3Amicrosasa%2Fcli-tools+%22gh-aw-workflow-id%3A+issue-implementer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Issue Implementer, engine: copilot, model: claude-opus-4.6, id: 23982783274, workflow_id: issue-implementer, run: https://github.com/microsasa/cli-tools/actions/runs/23982783274 -->

<!-- gh-aw-workflow-id: issue-implementer -->