### PR TITLE
perf: lazy-import vscode_parser and vscode_report in CLI (#890)

### DIFF
--- a/src/copilot_usage/cli.py
+++ b/src/copilot_usage/cli.py
@@ -35,8 +35,6 @@ from copilot_usage.report import (
     render_summary,
     session_display_name,
 )
-from copilot_usage.vscode_parser import get_vscode_summary
-from copilot_usage.vscode_report import render_vscode_summary
 
 type _View = Literal["home", "detail", "cost"]
 
@@ -661,6 +659,9 @@ def live(ctx: click.Context, path: Path | None) -> None:
 )
 def vscode(vscode_logs: Path | None) -> None:
     """Show usage from VS Code Copilot Chat logs."""
+    from copilot_usage.vscode_parser import get_vscode_summary
+    from copilot_usage.vscode_report import render_vscode_summary
+
     _print_version_header()
     summary = get_vscode_summary(vscode_logs)
     if summary.total_requests == 0:

--- a/tests/copilot_usage/test_vscode_parser.py
+++ b/tests/copilot_usage/test_vscode_parser.py
@@ -859,7 +859,10 @@ class TestVscodeCliCommand:
         summary = VSCodeLogSummary(
             log_files_found=2, log_files_parsed=0, total_requests=0
         )
-        with patch("copilot_usage.cli.get_vscode_summary", return_value=summary):
+        with patch(
+            "copilot_usage.vscode_parser.get_vscode_summary",
+            return_value=summary,
+        ):
             runner = CliRunner()
             result = runner.invoke(main, ["vscode"])
         assert result.exit_code == 1
@@ -870,7 +873,10 @@ class TestVscodeCliCommand:
         summary = VSCodeLogSummary(
             log_files_found=0, log_files_parsed=0, total_requests=0
         )
-        with patch("copilot_usage.cli.get_vscode_summary", return_value=summary):
+        with patch(
+            "copilot_usage.vscode_parser.get_vscode_summary",
+            return_value=summary,
+        ):
             runner = CliRunner()
             result = runner.invoke(main, ["vscode"])
         assert result.exit_code == 1

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -99,3 +99,29 @@ def test_ccreq_re_not_in_vscode_parser_all() -> None:
 
     dunder_all = vscode_mod.__all__
     assert "CCREQ_RE" not in dunder_all, "CCREQ_RE must not be in vscode_parser.__all__"
+
+
+def test_cli_does_not_import_vscode_modules_at_module_level() -> None:
+    """``vscode_parser`` and ``vscode_report`` must be lazy-imported.
+
+    Regression guard for issue #890: these modules are only needed by the
+    ``vscode`` subcommand and should not be imported at ``cli`` module level
+    to avoid loading ``re``, ``stat``, ``types``, and running ``re.compile``
+    on every invocation.
+    """
+    import sys
+
+    # Purge any previously imported copilot_usage modules so we get a
+    # clean import of cli.
+    for mod_name in list(sys.modules):
+        if "copilot_usage" in mod_name:
+            del sys.modules[mod_name]
+
+    importlib.import_module("copilot_usage.cli")
+
+    assert "copilot_usage.vscode_parser" not in sys.modules, (
+        "vscode_parser must not be imported at cli module level"
+    )
+    assert "copilot_usage.vscode_report" not in sys.modules, (
+        "vscode_report must not be imported at cli module level"
+    )

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -111,17 +111,22 @@ def test_cli_does_not_import_vscode_modules_at_module_level() -> None:
     """
     import sys
 
-    # Purge any previously imported copilot_usage modules so we get a
-    # clean import of cli.
-    for mod_name in list(sys.modules):
-        if "copilot_usage" in mod_name:
-            del sys.modules[mod_name]
+    original_sys_modules = sys.modules.copy()
+    try:
+        # Purge any previously imported copilot_usage modules so we get a
+        # clean import of cli.
+        for mod_name in list(sys.modules):
+            if mod_name == "copilot_usage" or mod_name.startswith("copilot_usage."):
+                del sys.modules[mod_name]
 
-    importlib.import_module("copilot_usage.cli")
+        importlib.import_module("copilot_usage.cli")
 
-    assert "copilot_usage.vscode_parser" not in sys.modules, (
-        "vscode_parser must not be imported at cli module level"
-    )
-    assert "copilot_usage.vscode_report" not in sys.modules, (
-        "vscode_report must not be imported at cli module level"
-    )
+        assert "copilot_usage.vscode_parser" not in sys.modules, (
+            "vscode_parser must not be imported at cli module level"
+        )
+        assert "copilot_usage.vscode_report" not in sys.modules, (
+            "vscode_report must not be imported at cli module level"
+        )
+    finally:
+        sys.modules.clear()
+        sys.modules.update(original_sys_modules)


### PR DESCRIPTION
## Summary

Moves the `vscode_parser` and `vscode_report` imports from module level into the `vscode()` command function so they are only loaded when that subcommand is actually invoked.

## Changes

- **`src/copilot_usage/cli.py`**: Removed module-level imports of `get_vscode_summary` and `render_vscode_summary`; added local imports inside the `vscode()` function.
- **`tests/copilot_usage/test_vscode_parser.py`**: Updated two tests that patched `copilot_usage.cli.get_vscode_summary` to patch `copilot_usage.vscode_parser.get_vscode_summary` instead, since the import is now local.
- **`tests/test_packaging.py`**: Added `test_cli_does_not_import_vscode_modules_at_module_level` regression test that verifies neither `copilot_usage.vscode_parser` nor `copilot_usage.vscode_report` appear in `sys.modules` after a clean import of `copilot_usage.cli`.

## Impact

Removes `re`, `stat`, `types`, and the `re.compile(...)` call from the startup path of all non-vscode subcommands (`summary`, `session`, `cost`, `live`, interactive mode). Estimated saving: ~3-5 ms per cold invocation.

Closes #890




> Generated by [Issue Implementer](https://github.com/microsasa/cli-tools/actions/runs/24211040998/agentic_workflow) · ● 11M · [◷](https://github.com/search?q=repo%3Amicrosasa%2Fcli-tools+%22gh-aw-workflow-id%3A+issue-implementer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Issue Implementer, engine: copilot, model: claude-opus-4.6, id: 24211040998, workflow_id: issue-implementer, run: https://github.com/microsasa/cli-tools/actions/runs/24211040998 -->

<!-- gh-aw-workflow-id: issue-implementer -->