### PR TITLE
test: cover explicit `file_id` paths in `_get_cached_vscode_requests` (#825)

### DIFF
--- a/tests/copilot_usage/test_vscode_parser.py
+++ b/tests/copilot_usage/test_vscode_parser.py
@@ -1363,6 +1363,58 @@ class TestVscodeLogCache:
         assert s1.total_requests == 1
         assert s2.total_requests == 1
 
+    def test_explicit_file_id_skips_safe_file_identity(self, tmp_path: Path) -> None:
+        """Passing an explicit file_id bypasses safe_file_identity entirely."""
+        log_file = tmp_path / "chat.log"
+        log_file.write_text(_make_log_line(req_idx=0))
+
+        # Warm the cache with the default sentinel (safe_file_identity is used).
+        first = _get_cached_vscode_requests(log_file)
+        assert len(first) == 1
+
+        # Retrieve the file_id that was cached so we can pass it explicitly.
+        cached_id = _VSCODE_LOG_CACHE[log_file].file_id
+
+        # Patch safe_file_identity to raise — it must never be called.
+        with patch(
+            "copilot_usage.vscode_parser.safe_file_identity",
+            side_effect=AssertionError("safe_file_identity should not be called"),
+        ):
+            second = _get_cached_vscode_requests(log_file, file_id=cached_id)
+
+        assert second == first
+
+    def test_explicit_file_id_none_cache_hit(self, tmp_path: Path) -> None:
+        """Two calls with file_id=None parse only once (None == None cache hit)."""
+        log_file = tmp_path / "chat.log"
+        log_file.write_text(_make_log_line(req_idx=0))
+
+        with patch(
+            "copilot_usage.vscode_parser.parse_vscode_log",
+            wraps=parse_vscode_log,
+        ) as spy:
+            first = _get_cached_vscode_requests(log_file, file_id=None)
+            second = _get_cached_vscode_requests(log_file, file_id=None)
+            assert spy.call_count == 1
+
+        assert first == second
+        assert len(first) == 1
+
+    def test_explicit_file_id_mismatch_triggers_reparse(self, tmp_path: Path) -> None:
+        """A different explicit file_id invalidates the cache and re-parses."""
+        log_file = tmp_path / "chat.log"
+        log_file.write_text(_make_log_line(req_idx=0))
+
+        with patch(
+            "copilot_usage.vscode_parser.parse_vscode_log",
+            wraps=parse_vscode_log,
+        ) as spy:
+            _get_cached_vscode_requests(log_file, file_id=(0, 0))
+            assert spy.call_count == 1
+
+            _get_cached_vscode_requests(log_file, file_id=(1, 1))
+            assert spy.call_count == 2
+
 
 # ---------------------------------------------------------------------------
 # _vscode_summary_cache – summary-level caching


### PR DESCRIPTION
Closes #825

Adds three direct unit tests to `TestVscodeLogCache` covering the explicit `file_id` parameter branch of `_get_cached_vscode_requests`, which was previously exercised only indirectly through `get_vscode_summary` integration tests.

### New tests

| Test | Branch covered |
|---|---|
| `test_explicit_file_id_skips_safe_file_identity` | Explicit tuple `file_id` — cache hit; verifies `safe_file_identity` is **not** called |
| `test_explicit_file_id_none_cache_hit` | Explicit `file_id=None` — `None == None` cache hit; `parse_vscode_log` called only once |
| `test_explicit_file_id_mismatch_triggers_reparse` | Explicit tuple `file_id` — cache miss on identity mismatch; `parse_vscode_log` called again |

### Regression scenario protected

These tests would catch a regression where `file_id == _FILE_ID_UNSET` is changed to `file_id is _FILE_ID_UNSET`, which would silently bypass the cache for all `get_vscode_summary` calls.

All existing checks pass (`make check` — lint, typecheck, security, tests at 99% coverage).




> Generated by [Issue Implementer](https://github.com/microsasa/cli-tools/actions/runs/24077960073/agentic_workflow) · ● 6.9M · [◷](https://github.com/search?q=repo%3Amicrosasa%2Fcli-tools+%22gh-aw-workflow-id%3A+issue-implementer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Issue Implementer, engine: copilot, model: claude-opus-4.6, id: 24077960073, workflow_id: issue-implementer, run: https://github.com/microsasa/cli-tools/actions/runs/24077960073 -->

<!-- gh-aw-workflow-id: issue-implementer -->