### PR TITLE
test(models): add unit tests for `_sanitize_non_numeric_tokens` validator (#815)

### DIFF
--- a/tests/copilot_usage/test_models.py
+++ b/tests/copilot_usage/test_models.py
@@ -184,6 +184,34 @@ def test_assistant_message_data_tool_requests_populated() -> None:
     assert d.toolRequests[0].toolCallId == "t1"
 
 
+class TestSanitizeNonNumericTokens:
+    """Validator maps bool/str outputTokens to 0 to prevent lax coercion."""
+
+    def test_bool_true_maps_to_zero(self) -> None:
+        d = AssistantMessageData.model_validate({"outputTokens": True})
+        assert d.outputTokens == 0
+
+    def test_bool_false_maps_to_zero(self) -> None:
+        d = AssistantMessageData.model_validate({"outputTokens": False})
+        assert d.outputTokens == 0
+
+    def test_numeric_string_maps_to_zero(self) -> None:
+        d = AssistantMessageData.model_validate({"outputTokens": "100"})
+        assert d.outputTokens == 0
+
+    def test_non_numeric_string_maps_to_zero(self) -> None:
+        d = AssistantMessageData.model_validate({"outputTokens": "abc"})
+        assert d.outputTokens == 0
+
+    def test_valid_int_passes_through(self) -> None:
+        d = AssistantMessageData.model_validate({"outputTokens": 373})
+        assert d.outputTokens == 373
+
+    def test_zero_int_passes_through(self) -> None:
+        d = AssistantMessageData.model_validate({"outputTokens": 0})
+        assert d.outputTokens == 0
+
+
 def test_session_shutdown_data() -> None:
     d = SessionShutdownData.model_validate(RAW_SHUTDOWN["data"])
     assert d.totalPremiumRequests == 24


### PR DESCRIPTION
Closes #815

Adds a `TestSanitizeNonNumericTokens` class to `tests/copilot_usage/test_models.py` with six unit tests covering every branch of the `AssistantMessageData._sanitize_non_numeric_tokens` field validator:

| Test | Input | Expected `outputTokens` |
|---|---|---|
| `test_bool_true_maps_to_zero` | `True` | `0` |
| `test_bool_false_maps_to_zero` | `False` | `0` |
| `test_numeric_string_maps_to_zero` | `"100"` | `0` |
| `test_non_numeric_string_maps_to_zero` | `"abc"` | `0` |
| `test_valid_int_passes_through` | `373` | `373` |
| `test_zero_int_passes_through` | `0` | `0` |

These tests validate the model-level validator directly via `AssistantMessageData.model_validate()`, complementing the existing integration tests in `test_parser.py` that exercise the same validator through `_extract_output_tokens` and the full parse pipeline.

All checks pass (`make check`): lint ✅, typecheck ✅, security ✅, unit tests (99% coverage) ✅, e2e tests ✅.




> Generated by [Issue Implementer](https://github.com/microsasa/cli-tools/actions/runs/24065083358/agentic_workflow) · ● 6.2M · [◷](https://github.com/search?q=repo%3Amicrosasa%2Fcli-tools+%22gh-aw-workflow-id%3A+issue-implementer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Issue Implementer, engine: copilot, model: claude-opus-4.6, id: 24065083358, workflow_id: issue-implementer, run: https://github.com/microsasa/cli-tools/actions/runs/24065083358 -->

<!-- gh-aw-workflow-id: issue-implementer -->