### PR TITLE
test: cover `_default_log_candidates` catch-all for non-Linux platforms (#745)

### DIFF
--- a/tests/copilot_usage/test_vscode_parser.py
+++ b/tests/copilot_usage/test_vscode_parser.py
@@ -519,6 +519,23 @@ class TestDefaultLogCandidates:
             tmp_path / "AppData" / "Roaming" / "Code - Insiders" / "logs",
         ]
 
+    @pytest.mark.parametrize("platform", ["freebsd", "openbsd", "sunos", "haiku"])
+    def test_unknown_platform_falls_back_to_linux_layout(
+        self,
+        platform: str,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Any unrecognised platform uses the ~/.config/Code/logs layout."""
+        monkeypatch.setattr("copilot_usage.vscode_parser.sys.platform", platform)
+        monkeypatch.delenv("APPDATA", raising=False)
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        candidates = _default_log_candidates()
+        assert candidates == [
+            tmp_path / ".config" / "Code" / "logs",
+            tmp_path / ".config" / "Code - Insiders" / "logs",
+        ], f"Expected ~/.config layout for platform={platform!r}"
+
 
 # ---------------------------------------------------------------------------
 # get_vscode_summary (end-to-end)


### PR DESCRIPTION
Closes #745

## What

Adds a parametrized test (`test_unknown_platform_falls_back_to_linux_layout`) to `TestDefaultLogCandidates` that verifies the catch-all branch in `_default_log_candidates()` returns the `~/.config/Code/logs` layout for platform strings other than `"win32"`, `"darwin"`, and `"linux"`.

**Platforms tested:** `freebsd`, `openbsd`, `sunos`, `haiku`

## Why

The existing tests only exercise the catch-all with `sys.platform = "linux"`. If a future refactor accidentally narrows the final branch to `elif sys.platform == "linux":`, the function would silently return `[]` on FreeBSD/OpenBSD/Haiku. The new parametrized test catches this regression immediately.

## Verification

- `ruff check` / `ruff format` — clean
- `pyright` — 0 errors
- `pytest --cov --cov-fail-under=80` — 1161 passed, 99.25% coverage




> Generated by [Issue Implementer](https://github.com/microsasa/cli-tools/actions/runs/23995449754/agentic_workflow) · ● 3.4M · [◷](https://github.com/search?q=repo%3Amicrosasa%2Fcli-tools+%22gh-aw-workflow-id%3A+issue-implementer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Issue Implementer, engine: copilot, model: claude-opus-4.6, id: 23995449754, workflow_id: issue-implementer, run: https://github.com/microsasa/cli-tools/actions/runs/23995449754 -->

<!-- gh-aw-workflow-id: issue-implementer -->