### PR TITLE
refactor: use `lru_insert` in `_insert_session_entry` (#791)

### DIFF
--- a/src/copilot_usage/parser.py
+++ b/src/copilot_usage/parser.py
@@ -82,17 +82,8 @@ def _insert_session_entry(
     events_path: Path,
     entry: _CachedSession,
 ) -> None:
-    """Insert a session entry into ``_SESSION_CACHE`` with LRU eviction.
-
-    If *events_path* already exists in the cache (stale entry), the old
-    entry is removed first.  Otherwise, when the cache is full the
-    least-recently-used entry (front of the ``OrderedDict``) is evicted.
-    """
-    if events_path in _SESSION_CACHE:
-        del _SESSION_CACHE[events_path]
-    elif len(_SESSION_CACHE) >= _MAX_CACHED_SESSIONS:
-        _SESSION_CACHE.popitem(last=False)  # evict LRU (front)
-    _SESSION_CACHE[events_path] = entry
+    """Insert a session entry into ``_SESSION_CACHE`` with LRU eviction."""
+    lru_insert(_SESSION_CACHE, events_path, entry, _MAX_CACHED_SESSIONS)
 
 
 @dataclasses.dataclass(frozen=True, slots=True)


### PR DESCRIPTION
Closes #791

## Summary

`_insert_session_entry` manually reimplemented the same LRU eviction logic that `lru_insert()` in `_fs_utils.py` already provides. `_insert_events_entry` was updated to use the shared helper, but `_insert_session_entry` was left behind with an inline copy.

## Changes

Replaced the 5-line inline LRU logic in `_insert_session_entry` with a single `lru_insert()` call, matching what `_insert_events_entry` already does.

This is a pure refactor — no behaviour change. The existing `test_insert_session_entry_evicts_lru` test (and all other `_SESSION_CACHE` tests) continue to pass unchanged, confirming behavioural equivalence.

## Verification

- `make fix` — no lint/format issues
- `make check` — all checks pass (lint ✅, pyright ✅, bandit ✅, unit tests 99% coverage ✅, e2e 86 passed ✅)




> Generated by [Issue Implementer](https://github.com/microsasa/cli-tools/actions/runs/24022604241/agentic_workflow) · ● 3.8M · [◷](https://github.com/search?q=repo%3Amicrosasa%2Fcli-tools+%22gh-aw-workflow-id%3A+issue-implementer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Issue Implementer, engine: copilot, model: claude-opus-4.6, id: 24022604241, workflow_id: issue-implementer, run: https://github.com/microsasa/cli-tools/actions/runs/24022604241 -->

<!-- gh-aw-workflow-id: issue-implementer -->