### PR TITLE
fix(vscode_parser): eliminate redundant stat() per log file (#795)

### DIFF
--- a/src/copilot_usage/vscode_parser.py
+++ b/src/copilot_usage/vscode_parser.py
@@ -8,7 +8,7 @@ from collections.abc import Sequence
 from dataclasses import dataclass, field, replace
 from datetime import date, datetime
 from pathlib import Path
-from typing import Final
+from typing import Final, Literal
 
 from loguru import logger
 
@@ -195,8 +195,20 @@ class _CachedVSCodeSummary:
 _vscode_summary_cache: _CachedVSCodeSummary | None = None
 
 
-def _get_cached_vscode_requests(log_path: Path) -> tuple[VSCodeRequest, ...]:
+_FILE_ID_UNSET: Final = "unset"
+
+
+def _get_cached_vscode_requests(
+    log_path: Path,
+    file_id: tuple[int, int] | None | Literal["unset"] = _FILE_ID_UNSET,
+) -> tuple[VSCodeRequest, ...]:
     """Return parsed requests, re-parsing only when ``(mtime_ns, size)`` changes.
+
+    When *file_id* is omitted (or the sentinel ``"unset"``), the file
+    identity is computed internally via :func:`safe_file_identity`.
+    Callers that have already stat'd the file (e.g.
+    :func:`get_vscode_summary`) can pass the pre-computed identity to
+    avoid a redundant ``stat()`` call.
 
     On the first call for a given *log_path*, delegates to
     :func:`parse_vscode_log` and stores the result.  Subsequent calls
@@ -214,16 +226,18 @@ def _get_cached_vscode_requests(log_path: Path) -> tuple[VSCodeRequest, ...]:
         OSError: Propagated from :func:`parse_vscode_log` when the file
             cannot be opened or read.
     """
-    file_id = safe_file_identity(log_path)
+    resolved_id: tuple[int, int] | None = (
+        safe_file_identity(log_path) if file_id == _FILE_ID_UNSET else file_id
+    )
     cached = _VSCODE_LOG_CACHE.get(log_path)
-    if cached is not None and cached.file_id == file_id:
+    if cached is not None and cached.file_id == resolved_id:
         _VSCODE_LOG_CACHE.move_to_end(log_path)
         return cached.requests
     requests = tuple(parse_vscode_log(log_path))
     lru_insert(
         _VSCODE_LOG_CACHE,
         log_path,
-        _CachedVSCodeLog(file_id=file_id, requests=requests),
+        _CachedVSCodeLog(file_id=resolved_id, requests=requests),
         _MAX_CACHED_VSCODE_LOGS,
     )
     return requests
@@ -348,9 +362,10 @@ def get_vscode_summary(base_path: Path | None = None) -> VSCodeLogSummary:
     global _vscode_summary_cache  # noqa: PLW0603
 
     logs = discover_vscode_logs(base_path)
-    current_ids: frozenset[tuple[Path, tuple[int, int] | None]] = frozenset(
+    log_ids: list[tuple[Path, tuple[int, int] | None]] = [
         (p, safe_file_identity(p)) for p in logs
-    )
+    ]
+    current_ids: frozenset[tuple[Path, tuple[int, int] | None]] = frozenset(log_ids)
 
     if (
         _vscode_summary_cache is not None
@@ -359,9 +374,9 @@ def get_vscode_summary(base_path: Path | None = None) -> VSCodeLogSummary:
         return _copy_summary(_vscode_summary_cache.summary)
 
     acc = _SummaryAccumulator(log_files_found=len(logs))
-    for log_path in logs:
+    for log_path, file_id in log_ids:
         try:
-            result = _get_cached_vscode_requests(log_path)
+            result = _get_cached_vscode_requests(log_path, file_id)
         except OSError as exc:
             logger.warning("Could not read log file {}: {}", log_path, exc)
             continue

--- a/tests/copilot_usage/test_vscode_parser.py
+++ b/tests/copilot_usage/test_vscode_parser.py
@@ -9,6 +9,7 @@ import pytest
 from click.testing import CliRunner
 from loguru import logger
 
+from copilot_usage._fs_utils import safe_file_identity
 from copilot_usage.cli import main
 from copilot_usage.vscode_parser import (
     _CCREQ_RE,  # pyright: ignore[reportPrivateUsage]
@@ -1468,10 +1469,13 @@ class TestVscodeSummaryCacheSkipsReaggregation:
         # Capture the real function before patching to avoid recursion.
         real_fn = _get_cached_vscode_requests
 
-        def _fail_second(log_path: Path) -> tuple[VSCodeRequest, ...]:
+        def _fail_second(
+            log_path: Path,
+            file_id: tuple[int, int] | None = None,
+        ) -> tuple[VSCodeRequest, ...]:
             if log_path == log_file2:
                 raise OSError("transient read failure")
-            return real_fn(log_path)
+            return real_fn(log_path, file_id)
 
         with patch(
             "copilot_usage.vscode_parser._get_cached_vscode_requests",
@@ -1511,3 +1515,92 @@ class TestVscodeSummaryCacheSkipsReaggregation:
         s2 = get_vscode_summary(tmp_path)
         assert s2.requests_by_model == {"gpt-4o-mini": 1}
         assert "injected" not in s2.requests_by_model
+
+
+# ---------------------------------------------------------------------------
+# stat() syscall budget — safe_file_identity called at most once per file
+# ---------------------------------------------------------------------------
+
+
+class TestSafeFileIdentityCalledOncePerFile:
+    """Assert safe_file_identity is called at most once per log file per call.
+
+    Before the optimisation, ``get_vscode_summary`` stat'd every file
+    twice on a cold summary cache: once to build ``current_ids`` and
+    again inside ``_get_cached_vscode_requests``.  After the fix the
+    pre-computed identity is threaded through, so only one stat per file
+    should occur.
+    """
+
+    @staticmethod
+    def _make_log_tree(tmp_path: Path, n_files: int) -> list[Path]:
+        """Create *n_files* log files under a VS Code log directory layout."""
+        paths: list[Path] = []
+        for i in range(n_files):
+            log_dir = (
+                tmp_path
+                / f"2026031{i}T211400"
+                / "window1"
+                / "exthost"
+                / "GitHub.copilot-chat"
+            )
+            log_dir.mkdir(parents=True)
+            log_file = log_dir / "GitHub Copilot Chat.log"
+            log_file.write_text(_make_log_line(req_idx=i))
+            paths.append(log_file)
+        return paths
+
+    def test_cold_cache_stats_each_file_once(self, tmp_path: Path) -> None:
+        """On a cold summary + per-file cache, each file is stat'd once."""
+        log_files = self._make_log_tree(tmp_path, n_files=5)
+        call_counts: dict[Path, int] = {}
+        real_fn = safe_file_identity
+
+        def _counting_spy(path: Path) -> tuple[int, int] | None:
+            call_counts[path] = call_counts.get(path, 0) + 1
+            return real_fn(path)
+
+        with patch(
+            "copilot_usage.vscode_parser.safe_file_identity",
+            side_effect=_counting_spy,
+        ):
+            summary = get_vscode_summary(tmp_path)
+
+        assert summary.total_requests == len(log_files)
+        for log_file in log_files:
+            assert call_counts.get(log_file, 0) <= 1, (
+                f"safe_file_identity called {call_counts[log_file]} times "
+                f"for {log_file.name}, expected at most 1"
+            )
+
+    def test_warm_per_file_cache_stats_each_file_once(self, tmp_path: Path) -> None:
+        """With a warm per-file cache but cold summary cache, still one stat."""
+        log_files = self._make_log_tree(tmp_path, n_files=3)
+        # Warm the per-file cache.
+        for lf in log_files:
+            _get_cached_vscode_requests(lf)
+
+        # Clear summary cache only (per-file cache stays warm).
+        import copilot_usage.vscode_parser as _mod
+
+        _mod._vscode_summary_cache = None  # pyright: ignore[reportPrivateUsage]
+
+        call_counts: dict[Path, int] = {}
+        real_fn = safe_file_identity
+
+        def _counting_spy(path: Path) -> tuple[int, int] | None:
+            call_counts[path] = call_counts.get(path, 0) + 1
+            return real_fn(path)
+
+        with patch(
+            "copilot_usage.vscode_parser.safe_file_identity",
+            side_effect=_counting_spy,
+        ):
+            summary = get_vscode_summary(tmp_path)
+
+        assert summary.total_requests == len(log_files)
+        for log_file in log_files:
+            assert call_counts.get(log_file, 0) <= 1, (
+                f"safe_file_identity called {call_counts[log_file]} times "
+                f"for {log_file.name}, expected at most 1"
+            )


### PR DESCRIPTION
Closes #795

## Problem

`get_vscode_summary` stat'd every discovered log file **twice** on each invocation when the summary-level cache was stale or cold:

1. **First stat** — building `current_ids` frozenset for the summary cache check
2. **Second stat** — inside `_get_cached_vscode_requests` for each file

This doubled syscalls from N → 2N where N is the number of VS Code log files (typically 50–200+).

## Fix

- **`_get_cached_vscode_requests`** now accepts an optional `file_id` parameter (typed `tuple[int, int] | None | Literal["unset"]`). When omitted, the file identity is computed internally as before. When provided, the redundant `stat()` is skipped.
- **`get_vscode_summary`** materialises a `log_ids` list of `(path, file_id)` pairs and threads the pre-computed identity into `_get_cached_vscode_requests`.

## Testing

- Added `TestSafeFileIdentityCalledOncePerFile` with two tests:
  - `test_cold_cache_stats_each_file_once` — cold summary + per-file cache
  - `test_warm_per_file_cache_stats_each_file_once` — warm per-file cache, cold summary cache
  
  Both monkeypatch `safe_file_identity` with a counting spy and assert it is called **at most once** per discovered log file.

- Fixed `_fail_second` mock signature in `test_cache_not_populated_on_partial_failure` to accept the new `file_id` parameter.

All `make check` passes (lint ✅, pyright strict ✅, bandit ✅, unit 99% coverage ✅, e2e ✅).




> Generated by [Issue Implementer](https://github.com/microsasa/cli-tools/actions/runs/24025527900/agentic_workflow) · ● 12M · [◷](https://github.com/search?q=repo%3Amicrosasa%2Fcli-tools+%22gh-aw-workflow-id%3A+issue-implementer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Issue Implementer, engine: copilot, model: claude-opus-4.6, id: 24025527900, workflow_id: issue-implementer, run: https://github.com/microsasa/cli-tools/actions/runs/24025527900 -->

<!-- gh-aw-workflow-id: issue-implementer -->