### PR TITLE
Test OSError in _full_scandir_discovery is_dir() (#896)

### DIFF
--- a/tests/copilot_usage/test_parser.py
+++ b/tests/copilot_usage/test_parser.py
@@ -55,6 +55,7 @@ from copilot_usage.parser import (
     _extract_session_name,
     _first_pass,
     _FirstPassResult,
+    _full_scandir_discovery,
     _infer_model_from_metrics,
     _insert_session_entry,
     _read_config_model,
@@ -520,6 +521,33 @@ class TestDiscoverSessionsDepth:
         # Also verify via discover_sessions directly
         paths = discover_sessions(tmp_path)
         assert paths == [valid]
+
+
+# ---------------------------------------------------------------------------
+# _full_scandir_discovery — OSError on DirEntry.is_dir (issue #896)
+# ---------------------------------------------------------------------------
+
+
+class TestFullScanDirDiscovery:
+    """Cover error-handling paths in _full_scandir_discovery."""
+
+    def test_is_dir_oserror_entry_is_skipped(self, tmp_path: Path) -> None:
+        """An entry whose is_dir() raises OSError must be silently skipped."""
+        from unittest.mock import MagicMock
+
+        bad_entry = MagicMock(spec=os.DirEntry)
+        bad_entry.name = "broken-session"
+        bad_entry.is_dir.side_effect = OSError("permission denied")
+
+        ctx = MagicMock()
+        ctx.__enter__ = MagicMock(return_value=iter([bad_entry]))
+        ctx.__exit__ = MagicMock(return_value=False)
+
+        with patch("os.scandir", return_value=ctx):
+            result = _full_scandir_discovery(tmp_path, include_plan=False)
+
+        assert result == []
+        bad_entry.is_dir.assert_called_once_with(follow_symlinks=False)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Adds a test for the untested `except OSError` branch in `_full_scandir_discovery()` (`parser.py` lines 307-310).

When `DirEntry.is_dir(follow_symlinks=False)` raises `OSError` (e.g., broken bind-mount, stale NFS entry, security module denying stat), the entry is correctly treated as a non-directory and skipped. This test verifies that behavior using a `MagicMock` `DirEntry` whose `is_dir()` raises `OSError`.

Follows the same pattern as `test_stat_failure_on_entry_skipped` in `test_vscode_parser.py`.

Closes #896




> Generated by [Issue Implementer](https://github.com/microsasa/cli-tools/actions/runs/24236289330/agentic_workflow) · ● 8.4M · [◷](https://github.com/search?q=repo%3Amicrosasa%2Fcli-tools+%22gh-aw-workflow-id%3A+issue-implementer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Issue Implementer, engine: copilot, model: claude-opus-4.6, id: 24236289330, workflow_id: issue-implementer, run: https://github.com/microsasa/cli-tools/actions/runs/24236289330 -->

<!-- gh-aw-workflow-id: issue-implementer -->