### PR TITLE
perf(parser): replace Pydantic validation in `_extract_output_tokens` with direct dict access (#817)

### DIFF
--- a/src/copilot_usage/parser.py
+++ b/src/copilot_usage/parser.py
@@ -26,7 +26,6 @@ __all__: Final[list[str]] = [
 
 from copilot_usage._fs_utils import lru_insert, safe_file_identity
 from copilot_usage.models import (
-    AssistantMessageData,
     CodeChanges,
     EventType,
     ModelMetrics,
@@ -239,22 +238,28 @@ def _read_config_model(config_path: Path | None = None) -> str | None:
 
 
 def _extract_output_tokens(ev: SessionEvent) -> int | None:
-    """Extract ``outputTokens`` from an ``assistant.message`` event via Pydantic validation.
+    """Extract ``outputTokens`` from an ``assistant.message`` event via direct dict access.
 
-    Returns the validated positive integer token count, or ``None`` if the
-    event payload is malformed or the value is zero/negative.  Pydantic
-    lax-mode coercion handles whole-number floats (e.g. ``1234.0 → 1234``)
-    that the raw dict path would silently discard.  Bool and str values are
-    mapped to ``0`` by a field validator so that the rest of the assistant
-    message payload remains parsable.
+    Replicates the :class:`AssistantMessageData` field-validator behaviour
+    without constructing a full Pydantic model:
+
+    - ``bool`` / ``str`` → treated as ``0`` (returns ``None``)
+    - whole-number ``float`` → coerced to ``int`` (Pydantic lax-mode parity)
+    - non-whole ``float`` / other non-numeric → returns ``None``
 
     Callers are responsible for verifying ``ev.type`` before calling; this
-    function validates only the ``data`` payload via
-    :class:`AssistantMessageData`.
+    function reads only the ``outputTokens`` key from the event data dict.
     """
-    try:
-        tokens = AssistantMessageData.model_validate(ev.data).outputTokens
-    except ValidationError:
+    raw = ev.data.get("outputTokens")
+    if raw is None or isinstance(raw, (bool, str)):
+        return None
+    if isinstance(raw, float):
+        if not raw.is_integer():
+            return None
+        tokens = int(raw)
+    elif isinstance(raw, int):
+        tokens = raw
+    else:
         return None
     return tokens if tokens > 0 else None
 

--- a/tests/copilot_usage/test_parser.py
+++ b/tests/copilot_usage/test_parser.py
@@ -4274,14 +4274,14 @@ class TestExtractOutputTokens:
         assert _extract_output_tokens(_make_assistant_event(42)) == 42
 
     def test_coerces_whole_float_to_int(self) -> None:
-        """Whole-number floats like ``1234.0`` are coerced to int via Pydantic."""
+        """Whole-number floats like ``1234.0`` are coerced to int."""
         assert _extract_output_tokens(_make_assistant_event(1234.0)) == 1234
 
     def test_returns_none_for_fractional_float(self) -> None:
         assert _extract_output_tokens(_make_assistant_event(3.14)) is None
 
     def test_returns_none_for_bool_true(self) -> None:
-        """Boolean True is mapped to 0 by the field validator, not coerced to 1."""
+        """Boolean True is treated as invalid, not coerced to 1."""
         assert _extract_output_tokens(_make_assistant_event(True)) is None
 
     def test_returns_none_for_bool_false(self) -> None:
@@ -4291,11 +4291,11 @@ class TestExtractOutputTokens:
         assert _extract_output_tokens(_make_assistant_event(None)) is None
 
     def test_returns_none_for_string(self) -> None:
-        """Strings are mapped to 0 by the field validator, even numeric ones."""
+        """Strings are treated as invalid, even numeric ones."""
         assert _extract_output_tokens(_make_assistant_event("abc")) is None
 
     def test_returns_none_for_numeric_string(self) -> None:
-        """Numeric strings like ``"100"`` are mapped to 0, not coerced to int."""
+        """Numeric strings like ``"100"`` are treated as invalid, not coerced to int."""
         assert _extract_output_tokens(_make_assistant_event("100")) is None
 
     def test_returns_none_for_zero(self) -> None:
@@ -4314,6 +4314,70 @@ class TestExtractOutputTokens:
             data={"unexpected": "payload", "outputTokens": "not-a-number"},
         )
         assert _extract_output_tokens(ev) is None
+
+    def test_returns_none_for_missing_key(self) -> None:
+        """An event with no outputTokens key yields None."""
+        ev = SessionEvent(
+            type=EventType.ASSISTANT_MESSAGE,
+            data={"messageId": "m1", "content": "hi"},
+            id="ev-test",
+            timestamp=datetime(2026, 3, 7, 10, 1, tzinfo=UTC),
+        )
+        assert _extract_output_tokens(ev) is None
+
+
+_EXTRACT_TOKENS_CASES: list[tuple[str, object, int | None]] = [
+    ("valid_int", 42, 42),
+    ("whole_float", 1234.0, 1234),
+    ("bool_true", True, None),
+    ("str_numeric", "100", None),
+    ("fractional_float", 1.5, None),
+    ("none_value", None, None),
+]
+
+
+class TestExtractOutputTokensParametrized:
+    """Parametrized tests ensuring _extract_output_tokens matches field-validator behaviour."""
+
+    @pytest.mark.parametrize(
+        ("label", "raw_value", "expected"),
+        _EXTRACT_TOKENS_CASES,
+        ids=[c[0] for c in _EXTRACT_TOKENS_CASES],
+    )
+    def test_output_matches_expected(
+        self, label: str, raw_value: object, expected: int | None
+    ) -> None:
+        """Each raw value produces the expected result without Pydantic."""
+        _ = label  # used only as test-case id
+        assert _extract_output_tokens(_make_assistant_event(raw_value)) == expected
+
+    @pytest.mark.parametrize(
+        ("label", "raw_value", "expected"),
+        _EXTRACT_TOKENS_CASES,
+        ids=[c[0] for c in _EXTRACT_TOKENS_CASES],
+    )
+    def test_no_pydantic_model_validate_called(
+        self, label: str, raw_value: object, expected: int | None
+    ) -> None:
+        """AssistantMessageData.model_validate must NOT be called."""
+        _ = label, expected  # used only as test-case id / reference
+        with patch.object(
+            AssistantMessageData, "model_validate", side_effect=AssertionError
+        ):
+            _extract_output_tokens(_make_assistant_event(raw_value))
+
+    def test_missing_key_no_pydantic(self) -> None:
+        """Missing outputTokens key returns None without Pydantic."""
+        ev = SessionEvent(
+            type=EventType.ASSISTANT_MESSAGE,
+            data={"messageId": "m1", "content": "hi"},
+            id="ev-test",
+            timestamp=datetime(2026, 3, 7, 10, 1, tzinfo=UTC),
+        )
+        with patch.object(
+            AssistantMessageData, "model_validate", side_effect=AssertionError
+        ):
+            assert _extract_output_tokens(ev) is None
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #817

## What changed

Replaced the full `AssistantMessageData.model_validate(ev.data)` call in `_extract_output_tokens` with a direct `ev.data.get("outputTokens")` dict access that replicates all field-validator behaviour:

- `bool` / `str` → returns `None` (matches sanitizer mapping to `0`)
- whole-number `float` (e.g. `1234.0`) → coerced to `int` (Pydantic lax-mode parity)
- non-whole `float` / other non-numeric → returns `None`
- `None` / missing key → returns `None`
- zero / negative → returns `None`

## Why

`_extract_output_tokens` is called once per `assistant.message` event in both `_first_pass` and `_detect_resume`. The previous implementation triggered a full Pydantic v2 model construction (including `list[ToolRequest]` iteration) just to read a single integer. For sessions with many assistant messages this created unnecessary overhead scaling linearly with message count.

## Tests

- Updated existing `TestExtractOutputTokens` docstrings to reflect the new implementation
- Added `test_returns_none_for_missing_key` covering the missing-key case
- Added `TestExtractOutputTokensParametrized` with:
  - Parametrized value/expected tests for: valid int, whole float, bool, str, fractional float, None, and missing key
  - Spy assertions using `patch.object(AssistantMessageData, "model_validate", side_effect=AssertionError)` to verify Pydantic is never called

All checks pass (`make check` — lint, typecheck, security, unit + e2e tests, 99% coverage).




> Generated by [Issue Implementer](https://github.com/microsasa/cli-tools/actions/runs/24065806662/agentic_workflow) · ● 5.9M · [◷](https://github.com/search?q=repo%3Amicrosasa%2Fcli-tools+%22gh-aw-workflow-id%3A+issue-implementer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Issue Implementer, engine: copilot, model: claude-opus-4.6, id: 24065806662, workflow_id: issue-implementer, run: https://github.com/microsasa/cli-tools/actions/runs/24065806662 -->

<!-- gh-aw-workflow-id: issue-implementer -->