### PR TITLE
fix: show output tokens in cost view for no-model sessions (#734)

### DIFF
--- a/src/copilot_usage/report.py
+++ b/src/copilot_usage/report.py
@@ -691,13 +691,14 @@ def render_cost_view(
                 name = ""
                 model_calls_display = ""
         else:
+            session_output = total_output_tokens(s)
             table.add_row(
                 name,
                 s.model or "—",
                 "—",
                 "—",
                 str(s.model_calls),
-                "—",
+                format_tokens(session_output) if session_output else "—",
             )
 
         grand_output += total_output_tokens(s)

--- a/tests/copilot_usage/test_report.py
+++ b/tests/copilot_usage/test_report.py
@@ -5355,18 +5355,83 @@ class TestRenderCostViewNoModelMetricsGrandTotal:
         )
         output = _capture_cost_view([session])
         clean = re.sub(r"\x1b\[[0-9;]*m", "", output)
-        # The per-session Output Tokens cell should be "—" (no model breakdown)
+        expected = format_tokens(total_output_tokens(session))
         lines = clean.splitlines()
+        # Per-session row must show actual token count (issue #734 fix)
         session_row = next(line for line in lines if "No Metrics Active" in line)
         session_cols = [c.strip() for c in session_row.split("│")]
-        assert session_cols[6] == "—"
+        assert session_cols[6] == expected, (
+            f"Per-session output tokens should be {expected}, got '{session_cols[6]}'"
+        )
         assert "Grand Total" in clean
         grand_row = next(line for line in lines if "Grand Total" in line)
         grand_cols = [c.strip() for c in grand_row.split("│")]
-        expected = format_tokens(total_output_tokens(session))
         assert grand_cols[6] == expected, (
             f"Grand Total output tokens should be {expected}, got '{grand_cols[6]}'"
         )
+
+
+# ---------------------------------------------------------------------------
+# Issue #734 — render_cost_view per-session row must show output tokens for
+# no-model sessions with active_output_tokens > 0
+# ---------------------------------------------------------------------------
+
+
+class TestRenderCostViewNoModelOutputTokensRow:
+    """Per-session row must show actual tokens, not '—', for no-model sessions."""
+
+    def test_no_model_active_output_tokens_shown_in_row(self) -> None:
+        """Active session with model_metrics={} and active_output_tokens=1500
+        must display the formatted token count in its row and match the
+        Grand Total (issue #734)."""
+        session = SessionSummary(
+            session_id="no-model-active-734",
+            name="No Model Active 734",
+            model=None,
+            is_active=True,
+            model_calls=5,
+            active_model_calls=5,
+            active_output_tokens=1500,
+            model_metrics={},
+        )
+        output = _capture_cost_view([session])
+        clean = re.sub(r"\x1b\[[0-9;]*m", "", output)
+        lines = clean.splitlines()
+
+        expected = format_tokens(total_output_tokens(session))
+
+        # 1. Per-session row shows the formatted token count (not "—")
+        session_row = next(line for line in lines if "No Model Active 734" in line)
+        session_cols = [c.strip() for c in session_row.split("│")]
+        assert session_cols[6] == expected, (
+            f"Per-session output tokens should be {expected}, got '{session_cols[6]}'"
+        )
+
+        # 2. Grand Total row output-token value equals the per-session value
+        grand_row = next(line for line in lines if "Grand Total" in line)
+        grand_cols = [c.strip() for c in grand_row.split("│")]
+        assert grand_cols[6] == expected, (
+            f"Grand Total output tokens should be {expected}, got '{grand_cols[6]}'"
+        )
+
+    def test_no_model_zero_output_tokens_shows_dash(self) -> None:
+        """No-model session with zero active_output_tokens still shows '—'."""
+        session = SessionSummary(
+            session_id="no-model-zero-734",
+            name="No Model Zero",
+            model=None,
+            is_active=True,
+            model_calls=2,
+            active_model_calls=2,
+            active_output_tokens=0,
+            model_metrics={},
+        )
+        output = _capture_cost_view([session])
+        clean = re.sub(r"\x1b\[[0-9;]*m", "", output)
+        lines = clean.splitlines()
+        session_row = next(line for line in lines if "No Model Zero" in line)
+        session_cols = [c.strip() for c in session_row.split("│")]
+        assert session_cols[6] == "—"
 
 
 class TestRenderSessionTablePreSorted:


### PR DESCRIPTION
Closes #734

## Problem

When a session has no identified model (`model_metrics` is empty), `render_cost_view` displayed `—` for the output tokens column, but `total_output_tokens(s)` could return a non-zero value from `active_output_tokens`. This caused the **Grand Total** output tokens to exceed the sum of all visible per-session rows.

## Fix

Replaced the hard-coded `—` in the `else` branch with the actual token count via `format_tokens(session_output)` when `session_output > 0`, keeping `—` when tokens are genuinely zero.

## Tests

- Updated existing `TestRenderCostViewNoModelMetricsGrandTotal` to assert the per-session row shows actual tokens (not `—`).
- Added `TestRenderCostViewNoModelOutputTokensRow` with two cases:
  - `active_output_tokens=1500` → per-session row and Grand Total both show `1.5K`
  - `active_output_tokens=0` → per-session row correctly shows `—`

All 1140 tests pass, 99.13% coverage, pyright 0 errors.




> Generated by [Issue Implementer](https://github.com/microsasa/cli-tools/actions/runs/23988340955/agentic_workflow) · ● 5.1M · [◷](https://github.com/search?q=repo%3Amicrosasa%2Fcli-tools+%22gh-aw-workflow-id%3A+issue-implementer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Issue Implementer, engine: copilot, model: claude-opus-4.6, id: 23988340955, workflow_id: issue-implementer, run: https://github.com/microsasa/cli-tools/actions/runs/23988340955 -->

<!-- gh-aw-workflow-id: issue-implementer -->