### PR TITLE
test: cover `is_dir()` OSError guard in `_full_scandir_discovery` (#846)

### DIFF
--- a/tests/copilot_usage/test_parser.py
+++ b/tests/copilot_usage/test_parser.py
@@ -10,7 +10,7 @@ import time
 from collections.abc import Iterator
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import SupportsIndex, overload
+from typing import SupportsIndex, cast, overload
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -662,7 +662,7 @@ class TestDiscoverWithIdentityNoAbsentPlanStat:
                             m.name = e.name
                             m.path = e.path
                             m.is_dir.side_effect = OSError("lstat failed")
-                            wrapped.append(m)
+                            wrapped.append(cast(os.DirEntry[str], m))
                         else:
                             wrapped.append(e)
                     return iter(wrapped)

--- a/tests/copilot_usage/test_parser.py
+++ b/tests/copilot_usage/test_parser.py
@@ -11,7 +11,7 @@ from collections.abc import Iterator
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import SupportsIndex, overload
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from pydantic import ValidationError
@@ -624,6 +624,55 @@ class TestDiscoverWithIdentityNoAbsentPlanStat:
             return original_scandir(path)
 
         with patch("copilot_usage.parser.os.scandir", side_effect=_bomb):
+            _, result = _discover_with_identity(tmp_path)
+
+        assert len(result) == 1
+        assert result[0][0].parent.name == "sess-good"
+
+    def test_full_scandir_is_dir_oserror_skips_entry(self, tmp_path: Path) -> None:
+        """Skip a root-level entry whose ``is_dir()`` raises ``OSError``.
+
+        Simulates a broken symlink or ``EACCES`` on ``lstat`` by wrapping
+        ``os.scandir`` so that one entry's ``is_dir()`` raises ``OSError``.
+        The faulting entry must be silently skipped, not crash discovery.
+        """
+        good = tmp_path / "sess-good"
+        _write_events(good / "events.jsonl", _START_EVENT)
+        bad = tmp_path / "sess-bad"
+        _write_events(bad / "events.jsonl", _START_EVENT)
+
+        original_scandir = os.scandir
+
+        def _patched_scandir(
+            path: str | os.PathLike[str],
+        ) -> Iterator[os.DirEntry[str]]:
+            ctx = original_scandir(path)
+            if str(path) != str(tmp_path):
+                return ctx  # type: ignore[return-value]
+
+            class _WrappedCtx:
+                """Context manager that wraps scandir entries."""
+
+                def __enter__(self) -> Iterator[os.DirEntry[str]]:
+                    entries: list[os.DirEntry[str]] = list(original_scandir(path))
+                    wrapped: list[os.DirEntry[str]] = []
+                    for e in entries:
+                        if e.name == "sess-bad":
+                            m = MagicMock(spec=os.DirEntry)
+                            m.name = e.name
+                            m.path = e.path
+                            m.is_dir.side_effect = OSError("lstat failed")
+                            wrapped.append(m)
+                        else:
+                            wrapped.append(e)
+                    return iter(wrapped)
+
+                def __exit__(self, *a: object) -> None:
+                    pass
+
+            return _WrappedCtx()  # type: ignore[return-value]
+
+        with patch("copilot_usage.parser.os.scandir", side_effect=_patched_scandir):
             _, result = _discover_with_identity(tmp_path)
 
         assert len(result) == 1

--- a/tests/copilot_usage/test_parser.py
+++ b/tests/copilot_usage/test_parser.py
@@ -650,25 +650,32 @@ class TestDiscoverWithIdentityNoAbsentPlanStat:
                 return original_scandir(path)  # type: ignore[return-value]
 
             class _WrappedCtx:
-                """Context manager that wraps scandir entries."""
+                """Context manager keeping the scandir iterator open."""
 
-                def __enter__(self) -> Iterator[os.DirEntry[str]]:
-                    with original_scandir(path) as it:
-                        entries: list[os.DirEntry[str]] = list(it)
-                    wrapped: list[os.DirEntry[str]] = []
-                    for e in entries:
+                def __init__(self) -> None:
+                    self._it: Iterator[os.DirEntry[str]] | None = None
+
+                def _iter_wrapped_entries(self) -> Iterator[os.DirEntry[str]]:
+                    if self._it is None:
+                        return
+                    for e in self._it:
                         if e.name == "sess-bad":
                             m = MagicMock(spec=os.DirEntry)
                             m.name = e.name
                             m.path = e.path
                             m.is_dir.side_effect = OSError("lstat failed")
-                            wrapped.append(cast(os.DirEntry[str], m))
+                            yield cast(os.DirEntry[str], m)
                         else:
-                            wrapped.append(e)
-                    return iter(wrapped)
+                            yield e
+
+                def __enter__(self) -> Iterator[os.DirEntry[str]]:
+                    self._it = original_scandir(path)
+                    return self._iter_wrapped_entries()
 
                 def __exit__(self, *a: object) -> None:
-                    pass
+                    if self._it is not None:
+                        self._it.close()  # type: ignore[union-attr]
+                        self._it = None
 
             return _WrappedCtx()  # type: ignore[return-value]
 

--- a/tests/copilot_usage/test_parser.py
+++ b/tests/copilot_usage/test_parser.py
@@ -8,6 +8,7 @@ import json
 import os
 import time
 from collections.abc import Iterator
+from contextlib import AbstractContextManager
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import SupportsIndex, cast, overload
@@ -645,9 +646,9 @@ class TestDiscoverWithIdentityNoAbsentPlanStat:
 
         def _patched_scandir(
             path: str | os.PathLike[str],
-        ) -> Iterator[os.DirEntry[str]]:
+        ) -> AbstractContextManager[Iterator[os.DirEntry[str]]]:
             if str(path) != str(tmp_path):
-                return original_scandir(path)  # type: ignore[return-value]
+                return original_scandir(path)
 
             class _WrappedCtx:
                 """Context manager keeping the scandir iterator open."""
@@ -677,7 +678,7 @@ class TestDiscoverWithIdentityNoAbsentPlanStat:
                         self._it.close()  # type: ignore[union-attr]
                         self._it = None
 
-            return _WrappedCtx()  # type: ignore[return-value]
+            return _WrappedCtx()
 
         with patch("copilot_usage.parser.os.scandir", side_effect=_patched_scandir):
             _, result = _discover_with_identity(tmp_path)

--- a/tests/copilot_usage/test_parser.py
+++ b/tests/copilot_usage/test_parser.py
@@ -646,15 +646,15 @@ class TestDiscoverWithIdentityNoAbsentPlanStat:
         def _patched_scandir(
             path: str | os.PathLike[str],
         ) -> Iterator[os.DirEntry[str]]:
-            ctx = original_scandir(path)
             if str(path) != str(tmp_path):
-                return ctx  # type: ignore[return-value]
+                return original_scandir(path)  # type: ignore[return-value]
 
             class _WrappedCtx:
                 """Context manager that wraps scandir entries."""
 
                 def __enter__(self) -> Iterator[os.DirEntry[str]]:
-                    entries: list[os.DirEntry[str]] = list(original_scandir(path))
+                    with original_scandir(path) as it:
+                        entries: list[os.DirEntry[str]] = list(it)
                     wrapped: list[os.DirEntry[str]] = []
                     for e in entries:
                         if e.name == "sess-bad":


### PR DESCRIPTION
Closes #846

## What

Adds `test_full_scandir_is_dir_oserror_skips_entry` to `TestDiscoverWithIdentityNoAbsentPlanStat` in `tests/copilot_usage/test_parser.py`, covering the previously untested `try/except OSError` guard around `session_entry.is_dir(follow_symlinks=False)` in `_full_scandir_discovery`.

## How

The test creates two session directories (`sess-good`, `sess-bad`), then patches `os.scandir` to wrap the root-level entries so that `sess-bad`'s `DirEntry.is_dir()` raises `OSError("lstat failed")`. It asserts that `_discover_with_identity` returns exactly one session (the good one), confirming the faulting entry is silently skipped.

## Why

Without this test, a refactor that removes the inner `try/except OSError` around `is_dir()` would introduce a crash on broken symlinks with no test catching the regression.




> Generated by [Issue Implementer](https://github.com/microsasa/cli-tools/actions/runs/24120425895/agentic_workflow) · ● 5.9M · [◷](https://github.com/search?q=repo%3Amicrosasa%2Fcli-tools+%22gh-aw-workflow-id%3A+issue-implementer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Issue Implementer, engine: copilot, model: claude-opus-4.6, id: 24120425895, workflow_id: issue-implementer, run: https://github.com/microsasa/cli-tools/actions/runs/24120425895 -->

<!-- gh-aw-workflow-id: issue-implementer -->