### PR TITLE
test: cover _safe_event_data exception paths and wildcard case (#885)

### DIFF
--- a/tests/copilot_usage/test_render_detail.py
+++ b/tests/copilot_usage/test_render_detail.py
@@ -21,6 +21,7 @@ from copilot_usage.models import (
     TokenUsage,
     ToolExecutionData,
     ToolTelemetry,
+    UserMessageData,
 )
 from copilot_usage.render_detail import (
     _build_event_details,
@@ -31,6 +32,7 @@ from copilot_usage.render_detail import (
     _render_code_changes,
     _render_recent_events,
     _render_shutdown_cycles,
+    _safe_event_data,
     render_session_detail,
 )
 
@@ -806,3 +808,50 @@ class TestBuildEventDetailsUserMessage:
         """Empty content → empty string."""
         ev = SessionEvent(type=EventType.USER_MESSAGE, data={"content": ""})
         assert _build_event_details(ev) == ""
+
+
+# ---------------------------------------------------------------------------
+# _safe_event_data — exception recovery paths (issue #885)
+# ---------------------------------------------------------------------------
+
+
+class TestSafeEventData:
+    """Cover the except (ValidationError, ValueError) branch of _safe_event_data."""
+
+    def test_returns_none_on_validation_error(self) -> None:
+        """ValidationError from the parser must be caught; returns None."""
+        ev = SessionEvent(
+            type=EventType.USER_MESSAGE,
+            data={"attachments": 123},  # int, not list[str]
+        )
+        result = _safe_event_data(ev, ev.as_user_message)
+        assert result is None
+
+    def test_returns_none_on_value_error(self) -> None:
+        """ValueError from the parser must be caught; returns None."""
+        ev = SessionEvent(type=EventType.USER_MESSAGE, data={})
+
+        def _raise() -> UserMessageData:
+            raise ValueError("synthetic mismatch")
+
+        result = _safe_event_data(ev, _raise)
+        assert result is None
+
+    def test_returns_none_propagates_to_build_event_details(self) -> None:
+        """_build_event_details returns '' when _safe_event_data returns None."""
+        ev = SessionEvent(
+            type=EventType.USER_MESSAGE,
+            data={"attachments": 123},
+        )
+        assert _build_event_details(ev) == ""
+
+
+# ---------------------------------------------------------------------------
+# _build_event_details — wildcard case (issue #885)
+# ---------------------------------------------------------------------------
+
+
+def test_build_event_details_returns_empty_for_unrecognized_type() -> None:
+    """Wildcard case must return '' for event types without explicit handling."""
+    ev = SessionEvent(type=EventType.SESSION_RESUME, data={})
+    assert _build_event_details(ev) == ""


### PR DESCRIPTION
Closes #885

Adds tests for two uncovered code paths in `render_detail.py`:

### Gap 1 — `_safe_event_data` exception recovery

New `TestSafeEventData` class with three tests:

- **`test_returns_none_on_validation_error`** — constructs a `SessionEvent` with invalid `data` (`attachments: 123` instead of `list[str]`) so Pydantic raises `ValidationError`; asserts the function catches it and returns `None`.
- **`test_returns_none_on_value_error`** — passes a parser that raises `ValueError`; asserts the function catches it and returns `None`.
- **`test_returns_none_propagates_to_build_event_details`** — confirms `_build_event_details` returns `""` when `_safe_event_data` returns `None` due to invalid data.

### Gap 2 — `_build_event_details` wildcard `case _:`

- **`test_build_event_details_returns_empty_for_unrecognized_type`** — passes a `SESSION_RESUME` event (not handled by any explicit case) and asserts the wildcard branch returns `""`.

All existing checks pass (`make check`: lint, typecheck, security, tests at 99% coverage).




> Generated by [Issue Implementer](https://github.com/microsasa/cli-tools/actions/runs/24198232512/agentic_workflow) · ● 4.5M · [◷](https://github.com/search?q=repo%3Amicrosasa%2Fcli-tools+%22gh-aw-workflow-id%3A+issue-implementer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Issue Implementer, engine: copilot, model: claude-opus-4.6, id: 24198232512, workflow_id: issue-implementer, run: https://github.com/microsasa/cli-tools/actions/runs/24198232512 -->

<!-- gh-aw-workflow-id: issue-implementer -->