### PR TITLE
perf: break early in `_filter_sessions` for `--since` filtered views (#755)

### DIFF
--- a/src/copilot_usage/report.py
+++ b/src/copilot_usage/report.py
@@ -232,7 +232,12 @@ def _filter_sessions(
     since: datetime | None,
     until: datetime | None,
 ) -> list[SessionSummary]:
-    """Return sessions whose start_time falls within [since, until]."""
+    """Return sessions whose start_time falls within [since, until].
+
+    *sessions* must be sorted newest-first (descending ``start_time``).
+    When *since* is provided the loop breaks on the first session older
+    than the threshold, so unsorted input will produce incorrect results.
+    """
     if since is not None and until is not None and since > until:
         return []
 

--- a/tests/copilot_usage/test_report.py
+++ b/tests/copilot_usage/test_report.py
@@ -5232,9 +5232,7 @@ class TestFilterSessionsEarlyTermination:
 
         with patch(
             "copilot_usage.report.ensure_aware",
-            wraps=__import__(
-                "copilot_usage.models", fromlist=["ensure_aware"]
-            ).ensure_aware,
+            wraps=ensure_aware,
         ) as spy:
             result = _filter_sessions(sessions, since=since, until=None)
 
@@ -5245,8 +5243,8 @@ class TestFilterSessionsEarlyTermination:
         )
 
     def test_none_start_time_at_end_excluded_with_break(self) -> None:
-        """A session with start_time=None at the end of the list must still be
-        excluded — the None guard fires before the since-break check."""
+        """Sessions with start_time=None must not be included even when
+        early termination on ``since`` breaks the loop before reaching them."""
         now = datetime(2026, 4, 5, tzinfo=UTC)
         since = now - timedelta(days=1)
         recent = SessionSummary(


### PR DESCRIPTION
Closes #755

## Summary

`_filter_sessions` now uses `break` instead of `continue` when `aware_start < since`, leveraging the guaranteed newest-first sort order of sessions. Once a session is older than the `since` threshold, all remaining sessions are even older and can be skipped entirely.

**Performance improvement:** O(n) → O(k) per call, where k is the number of matching sessions. For 500 sessions with only 10 recent matches, this is a ~50× reduction in iterations.

## Changes

- **`src/copilot_usage/report.py`** — `continue` → `break` in the `since` check
- **`tests/copilot_usage/test_report.py`** — Added `TestFilterSessionsEarlyTermination` class with:
  - `test_ensure_aware_called_at_most_k_plus_one_times` — verifies early termination by spying on `ensure_aware` call count (1000 sessions, only k+1 calls)
  - `test_none_start_time_at_end_excluded_with_break` — regression test ensuring `start_time=None` sessions at the end of the list are still excluded
  - Fixed two existing tests that passed sessions in oldest-first order (violating the newest-first contract)

## Verification

All 1165 tests pass, 99.25% coverage, ruff/pyright clean.




> Generated by [Issue Implementer](https://github.com/microsasa/cli-tools/actions/runs/23997946247/agentic_workflow) · ● 7.4M · [◷](https://github.com/search?q=repo%3Amicrosasa%2Fcli-tools+%22gh-aw-workflow-id%3A+issue-implementer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Issue Implementer, engine: copilot, model: claude-opus-4.6, id: 23997946247, workflow_id: issue-implementer, run: https://github.com/microsasa/cli-tools/actions/runs/23997946247 -->

<!-- gh-aw-workflow-id: issue-implementer -->