### PR TITLE
perf(parser): cache root-directory identity to skip inner os.scandir calls (#809)

### DIFF
--- a/src/copilot_usage/parser.py
+++ b/src/copilot_usage/parser.py
@@ -52,10 +52,16 @@ class _DiscoveryCache:
     identity is unchanged on the next call, the inner per-session
     ``os.scandir`` calls are skipped entirely — only per-file ``stat``
     calls are issued to detect content changes.
+
+    *probe_cursor* tracks where the next ``plan.md`` probe sweep should
+    start so that every session is eventually probed across multiple
+    cache-hit calls rather than always probing the first
+    ``_MAX_PLAN_PROBES`` entries.
     """
 
     root_id: tuple[int, int] | None
     entries: list[tuple[Path, Path | None]]  # (events_path, plan_path)
+    probe_cursor: int = 0
 
 
 # Module-level discovery cache: root_path → _DiscoveryCache.
@@ -64,8 +70,8 @@ class _DiscoveryCache:
 _DISCOVERY_CACHE: dict[Path, _DiscoveryCache] = {}
 
 # On cache hits, probe at most this many sessions without a cached
-# plan.md for a newly-created file.  This keeps the cache-hit path
-# at O(N + _MAX_PLAN_PROBES) stats instead of O(2N).
+# plan.md for a newly-created file.  The probe window rotates via
+# _DiscoveryCache.probe_cursor so every session is eventually checked.
 _MAX_PLAN_PROBES: Final[int] = 5
 
 
@@ -316,8 +322,9 @@ def _discover_with_identity(
     cleared to avoid repeated failing syscalls.  On cache hits, up to
     ``_MAX_PLAN_PROBES`` entries with no cached ``plan.md`` are probed
     for a newly-created file so that session names appear without a full
-    rescan; remaining entries are left unprobed until the next full
-    rescan to keep the cache-hit path at O(N) stats.
+    rescan; the probe window rotates via a per-root cursor stored in
+    ``_DiscoveryCache.probe_cursor`` so every session is eventually
+    checked across successive cache-hit calls.
     When *include_plan* is ``False``, the ``plan_file_id`` element is
     always ``None`` — useful for callers that only need event ordering.
     """
@@ -339,9 +346,30 @@ def _discover_with_identity(
         _DISCOVERY_CACHE[root] = _DiscoveryCache(root_id=root_id, entries=entries)
         is_cache_hit = False
 
+    # On cache hits, select which entries to probe for newly-created
+    # plan.md, rotating from the stored cursor so every session is
+    # eventually checked across successive cache-hit calls.
+    probe_indices: frozenset[int] = frozenset()
+    current_cache = _DISCOVERY_CACHE.get(root)
+    if is_cache_hit and include_plan and current_cache is not None:
+        n = len(entries)
+        if n > 0:
+            cursor = current_cache.probe_cursor % n
+            selected: list[int] = []
+            for offset in range(n):
+                i = (cursor + offset) % n
+                if entries[i][1] is None:
+                    selected.append(i)
+                    if len(selected) >= _MAX_PLAN_PROBES:
+                        current_cache.probe_cursor = (i + 1) % n
+                        break
+            else:
+                # All entries scanned; wrap cursor to start.
+                current_cache.probe_cursor = 0
+            probe_indices = frozenset(selected)
+
     result: list[tuple[Path, tuple[int, int] | None, tuple[int, int] | None]] = []
     definitively_gone: list[Path] = []
-    plan_probes_remaining = _MAX_PLAN_PROBES if is_cache_hit else 0
     for idx, (events_path, plan_path) in enumerate(entries):
         # Distinguish permanent deletion from transient errors so only
         # truly-gone files are pruned from the cache.
@@ -364,13 +392,12 @@ def _discover_with_identity(
                     # Plan deleted or unreadable — clear cached path to
                     # avoid repeated failing syscalls on cache hits.
                     entries[idx] = (events_path, None)
-            elif plan_probes_remaining > 0:
+            elif idx in probe_indices:
                 # Probe for newly-created plan.md not yet in cache.
-                # Bounded to _MAX_PLAN_PROBES to keep cache-hit path
-                # at O(N) stats instead of O(2N).
+                # Bounded to _MAX_PLAN_PROBES per call; cursor rotates
+                # so every session is eventually checked.
                 candidate = events_path.parent / "plan.md"
                 plan_id = safe_file_identity(candidate)
-                plan_probes_remaining -= 1
                 if plan_id is not None:
                     entries[idx] = (events_path, candidate)
 

--- a/tests/copilot_usage/test_parser.py
+++ b/tests/copilot_usage/test_parser.py
@@ -40,6 +40,7 @@ from copilot_usage.parser import (
     _FIRST_PASS_EVENT_TYPES,
     _MAX_CACHED_EVENTS,
     _MAX_CACHED_SESSIONS,
+    _MAX_PLAN_PROBES,
     _SESSION_CACHE,
     _build_active_summary,
     _build_completed_summary,
@@ -979,6 +980,56 @@ class TestDiscoverWithIdentityCache:
         # Cached entry must now include the plan path.
         cached_entries = _DISCOVERY_CACHE[tmp_path].entries
         assert cached_entries[0][1] == plan
+
+    def test_plan_probe_rotates_across_cache_hits(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """plan.md created beyond initial probe budget is eventually detected.
+
+        Creates more sessions than ``_MAX_PLAN_PROBES`` without any
+        ``plan.md``.  A ``plan.md`` is then created in a session that
+        sits beyond the first probe window.  After enough cache-hit
+        calls for the rotating cursor to reach the target session, the
+        new ``plan.md`` must be detected.
+        """
+        n = _MAX_PLAN_PROBES * 3
+        for i in range(n):
+            _write_events(tmp_path / f"sess-{i:04d}" / "events.jsonl", _START_EVENT)
+
+        # Populate cache — no plan.md in any session.
+        result1 = _discover_with_identity(tmp_path)
+        assert len(result1) == n
+        for _, _, pid in result1:
+            assert pid is None
+
+        # Create plan.md in a session that is beyond the first probe
+        # window.  Which index it lands on depends on entry order, so
+        # target the *last* entry in the cached list to maximise the
+        # distance from any starting cursor.
+        cached = _DISCOVERY_CACHE[tmp_path]
+        last_events_path = cached.entries[-1][0]
+        target_dir = last_events_path.parent
+        plan = target_dir / "plan.md"
+        plan.write_text("# Late Session\n", encoding="utf-8")
+
+        # Call repeatedly — the rotating cursor should eventually reach
+        # the target entry.  ceil(n / _MAX_PLAN_PROBES) calls suffice.
+        max_calls = (n + _MAX_PLAN_PROBES - 1) // _MAX_PLAN_PROBES
+        detected = False
+        for _ in range(max_calls):
+            result = _discover_with_identity(tmp_path)
+            for path, _, pid in result:
+                if path == last_events_path and pid is not None:
+                    detected = True
+                    break
+            if detected:
+                break
+
+        assert detected, (
+            f"plan.md in {target_dir.name} not detected after "
+            f"{max_calls} cache-hit calls"
+        )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #809

## Problem

Every call to `get_all_sessions` invokes `_discover_with_identity`, which performs `os.scandir` on every session subdirectory (~N inner scandirs + N stats) even when the set of sessions hasn't changed. For N=500 sessions this is ~1,500 syscalls per call.

## Solution

Session directories are append-only — a new subdir only appears when the root directory's mtime changes. Introduce a `_DiscoveryCache` that stores the root's `(st_mtime_ns, st_size)` alongside the discovered `(events_path, plan_path)` pairs:

1. `stat(root)` → O(1) syscall
2. **Root unchanged** → skip all inner `os.scandir` calls; stat only the known files → **O(N) stats, zero inner scandirs**
3. **Root changed** → full rescan as before

Extracted the inner scandir loop into `_full_scandir_discovery()` for clarity.

### Syscall reduction

| Scenario | Before | After |
|---|---|---|
| N sessions, no new sessions | ~3N+1 | ~N+1 |

## Tests

Added `TestDiscoverWithIdentityCache` with 4 tests:
- Second call skips inner `os.scandir` when root is unchanged (patches `os.scandir` and asserts zero calls)
- Changed `events.jsonl` detected despite cached directory listing
- New session directory triggers full rescan
- Root mtime change triggers inner `os.scandir` calls

Updated existing `safe_file_identity` call-count assertions to account for the additional root-directory stat call.




> Generated by [Issue Implementer](https://github.com/microsasa/cli-tools/actions/runs/24048264287/agentic_workflow) · ● 16.2M · [◷](https://github.com/search?q=repo%3Amicrosasa%2Fcli-tools+%22gh-aw-workflow-id%3A+issue-implementer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Issue Implementer, engine: copilot, model: claude-opus-4.6, id: 24048264287, workflow_id: issue-implementer, run: https://github.com/microsasa/cli-tools/actions/runs/24048264287 -->

<!-- gh-aw-workflow-id: issue-implementer -->