### PR TITLE
perf(parser): skip config re-read when file unchanged (#607)

### DIFF
--- a/src/copilot_usage/parser.py
+++ b/src/copilot_usage/parser.py
@@ -108,6 +108,10 @@ class _CachedEvents:
 _MAX_CACHED_EVENTS: Final[int] = 32
 _EVENTS_CACHE: OrderedDict[Path, _CachedEvents] = OrderedDict()
 
+# Persists config file identity between invocations so that the
+# _read_config_model lru_cache is only cleared when the file changes.
+_config_file_id: tuple[int, int] | None = None
+
 
 def _insert_events_entry(
     events_path: Path,
@@ -762,12 +766,17 @@ def get_all_sessions(base_path: Path | None = None) -> list[SessionSummary]:
     refreshed from ``plan.md`` only when ``plan.md``'s own file
     identity has changed, avoiding redundant file reads.
 
-    The ``_read_config_model`` cache is cleared at the start of each
-    invocation so that interactive callers (e.g. ``_interactive_loop``)
-    pick up config-file edits between refreshes while still avoiding
-    redundant reads *within* a single invocation.
+    The ``_read_config_model`` cache is only cleared when the config
+    file's ``(st_mtime_ns, st_size)`` identity changes, so interactive
+    callers (e.g. ``_interactive_loop``) pick up config-file edits
+    between refreshes while avoiding a redundant file read + JSON parse
+    on every invocation.
     """
-    _read_config_model.cache_clear()
+    global _config_file_id  # noqa: PLW0603
+    current_id = _safe_file_identity(_CONFIG_PATH)
+    if current_id != _config_file_id:
+        _config_file_id = current_id
+        _read_config_model.cache_clear()
     # Pass None explicitly to match the lru_cache key used by
     # build_session_summary (which passes config_path=None by default).
     current_config_model = _read_config_model(None)

--- a/tests/copilot_usage/test_parser.py
+++ b/tests/copilot_usage/test_parser.py
@@ -14,6 +14,7 @@ from unittest.mock import patch
 
 import pytest
 
+import copilot_usage.parser as _parser_module
 from copilot_usage.models import (
     AssistantMessageData,
     EventType,
@@ -64,6 +65,7 @@ def _reset_all_caches() -> None:
     _SESSION_CACHE.clear()
     _EVENTS_CACHE.clear()
     _read_config_model.cache_clear()
+    _parser_module._config_file_id = None
 
 
 @pytest.fixture(autouse=True)
@@ -4383,6 +4385,73 @@ class TestReadConfigModelCaching:
         summary = build_session_summary(events, events_path=events_path)
         assert summary.model is None
 
+    def test_unchanged_config_skips_cache_clear(self, tmp_path: Path) -> None:
+        """get_all_sessions called twice with unchanged config reads it once.
+
+        When the config file has not changed between invocations, the
+        ``_read_config_model`` lru_cache is not cleared and the second
+        call is served entirely from cache — ``Path.read_text`` is
+        called at most once for the config file.
+        """
+        config = tmp_path / "config.json"
+        config.write_text('{"model": "gpt-5.1"}', encoding="utf-8")
+
+        session_start = json.dumps(
+            {
+                "type": "session.start",
+                "data": {
+                    "sessionId": "s1",
+                    "version": 1,
+                    "startTime": "2026-03-07T10:00:00.000Z",
+                    "context": {},
+                },
+                "id": "ev-s1",
+                "timestamp": "2026-03-07T10:00:00.000Z",
+            }
+        )
+        user_msg = json.dumps(
+            {
+                "type": "user.message",
+                "data": {
+                    "content": "hello",
+                    "transformedContent": "hello",
+                    "attachments": [],
+                    "interactionId": "int-1",
+                },
+                "id": "ev-u-s1",
+                "timestamp": "2026-03-07T10:01:00.000Z",
+            }
+        )
+        _write_events(
+            tmp_path / "sessions" / "s1" / "events.jsonl",
+            session_start,
+            user_msg,
+        )
+
+        read_count = 0
+        original_read = Path.read_text
+
+        def counting_read(self: Path, *a: object, **kw: object) -> str:
+            nonlocal read_count
+            if self == config:
+                read_count += 1
+            return original_read(self, *a, **kw)  # type: ignore[arg-type]
+
+        with (
+            patch.object(Path, "read_text", new=counting_read),
+            patch("copilot_usage.parser._CONFIG_PATH", config),
+        ):
+            # First call — should read config once (cache miss)
+            summaries = get_all_sessions(tmp_path / "sessions")
+            assert summaries[0].model == "gpt-5.1"
+            assert read_count == 1
+
+            # Second call — config file unchanged, cache NOT cleared
+            summaries = get_all_sessions(tmp_path / "sessions")
+            assert summaries[0].model == "gpt-5.1"
+            # read_count must still be 1: no extra read on the second call
+            assert read_count == 1
+
 
 # ---------------------------------------------------------------------------
 # Issue #418 — Gap 1: malformed session.start (ValidationError)
@@ -5100,9 +5169,10 @@ class TestSessionCacheMtime:
             "copilot_usage.parser._safe_file_identity", wraps=_safe_file_identity
         ) as spy:
             get_all_sessions(tmp_path)
-            # _safe_file_identity called once by _discover_with_identity for
-            # events.jsonl, and once for plan.md when storing the cache entry.
-            assert spy.call_count == 2
+            # _safe_file_identity called once for _CONFIG_PATH, once by
+            # _discover_with_identity for events.jsonl, and once for plan.md
+            # when storing the cache entry.
+            assert spy.call_count == 3
 
     def test_resumed_session_is_cached(self, tmp_path: Path) -> None:
         """A session that resumed after shutdown IS cached with config_model=None (model from shutdown)."""
@@ -5256,9 +5326,9 @@ class TestSessionCacheMtime:
         ) as spy:
             results = get_all_sessions(tmp_path)
             assert len(results) == n
-            # 2 per session from _discover_with_identity (events + plan),
-            # no additional stat calls in the main loop.
-            assert spy.call_count == 2 * n
+            # 1 for _CONFIG_PATH + 2 per session from _discover_with_identity
+            # (events + plan), no additional stat calls in the main loop.
+            assert spy.call_count == 1 + 2 * n
 
     def test_stale_cache_entries_evicted_on_session_delete(
         self, tmp_path: Path


### PR DESCRIPTION
Closes #607

## What changed

`get_all_sessions()` previously cleared the `_read_config_model` `@lru_cache` unconditionally on every call, forcing a file read + JSON parse of `~/.copilot/config.json` each time. In interactive mode this runs every few seconds, adding ~1 800 unnecessary reads per hour of active use.

Now `get_all_sessions()` calls `_safe_file_identity(_CONFIG_PATH)` first (a single `stat()` syscall) and only clears the lru_cache when the config file's `(st_mtime_ns, st_size)` identity has actually changed.

## Changes

- **`src/copilot_usage/parser.py`**: Add module-level `_config_file_id` to track the config file identity. In `get_all_sessions()`, compare current identity with the cached one before deciding whether to clear the `_read_config_model` cache.
- **`tests/copilot_usage/test_parser.py`**: 
  - Add `test_unchanged_config_skips_cache_clear` — calls `get_all_sessions()` twice with an unchanged config file and asserts `Path.read_text` is called only once (the second call hits the cache).
  - Update `test_single_stat_per_file` and `test_cached_sessions_no_redundant_plan_stat` to account for the additional `_safe_file_identity` call on `_CONFIG_PATH`.
  - Reset `_config_file_id` in `_reset_all_caches()` to isolate tests.




> Generated by [Issue Implementer](https://github.com/microsasa/cli-tools/actions/runs/23988558236/agentic_workflow) · ● 8.1M · [◷](https://github.com/search?q=repo%3Amicrosasa%2Fcli-tools+%22gh-aw-workflow-id%3A+issue-implementer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Issue Implementer, engine: copilot, model: claude-opus-4.6, id: 23988558236, workflow_id: issue-implementer, run: https://github.com/microsasa/cli-tools/actions/runs/23988558236 -->

<!-- gh-aw-workflow-id: issue-implementer -->