### PR TITLE
perf: replace dict scan with linear scan in _discover_with_identity (#773)

### DIFF
--- a/src/copilot_usage/parser.py
+++ b/src/copilot_usage/parser.py
@@ -261,9 +261,9 @@ def _discover_with_identity(
                             name = e.name
                             if name == "events.jsonl":
                                 events_entry = e
-                                if plan_entry is not None:
+                                if not include_plan or plan_entry is not None:
                                     break
-                            elif name == "plan.md":
+                            elif include_plan and name == "plan.md":
                                 plan_entry = e
                                 if events_entry is not None:
                                     break

--- a/tests/copilot_usage/test_parser.py
+++ b/tests/copilot_usage/test_parser.py
@@ -628,10 +628,10 @@ class TestDiscoverWithIdentityNoAbsentPlanStat:
 
 
 class TestDiscoverWithIdentityLinearScan:
-    """Verify linear scan returns correct tuples for 100+ session dirs."""
+    """Verify linear scan returns correct tuples for many session dirs."""
 
-    def test_100_sessions_correct_tuples(self, tmp_path: Path) -> None:
-        """100+ session dirs return correct (events_path, events_id, plan_id).
+    def test_120_sessions_correct_tuples(self, tmp_path: Path) -> None:
+        """120 session dirs return correct (events_path, events_id, plan_id).
 
         Creates 120 session directories: 40 with plan.md (plus extra files),
         80 without. Asserts that every session is returned with the correct


### PR DESCRIPTION
Closes #773

## Summary

Replaces the per-session-directory `dict` comprehension in `_discover_with_identity` with a two-variable linear scan that breaks early once both `events.jsonl` and `plan.md` are found.

## Changes

**`src/copilot_usage/parser.py`**
- Replaced `dir_files = {e.name: e for e in dir_entries}` with a simple `for` loop using two sentinel variables (`events_entry`, `plan_entry`)
- Loop breaks as soon as both target files are found — no need to iterate remaining directory entries
- Eliminates per-directory `dict` allocation and O(N) hash-insert overhead
- Updated docstring to reflect the new approach

**`tests/copilot_usage/test_parser.py`**
- Added `TestDiscoverWithIdentityLinearScan` class with 3 tests:
  1. **120 session dirs** (40 with `plan.md`, 80 without, plus unrelated files) — verifies correct `(events_path, events_id, plan_id)` tuples
  2. Sessions without `plan.md` get `plan_id=None`
  3. Directories lacking `events.jsonl` are excluded

## Verification

`make check` passes cleanly (lint ✅, typecheck ✅, security ✅, unit tests 99% coverage ✅, e2e tests ✅).




> Generated by [Issue Implementer](https://github.com/microsasa/cli-tools/actions/runs/24009321515/agentic_workflow) · ● 4.9M · [◷](https://github.com/search?q=repo%3Amicrosasa%2Fcli-tools+%22gh-aw-workflow-id%3A+issue-implementer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Issue Implementer, engine: copilot, model: claude-opus-4.6, id: 24009321515, workflow_id: issue-implementer, run: https://github.com/microsasa/cli-tools/actions/runs/24009321515 -->

<!-- gh-aw-workflow-id: issue-implementer -->