### PR TITLE
test(models): add dedicated `TestParseTokenInt` unit tests (#886)

### DIFF
--- a/tests/copilot_usage/test_models.py
+++ b/tests/copilot_usage/test_models.py
@@ -28,6 +28,7 @@ from copilot_usage.models import (
     ensure_aware_opt,
     has_active_period_stats,
     merge_model_metrics,
+    parse_token_int,
     shutdown_output_tokens,
     total_output_tokens,
 )
@@ -369,6 +370,68 @@ def test_session_summary_full() -> None:
     )
     assert s.total_premium_requests == 24
     assert s.model_metrics["claude-opus-4.6-1m"].usage.inputTokens == 1627935
+
+
+# ---------------------------------------------------------------------------
+# parse_token_int
+# ---------------------------------------------------------------------------
+
+
+class TestParseTokenInt:
+    """Direct unit tests for the public parse_token_int() function."""
+
+    # --- invalid / non-contributing inputs ---
+
+    @pytest.mark.parametrize("value", [True, False])
+    def test_bool_returns_none(self, value: bool) -> None:
+        """Bool inputs (subclass of int) must be rejected."""
+        assert parse_token_int(value) is None
+
+    @pytest.mark.parametrize("value", ["42", "abc", ""])
+    def test_str_returns_none(self, value: str) -> None:
+        """String inputs must be rejected even if numeric."""
+        assert parse_token_int(value) is None
+
+    @pytest.mark.parametrize("value", [3.14, 0.5, -1.5, 1.999])
+    def test_non_whole_float_returns_none(self, value: float) -> None:
+        """Non-whole floats must be rejected."""
+        assert parse_token_int(value) is None
+
+    @pytest.mark.parametrize("value", [0, -1, -100_000])
+    def test_zero_or_negative_int_returns_none(self, value: int) -> None:
+        """Zero and negative ints must be rejected."""
+        assert parse_token_int(value) is None
+
+    @pytest.mark.parametrize("value", [0.0, -1.0, -100.0])
+    def test_zero_or_negative_float_returns_none(self, value: float) -> None:
+        """Zero and negative whole floats must be rejected."""
+        assert parse_token_int(value) is None
+
+    @pytest.mark.parametrize("value", [None, {}, [], object()])
+    def test_other_types_return_none(self, value: object) -> None:
+        """Unsupported types must be rejected."""
+        assert parse_token_int(value) is None
+
+    # --- valid / contributing inputs ---
+
+    def test_positive_int_returned_as_is(self) -> None:
+        """Positive int should be returned unchanged."""
+        assert parse_token_int(42) == 42
+
+    def test_positive_whole_float_coerced_to_int(self) -> None:
+        """Positive whole float should be coerced to int."""
+        result = parse_token_int(1234.0)
+        assert result == 1234
+        assert isinstance(result, int)
+
+    def test_large_positive_int(self) -> None:
+        """Large positive ints should be returned unchanged."""
+        assert parse_token_int(1_000_000) == 1_000_000
+
+    def test_return_type_is_int_not_float(self) -> None:
+        """Whole-number float coercion must produce an int, not a float."""
+        result = parse_token_int(99.0)
+        assert type(result) is int
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #886

## Summary

Adds a `TestParseTokenInt` class in `tests/copilot_usage/test_models.py` that directly tests the public `parse_token_int()` function against its documented contract, covering all input categories:

### Invalid inputs → `None`
- **bool**: `True` / `False` (bool is a subclass of int — guard order matters)
- **str**: `"42"`, `"abc"`, `""` (no string coercion)
- **non-whole float**: `3.14`, `0.5`, `-1.5`, `1.999`
- **zero/negative int**: `0`, `-1`, `-100_000`
- **zero/negative float**: `0.0`, `-1.0`, `-100.0`
- **other types**: `None`, `{}`, `[]`, `object()`

### Valid inputs → positive `int`
- Positive int returned as-is (`42 → 42`)
- Positive whole float coerced to int (`1234.0 → 1234`)
- Large positive int (`1_000_000`)
- Return type verified as `int`, not `float`

## Regression risk addressed

Previously, all `parse_token_int` coverage was indirect (through `_extract_output_tokens`). A refactor that swapped the `isinstance(raw, bool)` guard order would silently break the contract — these direct tests catch that.




> Generated by [Issue Implementer](https://github.com/microsasa/cli-tools/actions/runs/24198846400/agentic_workflow) · ● 4.1M · [◷](https://github.com/search?q=repo%3Amicrosasa%2Fcli-tools+%22gh-aw-workflow-id%3A+issue-implementer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Issue Implementer, engine: copilot, model: claude-opus-4.6, id: 24198846400, workflow_id: issue-implementer, run: https://github.com/microsasa/cli-tools/actions/runs/24198846400 -->

<!-- gh-aw-workflow-id: issue-implementer -->