### PR TITLE
fix(#895): Add tests for IEEE 754 special floats in parse_token_int()

### DIFF
--- a/tests/copilot_usage/test_models.py
+++ b/tests/copilot_usage/test_models.py
@@ -247,6 +247,17 @@ class TestSanitizeNonNumericTokens:
         d = AssistantMessageData.model_validate({"outputTokens": 100.0})
         assert d.outputTokens == 100
 
+    @pytest.mark.parametrize("raw", [float("inf"), float("-inf"), float("nan")])
+    def test_special_float_maps_to_zero(self, raw: float) -> None:
+        """IEEE 754 special floats on the Pydantic boundary must map to 0."""
+        d = AssistantMessageData.model_validate({"outputTokens": raw})
+        assert d.outputTokens == 0
+
+    def test_negative_zero_float_maps_to_zero(self) -> None:
+        """-0.0 on the Pydantic boundary must map to 0."""
+        d = AssistantMessageData.model_validate({"outputTokens": -0.0})
+        assert d.outputTokens == 0
+
 
 def test_session_shutdown_data() -> None:
     d = SessionShutdownData.model_validate(RAW_SHUTDOWN["data"])
@@ -406,6 +417,15 @@ class TestParseTokenInt:
     def test_zero_or_negative_float_returns_none(self, value: float) -> None:
         """Zero and negative whole floats must be rejected."""
         assert parse_token_int(value) is None
+
+    @pytest.mark.parametrize("raw", [float("inf"), float("-inf"), float("nan")])
+    def test_special_float_returns_none(self, raw: float) -> None:
+        """IEEE 754 special floats must be rejected, not coerced to int."""
+        assert parse_token_int(raw) is None
+
+    def test_negative_zero_float_returns_none(self) -> None:
+        """-0.0 passes is_integer() but must not count as a positive token value."""
+        assert parse_token_int(-0.0) is None
 
     @pytest.mark.parametrize("value", [None, {}, [], object()])
     def test_other_types_return_none(self, value: object) -> None:


### PR DESCRIPTION
## Summary

Add test coverage for IEEE 754 special floats (`inf`, `-inf`, `nan`) and `-0.0` in `parse_token_int()` and the `AssistantMessageData` Pydantic boundary validator.

These values are already handled correctly by the implementation but had no regression tests documenting the expected behavior.

### Tests added

**`TestParseTokenInt`:**
- `test_special_float_returns_none` -- parametrized with `float('inf')`, `float('-inf')`, `float('nan')`
- `test_negative_zero_float_returns_none` -- verifies `-0.0` is rejected

**`TestSanitizeNonNumericTokens`:**
- `test_special_float_maps_to_zero` -- parametrized with `float('inf')`, `float('-inf')`, `float('nan')`
- `test_negative_zero_float_maps_to_zero` -- verifies `-0.0` maps to `0`

Closes #895




> Generated by [Issue Implementer](https://github.com/microsasa/cli-tools/actions/runs/24235429722/agentic_workflow) · ● 8.7M · [◷](https://github.com/search?q=repo%3Amicrosasa%2Fcli-tools+%22gh-aw-workflow-id%3A+issue-implementer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Issue Implementer, engine: copilot, model: claude-opus-4.6, id: 24235429722, workflow_id: issue-implementer, run: https://github.com/microsasa/cli-tools/actions/runs/24235429722 -->

<!-- gh-aw-workflow-id: issue-implementer -->