### PR TITLE
fix: add frozen=True to _SortedSessionsCache and _VSCodeDiscoveryCache (#937)

### DIFF
--- a/src/copilot_usage/parser.py
+++ b/src/copilot_usage/parser.py
@@ -148,7 +148,7 @@ _EVENTS_CACHE: OrderedDict[Path, _CachedEvents] = OrderedDict()
 _config_file_id: tuple[int, int] | None = None
 
 
-@dataclasses.dataclass(slots=True)
+@dataclasses.dataclass(frozen=True, slots=True)
 class _SortedSessionsCache:
     """Cached sorted result from ``get_all_sessions``.
 

--- a/src/copilot_usage/vscode_parser.py
+++ b/src/copilot_usage/vscode_parser.py
@@ -122,7 +122,7 @@ _GLOB_PATTERN: Final[str] = (
 # ---------------------------------------------------------------------------
 
 
-@dataclass(slots=True)
+@dataclass(frozen=True, slots=True)
 class _VSCodeDiscoveryCache:
     """Cached result of discover_vscode_logs for a given root directory.
 

--- a/tests/copilot_usage/test_parser.py
+++ b/tests/copilot_usage/test_parser.py
@@ -3,6 +3,7 @@
 # pyright: reportPrivateUsage=false
 
 import builtins
+import dataclasses
 import io
 import json
 import os
@@ -60,6 +61,7 @@ from copilot_usage.parser import (
     _insert_session_entry,
     _read_config_model,
     _ResumeInfo,
+    _SortedSessionsCache,
     build_session_summary,
     discover_sessions,
     get_all_sessions,
@@ -9283,3 +9285,17 @@ class TestOrphanedTurnStartDoesNotInflateActiveCalls:
 
         assert summary.is_active is False
         assert summary.active_model_calls == 0
+
+
+class TestSortedSessionsCacheIsFrozen:
+    """_SortedSessionsCache must be a frozen dataclass."""
+
+    def test_field_reassignment_raises(self) -> None:
+        """Assigning to a field after construction raises FrozenInstanceError."""
+        cache = _SortedSessionsCache(
+            root=Path("sessions"),
+            fingerprint=frozenset(),
+            summaries=[],
+        )
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            cache.root = Path("/other")  # type: ignore[misc]

--- a/tests/copilot_usage/test_vscode_parser.py
+++ b/tests/copilot_usage/test_vscode_parser.py
@@ -1,5 +1,6 @@
 """Tests for copilot_usage.vscode_parser and the vscode CLI subcommand."""
 
+import dataclasses
 import os
 import re
 from datetime import datetime
@@ -2436,3 +2437,19 @@ class TestUpdateVscodeSummaryLargeScale:
         assert acc.total_duration_ms == 0
         assert acc.first_timestamp is None
         assert acc.last_timestamp is None
+
+
+class TestVSCodeDiscoveryCacheIsFrozen:
+    """_VSCodeDiscoveryCache must be a frozen dataclass."""
+
+    def test_field_reassignment_raises(self) -> None:
+        """Assigning to a field after construction raises FrozenInstanceError."""
+        cache = _VSCodeDiscoveryCache(
+            root_id=(0, 0),
+            child_ids=frozenset(),
+            newest_child_path=None,
+            newest_child_id=None,
+            log_paths=(),
+        )
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            cache.root_id = (1, 1)  # type: ignore[misc]


### PR DESCRIPTION
Closes #937

## Summary

Adds `frozen=True` to two internal dataclasses that are immutable value objects but were missing the freeze annotation:

- **`_SortedSessionsCache`** in `src/copilot_usage/parser.py` — instances are always replaced wholesale via module-level global reassignment; no field is ever mutated after construction.
- **`_VSCodeDiscoveryCache`** in `src/copilot_usage/vscode_parser.py` — instances are always replaced into `_VSCODE_DISCOVERY_CACHE[key]`; no field is ever mutated after construction.

This enforces the immutability contract at runtime and satisfies the coding guideline:

> Prefer `dataclasses.dataclass(frozen=True, slots=True)` for immutable value objects that never touch I/O.

## Testing

- All existing tests pass unchanged (99% coverage).
- Two new unit tests verify that field reassignment raises `FrozenInstanceError`:
  - `TestSortedSessionsCacheIsFrozen` in `test_parser.py`
  - `TestVSCodeDiscoveryCacheIsFrozen` in `test_vscode_parser.py`




> Generated by [Issue Implementer](https://github.com/microsasa/cli-tools/actions/runs/24499507100/agentic_workflow) · ● 8.3M · [◷](https://github.com/search?q=repo%3Amicrosasa%2Fcli-tools+%22gh-aw-workflow-id%3A+issue-implementer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Issue Implementer, engine: copilot, model: claude-opus-4.6, id: 24499507100, workflow_id: issue-implementer, run: https://github.com/microsasa/cli-tools/actions/runs/24499507100 -->

<!-- gh-aw-workflow-id: issue-implementer -->