### PR TITLE
refactor: replace manual JSON parsing in `_read_config_model` with Pydantic validation (#796)

### DIFF
--- a/src/copilot_usage/parser.py
+++ b/src/copilot_usage/parser.py
@@ -12,10 +12,10 @@ from collections import OrderedDict
 from datetime import datetime
 from functools import lru_cache
 from pathlib import Path
-from typing import Final, cast
+from typing import Final
 
 from loguru import logger
-from pydantic import ValidationError
+from pydantic import BaseModel, ValidationError
 
 __all__: Final[list[str]] = [
     "build_session_summary",
@@ -173,6 +173,12 @@ def _infer_model_from_metrics(metrics: dict[str, ModelMetrics]) -> str | None:
     return max(metrics, key=lambda m: metrics[m].requests.count)
 
 
+class _CopilotConfig(BaseModel):
+    """Schema for ``~/.copilot/config.json``."""
+
+    model: str | None = None
+
+
 @lru_cache(maxsize=4)
 def _read_config_model(config_path: Path | None = None) -> str | None:
     """Read the active model from ``~/.copilot/config.json``."""
@@ -180,13 +186,9 @@ def _read_config_model(config_path: Path | None = None) -> str | None:
     if not path.is_file():
         return None
     try:
-        parsed = json.loads(path.read_text(encoding="utf-8"))
-        if not isinstance(parsed, dict):
-            return None
-        data = cast("dict[str, object]", parsed)
-        model = data.get("model")
-        return model if isinstance(model, str) and model else None
-    except json.JSONDecodeError as exc:
+        config = _CopilotConfig.model_validate_json(path.read_text(encoding="utf-8"))
+        return config.model if config.model else None
+    except (ValidationError, ValueError) as exc:
         logger.warning(
             "Config file {} contains malformed JSON; model will be unavailable: {}",
             path,

--- a/tests/copilot_usage/test_parser.py
+++ b/tests/copilot_usage/test_parser.py
@@ -13,6 +13,7 @@ from typing import SupportsIndex, overload
 from unittest.mock import patch
 
 import pytest
+from pydantic import ValidationError
 
 import copilot_usage.parser as _parser_module
 from copilot_usage._fs_utils import safe_file_identity
@@ -43,6 +44,7 @@ from copilot_usage.parser import (
     _build_completed_summary,
     _CachedEvents,
     _CachedSession,
+    _CopilotConfig,
     _detect_resume,
     _discover_with_identity,
     _extract_session_name,
@@ -4446,6 +4448,15 @@ class TestReadConfigModel:
         config = tmp_path / "config.json"
         config.write_text('"a string"', encoding="utf-8")
         assert _read_config_model(config) is None
+
+
+class TestCopilotConfigRejectsNonObject:
+    """Verify that ``_CopilotConfig`` rejects a non-object JSON root."""
+
+    def test_model_validate_json_rejects_list(self) -> None:
+        """``_CopilotConfig.model_validate_json('[]')`` raises ``ValidationError``."""
+        with pytest.raises(ValidationError):
+            _CopilotConfig.model_validate_json("[]")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #796

## Summary

Replaces the manual `json.loads()` + `isinstance` guards + `cast` pattern in `_read_config_model` with a proper Pydantic model, aligning with the project's **"Pydantic at the Boundary"** coding guideline.

## Changes

**`src/copilot_usage/parser.py`**
- Added `_CopilotConfig(BaseModel)` with `model: str | None = None` to validate `~/.copilot/config.json`
- Replaced `json.loads()` + manual `isinstance` checks with `_CopilotConfig.model_validate_json()`
- Removed the legacy string-form `cast("dict[str, object]", parsed)` call
- Removed unused `cast` import from `typing`
- Catches `(ValidationError, ValueError)` instead of `json.JSONDecodeError` — `model_validate_json` raises `ValidationError` for both malformed JSON and schema mismatches (e.g., root is a list)

**`tests/copilot_usage/test_parser.py`**
- Added `TestCopilotConfigRejectsNonObject` with a test verifying `_CopilotConfig.model_validate_json("[]")` raises `ValidationError`
- All 21 existing `TestReadConfigModel` and `TestReadConfigModelCaching` tests pass unchanged




> Generated by [Issue Implementer](https://github.com/microsasa/cli-tools/actions/runs/24026037981/agentic_workflow) · ● 8.3M · [◷](https://github.com/search?q=repo%3Amicrosasa%2Fcli-tools+%22gh-aw-workflow-id%3A+issue-implementer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Issue Implementer, engine: copilot, model: claude-opus-4.6, id: 24026037981, workflow_id: issue-implementer, run: https://github.com/microsasa/cli-tools/actions/runs/24026037981 -->

<!-- gh-aw-workflow-id: issue-implementer -->