### PR TITLE
chore: remove vestigial `noqa: PLW0603` comments (#818)

### DIFF
--- a/src/copilot_usage/parser.py
+++ b/src/copilot_usage/parser.py
@@ -951,7 +951,7 @@ def get_all_sessions(base_path: Path | None = None) -> list[SessionSummary]:
     between refreshes while avoiding a redundant file read + JSON parse
     on every invocation.
     """
-    global _config_file_id  # noqa: PLW0603
+    global _config_file_id
     current_id = safe_file_identity(_CONFIG_PATH)
     if current_id != _config_file_id:
         _config_file_id = current_id

--- a/src/copilot_usage/vscode_parser.py
+++ b/src/copilot_usage/vscode_parser.py
@@ -416,7 +416,7 @@ def get_vscode_summary(base_path: Path | None = None) -> VSCodeLogSummary:
     O(num_models + num_categories + num_dates) :func:`_merge_partial`
     instead of O(requests).
     """
-    global _vscode_summary_cache  # noqa: PLW0603
+    global _vscode_summary_cache
 
     logs = discover_vscode_logs(base_path)
     log_ids: list[tuple[Path, tuple[int, int] | None]] = [


### PR DESCRIPTION
Closes #818

## Changes

Remove unused `# noqa: PLW0603` directives from `global` statements in:
- `src/copilot_usage/parser.py` (line 954)
- `src/copilot_usage/vscode_parser.py` (line 419)

The `PLW0603` rule (pylint's "global statement" warning) is **not** in the ruff `select` list in `pyproject.toml`, so these noqa comments suppress a rule that is never evaluated — they are dead directives.

## Note on `import builtins` in models.py

The issue also proposed removing `import builtins` and changing `builtins.type[T]` → `type[T]` in `SessionEvent._as`. However, this change **breaks pyright strict mode** because the `SessionEvent` model has a `type: str` field that shadows the builtin `type`. The `builtins.type[T]` disambiguation is intentionally required and has been kept.

## Verification

- `make check` passes (lint, typecheck, security, tests)
- All 1170 unit tests pass (98.92% coverage)
- All 86 e2e tests pass




> Generated by [Issue Implementer](https://github.com/microsasa/cli-tools/actions/runs/24066220630/agentic_workflow) · ● 4.9M · [◷](https://github.com/search?q=repo%3Amicrosasa%2Fcli-tools+%22gh-aw-workflow-id%3A+issue-implementer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Issue Implementer, engine: copilot, model: claude-opus-4.6, id: 24066220630, workflow_id: issue-implementer, run: https://github.com/microsasa/cli-tools/actions/runs/24066220630 -->

<!-- gh-aw-workflow-id: issue-implementer -->