### PR TITLE
fix: paginate orchestrator issue dispatch to find eligible issues (#928)

### DIFF
--- a/.github/workflows/pipeline-orchestrator.yml
+++ b/.github/workflows/pipeline-orchestrator.yml
@@ -115,24 +115,52 @@ jobs:
             exit 0
           fi
 
-          # Find oldest aw-labeled issue without aw-dispatched, agentic-workflows, or aw-protected-files
-          ISSUE=$(gh api graphql -f query='
-            query($owner: String!, $repo: String!) {
-              repository(owner: $owner, name: $repo) {
-                issues(labels: ["aw"], states: OPEN, first: 20, orderBy: {field: CREATED_AT, direction: ASC}) {
-                  nodes {
-                    number
-                    title
-                    labels(first: 100) { nodes { name } }
+          # Find oldest aw-labeled issue without aw-dispatched, agentic-workflows, aw-protected-files, or backlog
+          CURSOR=""
+          ISSUE="null"
+          while true; do
+            if [[ -n "$CURSOR" ]]; then
+              CURSOR_ARG=", after: \"$CURSOR\""
+            else
+              CURSOR_ARG=""
+            fi
+
+            RESULT=$(gh api graphql -f query="
+              query(\$owner: String!, \$repo: String!) {
+                repository(owner: \$owner, name: \$repo) {
+                  issues(labels: [\"aw\"], states: OPEN, first: 100, orderBy: {field: CREATED_AT, direction: ASC}${CURSOR_ARG}) {
+                    nodes {
+                      number
+                      title
+                      labels(first: 100) { nodes { name } }
+                    }
+                    pageInfo {
+                      hasNextPage
+                      endCursor
+                    }
                   }
                 }
-              }
-            }' -f owner="$OWNER" -f repo="$REPO" \
-            --jq '[.data.repository.issues.nodes[] | select(
+              }" -f owner="$OWNER" -f repo="$REPO")
+
+            ISSUE=$(echo "$RESULT" | jq '[.data.repository.issues.nodes[] | select(
               ([.labels.nodes[].name] | any(. == "aw-dispatched") | not)
               and ([.labels.nodes[].name] | any(. == "agentic-workflows") | not)
               and ([.labels.nodes[].name] | any(. == "aw-protected-files") | not)
+              and ([.labels.nodes[].name] | any(. == "backlog") | not)
             )] | .[0]')
+
+            # Found an eligible issue — stop paginating
+            if [[ "$ISSUE" != "null" && -n "$ISSUE" ]]; then
+              break
+            fi
+
+            # Check if there are more pages
+            HAS_NEXT=$(echo "$RESULT" | jq -r '.data.repository.issues.pageInfo.hasNextPage')
+            if [[ "$HAS_NEXT" != "true" ]]; then
+              break
+            fi
+            CURSOR=$(echo "$RESULT" | jq -r '.data.repository.issues.pageInfo.endCursor')
+          done
 
           if [[ "$ISSUE" == "null" || -z "$ISSUE" ]]; then
             echo "No eligible issues to dispatch. Pipeline idle."


### PR DESCRIPTION
## Problem

The orchestrator's dispatch step queried only the first 20 `aw`-labeled issues (`first: 20`, oldest first, no pagination). It then post-filtered in jq to exclude already-handled labels. When all 20 slots were filled with old handled issues, the filter returned null — "No eligible issues to dispatch" — even though newer undispatched issues existed beyond the window.

The pipeline was idle for ~4 days because of this.

## Fix

- Wraps the GraphQL query in a paginated `while` loop with cursor-based pagination
- Uses `first: 100` (GraphQL max) per page
- Stops as soon as an eligible issue is found or all pages are exhausted
- Adds `backlog` to the label exclusion filter

## Review

Three-model review (Opus 4.6, Codex, Sonnet 4.6) — all clean, no issues. Pagination logic, cursor interpolation, error handling, and edge cases all verified.

Closes #928