### PR TITLE
fix: patch _CONFIG_PATH in stale-cache test to avoid real config leak

### DIFF
--- a/tests/copilot_usage/test_parser.py
+++ b/tests/copilot_usage/test_parser.py
@@ -5767,8 +5767,12 @@ class TestReadConfigModelCaching:
 
         # 3. Directly call build_session_summary (bypassing get_all_sessions)
         #    on an active session with no model info — model must be None.
+        #    Patch _CONFIG_PATH to a nonexistent file so the real
+        #    ~/.copilot/config.json doesn't leak into the assertion.
+        fake_config = tmp_path / "nonexistent" / "config.json"
         events = parse_events(events_path)
-        summary = build_session_summary(events, events_path=events_path)
+        with patch("copilot_usage.parser._CONFIG_PATH", fake_config):
+            summary = build_session_summary(events, events_path=events_path)
         assert summary.model is None
 
     def test_unchanged_config_skips_cache_clear(self, tmp_path: Path) -> None:


### PR DESCRIPTION
## Problem

`test_stale_lru_cache_not_visible_after_fixture_cleanup` calls `build_session_summary` without patching `_CONFIG_PATH`, so it reads the real `~/.copilot/config.json`. On any machine with a model configured (e.g. `claude-opus-4.6`), the assertion `summary.model is None` fails.

Passes on CI because runners don't have `~/.copilot/config.json`.

## Fix

Patch `_CONFIG_PATH` to a nonexistent path so the test is hermetic — consistent with how other tests in the same class handle it.

## Testing

- 1,420 passed, 0 failed locally (was 1 failed before)