### PR TITLE
fix: add `_formatting` to packaging test + convert numpy-style docstring (#802)

### DIFF
--- a/src/copilot_usage/render_detail.py
+++ b/src/copilot_usage/render_detail.py
@@ -350,24 +350,13 @@ def render_session_detail(
 ) -> None:
     """Render a useful summary view of a single session.
 
-    Displays:
-    - Header panel (name, ID, model, status, start time)
-    - Aggregate stats (model calls, user messages, output tokens, premium)
-    - Per-shutdown-cycle table
-    - Active period (if session is active)
-    - Last 10 events (recent activity, not a full timeline)
-    - Code changes (if any)
+    Prints a header panel, aggregate stats, per-shutdown-cycle table,
+    active-period info (if the session is still active), the last 10
+    events, and code changes (if any) to *target_console* (or a fresh
+    :class:`Console` when not supplied).
 
-    Parameters
-    ----------
-    events:
-        The full list of parsed :class:`SessionEvent` objects for this
-        session.
-    summary:
-        Pre-computed :class:`SessionSummary` for the session.
-    target_console:
-        Optional :class:`Console` to print to (defaults to a fresh
-        console).
+    *events* is the full list of parsed :class:`SessionEvent` objects for
+    this session.  *summary* is the pre-computed :class:`SessionSummary`.
     """
     out = target_console or Console()
 

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -10,6 +10,7 @@ import pytest
 
 # Modules that declare __all__ and the expected public names.
 _PUBLIC_MODULES: list[str] = [
+    "copilot_usage._formatting",
     "copilot_usage._fs_utils",
     "copilot_usage.logging_config",
     "copilot_usage.models",


### PR DESCRIPTION
Closes #802

## Changes

1. **Add `copilot_usage._formatting` to `_PUBLIC_MODULES`** in `tests/test_packaging.py` — the existing parametrised `test_all_names_importable` now covers `_formatting.__all__`, catching any future definition/export drift.

2. **Convert `render_session_detail` docstring to plain prose** in `src/copilot_usage/render_detail.py` — replaces the numpy-style `Parameters / ----------` section with inline prose, matching every other docstring in the codebase.

## Verification

- `ruff check` and `ruff format --check` pass
- `pyright` strict mode passes (0 errors)
- All 1122 unit tests + 86 e2e tests pass
- Coverage remains at 99%




> Generated by [Issue Implementer](https://github.com/microsasa/cli-tools/actions/runs/24040235334/agentic_workflow) · ● 4.9M · [◷](https://github.com/search?q=repo%3Amicrosasa%2Fcli-tools+%22gh-aw-workflow-id%3A+issue-implementer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Issue Implementer, engine: copilot, model: claude-opus-4.6, id: 24040235334, workflow_id: issue-implementer, run: https://github.com/microsasa/cli-tools/actions/runs/24040235334 -->

<!-- gh-aw-workflow-id: issue-implementer -->