### PR TITLE
fix: handle EOF in `_read_line_nonblocking` to prevent infinite loop (#746)

### DIFF
--- a/src/copilot_usage/cli.py
+++ b/src/copilot_usage/cli.py
@@ -163,10 +163,17 @@ def _write_prompt(prompt: str) -> None:
 
 
 def _read_line_nonblocking(timeout: float = 0.5) -> str | None:
-    """Return a line from stdin if available within *timeout*, else None."""
+    """Return a line from stdin if available within *timeout*, else None.
+
+    Raises :class:`EOFError` when stdin is closed (``readline()`` returns
+    an empty string), preventing an infinite polling loop.
+    """
     ready, _, _ = select.select([sys.stdin], [], [], timeout)
     if ready:
-        return sys.stdin.readline().strip()
+        line = sys.stdin.readline()
+        if not line:  # empty string means EOF
+            raise EOFError("stdin closed")
+        return line.strip()
     return None
 
 
@@ -320,6 +327,8 @@ def _interactive_loop(path: Path | None) -> None:
             # Non-blocking stdin read
             try:
                 line = _read_line_nonblocking(timeout=0.5)
+            except EOFError:
+                break
             except (ValueError, OSError):
                 # stdin not selectable (e.g. testing) — fall back to blocking
                 try:

--- a/tests/copilot_usage/test_cli.py
+++ b/tests/copilot_usage/test_cli.py
@@ -3379,3 +3379,54 @@ def test_session_index_lookup_performance() -> None:
     assert elapsed_ns < 50_000_000, (
         f"Lookup took {elapsed_ns / 1_000_000:.3f} ms (> 50 ms)"
     )
+
+
+# ---------------------------------------------------------------------------
+# EOF handling in _read_line_nonblocking (issue #746)
+# ---------------------------------------------------------------------------
+
+
+def test_read_line_nonblocking_raises_eoferror_on_closed_pipe(
+    monkeypatch: Any,
+) -> None:
+    """_read_line_nonblocking raises EOFError when stdin is a closed pipe."""
+    r_fd, w_fd = os.pipe()
+    os.close(w_fd)  # close write end → read end reaches EOF immediately
+    read_file = os.fdopen(r_fd, "r")
+    try:
+        monkeypatch.setattr("sys.stdin", read_file)
+        with pytest.raises(EOFError):
+            _read_line_nonblocking(timeout=1.0)
+    finally:
+        read_file.close()
+
+
+def test_interactive_loop_exits_on_selectable_eof_stdin(
+    tmp_path: Path,
+    monkeypatch: Any,
+) -> None:
+    """_interactive_loop exits cleanly (exit code 0) when _read_line_nonblocking raises EOFError."""
+    import copilot_usage.cli as cli_mod
+
+    _write_session(tmp_path, "eof70000-0000-0000-0000-000000000000", name="EOF-select")
+
+    call_count = 0
+
+    def _fake_read(timeout: float = 0.5) -> str | None:  # noqa: ARG001
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            raise EOFError("stdin closed")
+        return "q"  # safety fallback — should never be reached
+
+    monkeypatch.setattr(cli_mod, "_read_line_nonblocking", _fake_read)
+
+    def _noop_start(session_path: Path, change_event: threading.Event) -> None:  # noqa: ARG001
+        return None
+
+    monkeypatch.setattr(cli_mod, "_start_observer", _noop_start)
+
+    runner = CliRunner()
+    result = runner.invoke(main, ["--path", str(tmp_path)])
+    assert result.exit_code == 0
+    assert call_count == 1, "Loop should have exited on the first EOFError"


### PR DESCRIPTION
Closes #746

## Problem

`_read_line_nonblocking` uses `select.select` to wait for stdin data, then calls `sys.stdin.readline()`. When stdin reaches EOF (e.g. piped input, closed pipe), `select` marks stdin as "ready" but `readline()` returns `""`. The caller treated `""` as an empty command and continued looping, causing an infinite polling loop.

## Fix

- **`_read_line_nonblocking`**: After `readline()`, check for empty string (EOF indicator) and raise `EOFError("stdin closed")` instead of returning `""`.
- **`_interactive_loop`**: Catch `EOFError` from `_read_line_nonblocking` and `break` out of the loop cleanly.

## Tests Added

1. **`test_read_line_nonblocking_raises_eoferror_on_closed_pipe`** — Creates an `os.pipe()`, closes the write end, monkeypatches it as `sys.stdin`, and asserts `_read_line_nonblocking` raises `EOFError`.
2. **`test_interactive_loop_exits_on_selectable_eof_stdin`** — Monkeypatches `_read_line_nonblocking` to raise `EOFError` on the first call and verifies the interactive loop exits with code 0 (no infinite loop, no crash).
3. Existing `test_interactive_eof_exits` continues to pass (covers the fallback `input()` path).

## Verification

All 1077 tests pass. Ruff, pyright, and coverage (99.25%) all clean.




> Generated by [Issue Implementer](https://github.com/microsasa/cli-tools/actions/runs/23995625150/agentic_workflow) · ● 7.9M · [◷](https://github.com/search?q=repo%3Amicrosasa%2Fcli-tools+%22gh-aw-workflow-id%3A+issue-implementer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Issue Implementer, engine: copilot, model: claude-opus-4.6, id: 23995625150, workflow_id: issue-implementer, run: https://github.com/microsasa/cli-tools/actions/runs/23995625150 -->

<!-- gh-aw-workflow-id: issue-implementer -->