### PR TITLE
fix: extract `_glob_candidate` to deduplicate VS Code log discovery (#938)

### DIFF
--- a/src/copilot_usage/vscode_parser.py
+++ b/src/copilot_usage/vscode_parser.py
@@ -196,11 +196,23 @@ def _default_log_candidates() -> list[Path]:
     return [root / d / "logs" for d in code_dirs]
 
 
+def _glob_logs(candidate: Path) -> list[Path]:
+    """Glob *candidate* for Copilot Chat log files (no stat check).
+
+    The caller is responsible for verifying that *candidate* is a readable
+    directory before calling this function.  Results are returned in
+    arbitrary filesystem order; callers should sort if deterministic output
+    is required.
+    """
+    return list(candidate.glob(_GLOB_PATTERN))
+
+
 def _glob_candidate(candidate: Path) -> list[Path]:
-    """Glob *candidate* for Copilot Chat log files.
+    """Stat + glob *candidate* for Copilot Chat log files.
 
     Returns an empty list if *candidate* is not a directory or is unreadable.
-    Logs a debug message on ``OSError``.
+    Logs a debug message on ``OSError``.  Results are returned unsorted;
+    callers should sort if deterministic output is required.
     """
     try:
         st = candidate.stat()
@@ -210,7 +222,7 @@ def _glob_candidate(candidate: Path) -> list[Path]:
     if not stat.S_ISDIR(st.st_mode):
         logger.debug("VS Code logs directory not found: {}", candidate)
         return []
-    return sorted(candidate.glob(_GLOB_PATTERN))
+    return _glob_logs(candidate)
 
 
 def discover_vscode_logs(base_path: Path | None = None) -> list[Path]:
@@ -231,6 +243,7 @@ def discover_vscode_logs(base_path: Path | None = None) -> list[Path]:
     """
     if base_path is not None:
         logs = _glob_candidate(base_path)
+        logs.sort()
         logger.debug("Discovered {} VS Code log file(s) under {}", len(logs), base_path)
         return logs
 
@@ -320,10 +333,12 @@ def _cached_discover_vscode_logs(base_path: Path | None) -> list[Path]:
             # Root + sentinel child unchanged — reuse cached log paths.
             result.extend(cached.log_paths)
             continue
-        # Cache miss or root/sentinel changed — scan children and run glob
+        # Cache miss or root/sentinel changed — scan children and run glob.
+        # *candidate* is already verified as an existing directory above,
+        # so call _glob_logs directly to avoid a redundant stat().
         child_ids = _scan_child_ids(candidate)
         newest_path, newest_id = _newest_child_from_ids(candidate, child_ids)
-        found = _glob_candidate(candidate)
+        found = _glob_logs(candidate)
         _VSCODE_DISCOVERY_CACHE[candidate] = _VSCodeDiscoveryCache(
             root_id=root_id,
             child_ids=child_ids,

--- a/src/copilot_usage/vscode_parser.py
+++ b/src/copilot_usage/vscode_parser.py
@@ -222,7 +222,11 @@ def _glob_candidate(candidate: Path) -> list[Path]:
     if not stat.S_ISDIR(st.st_mode):
         logger.debug("VS Code logs directory not found: {}", candidate)
         return []
-    return _glob_logs(candidate)
+    try:
+        return _glob_logs(candidate)
+    except OSError as exc:
+        logger.debug("Skipping VS Code logs candidate {}: {}", candidate, exc)
+        return []
 
 
 def discover_vscode_logs(base_path: Path | None = None) -> list[Path]:
@@ -338,7 +342,15 @@ def _cached_discover_vscode_logs(base_path: Path | None) -> list[Path]:
         # so call _glob_logs directly to avoid a redundant stat().
         child_ids = _scan_child_ids(candidate)
         newest_path, newest_id = _newest_child_from_ids(candidate, child_ids)
-        found = _glob_logs(candidate)
+        try:
+            found = _glob_logs(candidate)
+        except OSError as exc:
+            logger.debug(
+                "Skipping VS Code logs candidate {}: glob failed: {}",
+                candidate,
+                exc,
+            )
+            continue
         _VSCODE_DISCOVERY_CACHE[candidate] = _VSCodeDiscoveryCache(
             root_id=root_id,
             child_ids=child_ids,

--- a/src/copilot_usage/vscode_parser.py
+++ b/src/copilot_usage/vscode_parser.py
@@ -199,10 +199,12 @@ def _default_log_candidates() -> list[Path]:
 def _glob_logs(candidate: Path) -> list[Path]:
     """Glob *candidate* for Copilot Chat log files (no stat check).
 
-    The caller is responsible for verifying that *candidate* is a readable
-    directory before calling this function.  Results are returned in
-    arbitrary filesystem order; callers should sort if deterministic output
-    is required.
+    The caller is responsible for passing an existing directory, typically
+    one that has already been stat'd by the caller. ``Path.glob()`` may
+    still raise ``OSError`` if the directory cannot be traversed, so callers
+    that need graceful handling should catch that exception. Results are
+    returned in arbitrary filesystem order; callers should sort if
+    deterministic output is required.
     """
     return list(candidate.glob(_GLOB_PATTERN))
 

--- a/src/copilot_usage/vscode_parser.py
+++ b/src/copilot_usage/vscode_parser.py
@@ -290,8 +290,9 @@ def _cached_discover_vscode_logs(base_path: Path | None) -> list[Path]:
     root ``(st_mtime_ns, st_size)`` *and* same identity of the most
     recently modified child), the stored paths are reused without
     scanning all child directories or running the multi-level glob.
-    On a miss, :func:`_scan_child_ids` runs and the glob executes to
-    repopulate the cache.
+    On a miss, :func:`_scan_child_ids` runs and :func:`_glob_logs` is
+    called directly (not :func:`_glob_candidate`) to repopulate the
+    cache, since the stat check has already been performed.
 
     The root identity check catches session-directory additions/removals
     (child additions update parent mtime on Linux/macOS).  The

--- a/src/copilot_usage/vscode_parser.py
+++ b/src/copilot_usage/vscode_parser.py
@@ -196,6 +196,23 @@ def _default_log_candidates() -> list[Path]:
     return [root / d / "logs" for d in code_dirs]
 
 
+def _glob_candidate(candidate: Path) -> list[Path]:
+    """Glob *candidate* for Copilot Chat log files.
+
+    Returns an empty list if *candidate* is not a directory or is unreadable.
+    Logs a debug message on ``OSError``.
+    """
+    try:
+        st = candidate.stat()
+    except OSError as exc:
+        logger.debug("Skipping VS Code logs candidate {}: {}", candidate, exc)
+        return []
+    if not stat.S_ISDIR(st.st_mode):
+        logger.debug("VS Code logs directory not found: {}", candidate)
+        return []
+    return sorted(candidate.glob(_GLOB_PATTERN))
+
+
 def discover_vscode_logs(base_path: Path | None = None) -> list[Path]:
     """Find all VS Code Copilot Chat log files.
 
@@ -213,20 +230,14 @@ def discover_vscode_logs(base_path: Path | None = None) -> list[Path]:
     When both exist, files from both are returned and sorted together.
     """
     if base_path is not None:
-        if not base_path.is_dir():
-            logger.debug("VS Code logs directory not found: {}", base_path)
-            return []
-        logs = sorted(base_path.glob(_GLOB_PATTERN))
+        logs = _glob_candidate(base_path)
         logger.debug("Discovered {} VS Code log file(s) under {}", len(logs), base_path)
         return logs
 
     candidates = _default_log_candidates()
     all_logs: list[Path] = []
     for candidate in candidates:
-        if not candidate.is_dir():
-            logger.debug("VS Code logs directory not found: {}", candidate)
-            continue
-        all_logs.extend(candidate.glob(_GLOB_PATTERN))
+        all_logs.extend(_glob_candidate(candidate))
     all_logs.sort()
     logger.debug(
         "Discovered {} VS Code log file(s) across {} candidate(s)",
@@ -312,7 +323,7 @@ def _cached_discover_vscode_logs(base_path: Path | None) -> list[Path]:
         # Cache miss or root/sentinel changed — scan children and run glob
         child_ids = _scan_child_ids(candidate)
         newest_path, newest_id = _newest_child_from_ids(candidate, child_ids)
-        found = sorted(candidate.glob(_GLOB_PATTERN))
+        found = _glob_candidate(candidate)
         _VSCODE_DISCOVERY_CACHE[candidate] = _VSCodeDiscoveryCache(
             root_id=root_id,
             child_ids=child_ids,

--- a/src/copilot_usage/vscode_parser.py
+++ b/src/copilot_usage/vscode_parser.py
@@ -248,7 +248,10 @@ def discover_vscode_logs(base_path: Path | None = None) -> list[Path]:
     if base_path is not None:
         logs = _glob_candidate(base_path)
         logs.sort()
-        logger.debug("Discovered {} VS Code log file(s) under {}", len(logs), base_path)
+        if logs:
+            logger.debug(
+                "Discovered {} VS Code log file(s) under {}", len(logs), base_path
+            )
         return logs
 
     candidates = _default_log_candidates()

--- a/tests/copilot_usage/test_vscode_parser.py
+++ b/tests/copilot_usage/test_vscode_parser.py
@@ -2364,7 +2364,7 @@ class TestGlobCandidate:
         assert _glob_candidate(tmp_path) == []
 
     def test_finds_matching_logs(self, tmp_path: Path) -> None:
-        """Returns sorted log paths when matching files exist."""
+        """Returns matching log paths when files exist."""
         log_dir = tmp_path / "20260313" / "window1" / "exthost" / "GitHub.copilot-chat"
         log_dir.mkdir(parents=True)
         log_file = log_dir / "GitHub Copilot Chat.log"

--- a/tests/copilot_usage/test_vscode_parser.py
+++ b/tests/copilot_usage/test_vscode_parser.py
@@ -24,6 +24,7 @@ from copilot_usage.vscode_parser import (
     _cached_discover_vscode_logs,  # pyright: ignore[reportPrivateUsage]
     _default_log_candidates,  # pyright: ignore[reportPrivateUsage]
     _get_cached_vscode_requests,  # pyright: ignore[reportPrivateUsage]
+    _glob_candidate,  # pyright: ignore[reportPrivateUsage]
     _merge_partial,  # pyright: ignore[reportPrivateUsage]
     _scan_child_ids,  # pyright: ignore[reportPrivateUsage]
     _SummaryAccumulator,  # pyright: ignore[reportPrivateUsage]
@@ -339,35 +340,35 @@ class TestDiscoverVscodeLogs:
     def test_default_windows(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setattr("copilot_usage.vscode_parser.sys.platform", "win32")
         monkeypatch.setenv("APPDATA", r"C:\Users\test\AppData\Roaming")
-        with patch.object(Path, "is_dir", return_value=False):
-            result = discover_vscode_logs()
+        result = discover_vscode_logs()
         assert result == []
 
     def test_default_windows_no_appdata(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Windows without APPDATA uses the home-relative fallback path."""
         monkeypatch.setattr("copilot_usage.vscode_parser.sys.platform", "win32")
         monkeypatch.setenv("APPDATA", "")  # empty → falsy
-        with patch.object(
-            Path, "is_dir", autospec=True, return_value=False
-        ) as mock_is_dir:
-            result = discover_vscode_logs()
-        mock_is_dir.assert_any_call(
-            Path.home() / "AppData" / "Roaming" / "Code" / "logs"
-        )
+
+        glob_calls: list[Path] = []
+
+        def _track(candidate: Path) -> list[Path]:
+            glob_calls.append(candidate)
+            return []
+
+        monkeypatch.setattr("copilot_usage.vscode_parser._glob_candidate", _track)
+        result = discover_vscode_logs()
+        assert Path.home() / "AppData" / "Roaming" / "Code" / "logs" in glob_calls
         assert result == []
 
     def test_default_macos(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setattr("copilot_usage.vscode_parser.sys.platform", "darwin")
         monkeypatch.delenv("APPDATA", raising=False)
-        with patch.object(Path, "is_dir", return_value=False):
-            result = discover_vscode_logs()
+        result = discover_vscode_logs()
         assert result == []
 
     def test_default_linux(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setattr("copilot_usage.vscode_parser.sys.platform", "linux")
         monkeypatch.delenv("APPDATA", raising=False)
-        with patch.object(Path, "is_dir", return_value=False):
-            result = discover_vscode_logs()
+        result = discover_vscode_logs()
         assert result == []
 
     # -- Insiders default discovery -----------------------------------------
@@ -2337,6 +2338,133 @@ class TestCachedDiscoverSkipsChildScanOnHit:
         monkeypatch.setattr(_mod, "_scan_child_ids", spy)
         _cached_discover_vscode_logs(tmp_path)
         assert scan_calls == [], "child scan must be skipped on root_id cache hit"
+
+
+# ---------------------------------------------------------------------------
+# _glob_candidate — unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestGlobCandidate:
+    """Tests for the shared _glob_candidate helper."""
+
+    def test_nonexistent_path_returns_empty(self, tmp_path: Path) -> None:
+        """A path that does not exist returns an empty list."""
+        missing = tmp_path / "no_such_dir"
+        assert _glob_candidate(missing) == []
+
+    def test_file_not_dir_returns_empty(self, tmp_path: Path) -> None:
+        """A regular file (not a directory) returns an empty list."""
+        regular_file = tmp_path / "not_a_dir"
+        regular_file.write_text("hello")
+        assert _glob_candidate(regular_file) == []
+
+    def test_empty_dir_returns_empty(self, tmp_path: Path) -> None:
+        """A directory with no matching log files returns an empty list."""
+        assert _glob_candidate(tmp_path) == []
+
+    def test_finds_matching_logs(self, tmp_path: Path) -> None:
+        """Returns sorted log paths when matching files exist."""
+        log_dir = tmp_path / "20260313" / "window1" / "exthost" / "GitHub.copilot-chat"
+        log_dir.mkdir(parents=True)
+        log_file = log_dir / "GitHub Copilot Chat.log"
+        log_file.write_text(_LOG_OPUS, encoding="utf-8")
+        result = _glob_candidate(tmp_path)
+        assert result == [log_file]
+
+    def test_oserror_logs_debug(self, tmp_path: Path) -> None:
+        """An OSError on stat() produces a debug log message."""
+        missing = tmp_path / "gone"
+        messages: list[str] = []
+
+        def _sink(message: object) -> None:
+            messages.append(str(message))
+
+        handler_id = logger.add(_sink, level="DEBUG")
+        try:
+            _glob_candidate(missing)
+        finally:
+            logger.remove(handler_id)
+        assert any("Skipping VS Code logs candidate" in m for m in messages)
+
+
+# ---------------------------------------------------------------------------
+# discover_vscode_logs — debug log on OSError (parity with cached path)
+# ---------------------------------------------------------------------------
+
+
+class TestDiscoverVscodeLogsOsError:
+    """Verify discover_vscode_logs emits debug logs on stat failure."""
+
+    def test_missing_basepath_logs_debug(self, tmp_path: Path) -> None:
+        """A non-existent base_path emits a debug log via _glob_candidate."""
+        missing = tmp_path / "vanished"
+        messages: list[str] = []
+
+        def _sink(message: object) -> None:
+            messages.append(str(message))
+
+        handler_id = logger.add(_sink, level="DEBUG")
+        try:
+            result = discover_vscode_logs(missing)
+        finally:
+            logger.remove(handler_id)
+        assert result == []
+        assert any("Skipping VS Code logs candidate" in m for m in messages)
+
+    def test_candidate_oserror_logs_debug(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Default candidates that raise OSError produce debug log output."""
+        monkeypatch.setattr("copilot_usage.vscode_parser.sys.platform", "linux")
+        monkeypatch.delenv("APPDATA", raising=False)
+        fake_home = tmp_path / "fakehome"
+        fake_home.mkdir()
+        monkeypatch.setattr(Path, "home", lambda: fake_home)
+
+        messages: list[str] = []
+
+        def _sink(message: object) -> None:
+            messages.append(str(message))
+
+        handler_id = logger.add(_sink, level="DEBUG")
+        try:
+            result = discover_vscode_logs()
+        finally:
+            logger.remove(handler_id)
+        assert result == []
+        assert any("Skipping VS Code logs candidate" in m for m in messages)
+
+
+# ---------------------------------------------------------------------------
+# Equivalence: discover_vscode_logs vs _cached_discover_vscode_logs
+# ---------------------------------------------------------------------------
+
+
+class TestDiscoverEquivalence:
+    """Both discovery functions return identical results for the same input."""
+
+    def test_empty_directory(self, tmp_path: Path) -> None:
+        """Both return [] for an empty directory."""
+        assert discover_vscode_logs(tmp_path) == _cached_discover_vscode_logs(tmp_path)
+
+    def test_nonexistent_directory(self, tmp_path: Path) -> None:
+        """Both return [] for a non-existent path."""
+        missing = tmp_path / "does_not_exist"
+        assert discover_vscode_logs(missing) == _cached_discover_vscode_logs(missing)
+
+    def test_with_log_files(self, tmp_path: Path) -> None:
+        """Both return the same sorted paths when log files exist."""
+        for session in ("20260313", "20260314"):
+            log_dir = tmp_path / session / "window1" / "exthost" / "GitHub.copilot-chat"
+            log_dir.mkdir(parents=True)
+            (log_dir / "GitHub Copilot Chat.log").write_text(
+                _make_log_line(req_idx=0), encoding="utf-8"
+            )
+        public = discover_vscode_logs(tmp_path)
+        cached = _cached_discover_vscode_logs(tmp_path)
+        assert public == cached
+        assert len(public) == 2
 
 
 # ---------------------------------------------------------------------------

--- a/tests/copilot_usage/test_vscode_parser.py
+++ b/tests/copilot_usage/test_vscode_parser.py
@@ -2301,6 +2301,32 @@ class TestCachedDiscoverOsErrors:
         assert result == []
         assert missing not in _VSCODE_DISCOVERY_CACHE
 
+    def test_glob_oserror_skipped(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A glob OSError after successful stat skips the candidate."""
+        existing_dir = tmp_path / "logs"
+        existing_dir.mkdir()
+
+        def _raise(_candidate: Path) -> list[Path]:
+            raise PermissionError("permission denied")
+
+        monkeypatch.setattr("copilot_usage.vscode_parser._glob_logs", _raise)
+
+        messages: list[str] = []
+
+        def _sink(message: object) -> None:
+            messages.append(str(message))
+
+        handler_id = logger.add(_sink, level="DEBUG")
+        try:
+            result = _cached_discover_vscode_logs(existing_dir)
+        finally:
+            logger.remove(handler_id)
+        assert result == []
+        assert existing_dir not in _VSCODE_DISCOVERY_CACHE
+        assert any("glob failed" in m for m in messages)
+
 
 class TestCachedDiscoverSkipsChildScanOnHit:
     """Verify _scan_child_ids is not called on root_id + sentinel cache hits.
@@ -2372,7 +2398,7 @@ class TestGlobCandidate:
         result = _glob_candidate(tmp_path)
         assert result == [log_file]
 
-    def test_oserror_logs_debug(self, tmp_path: Path) -> None:
+    def test_oserror_on_stat_logs_debug(self, tmp_path: Path) -> None:
         """An OSError on stat() produces a debug log message."""
         missing = tmp_path / "gone"
         messages: list[str] = []
@@ -2385,6 +2411,31 @@ class TestGlobCandidate:
             _glob_candidate(missing)
         finally:
             logger.remove(handler_id)
+        assert any("Skipping VS Code logs candidate" in m for m in messages)
+
+    def test_oserror_on_glob_returns_empty(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """An OSError during glob() returns [] and logs a debug message."""
+        existing_dir = tmp_path / "logs"
+        existing_dir.mkdir()
+
+        def _raise(_candidate: Path) -> list[Path]:
+            raise PermissionError("permission denied")
+
+        monkeypatch.setattr("copilot_usage.vscode_parser._glob_logs", _raise)
+
+        messages: list[str] = []
+
+        def _sink(message: object) -> None:
+            messages.append(str(message))
+
+        handler_id = logger.add(_sink, level="DEBUG")
+        try:
+            result = _glob_candidate(existing_dir)
+        finally:
+            logger.remove(handler_id)
+        assert result == []
         assert any("Skipping VS Code logs candidate" in m for m in messages)
 
 

--- a/tests/copilot_usage/test_vscode_parser.py
+++ b/tests/copilot_usage/test_vscode_parser.py
@@ -340,6 +340,11 @@ class TestDiscoverVscodeLogs:
     def test_default_windows(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setattr("copilot_usage.vscode_parser.sys.platform", "win32")
         monkeypatch.setenv("APPDATA", r"C:\Users\test\AppData\Roaming")
+
+        def _no_glob(_candidate: Path) -> list[Path]:
+            return []
+
+        monkeypatch.setattr("copilot_usage.vscode_parser._glob_candidate", _no_glob)
         result = discover_vscode_logs()
         assert result == []
 
@@ -362,12 +367,22 @@ class TestDiscoverVscodeLogs:
     def test_default_macos(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setattr("copilot_usage.vscode_parser.sys.platform", "darwin")
         monkeypatch.delenv("APPDATA", raising=False)
+
+        def _no_glob(_candidate: Path) -> list[Path]:
+            return []
+
+        monkeypatch.setattr("copilot_usage.vscode_parser._glob_candidate", _no_glob)
         result = discover_vscode_logs()
         assert result == []
 
     def test_default_linux(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setattr("copilot_usage.vscode_parser.sys.platform", "linux")
         monkeypatch.delenv("APPDATA", raising=False)
+
+        def _no_glob(_candidate: Path) -> list[Path]:
+            return []
+
+        monkeypatch.setattr("copilot_usage.vscode_parser._glob_candidate", _no_glob)
         result = discover_vscode_logs()
         assert result == []
 


### PR DESCRIPTION
Closes #938

## Summary

Extracts a private `_glob_candidate(candidate)` helper that encapsulates the single-candidate `stat()` → `S_ISDIR` → `glob()` logic. Both `discover_vscode_logs()` and `_cached_discover_vscode_logs()` now delegate to this helper, eliminating the duplicated iteration/glob logic and unifying error handling.

## Changes

**`src/copilot_usage/vscode_parser.py`**
- Added `_glob_candidate(candidate: Path) -> list[Path]` — uses `stat()` with explicit `OSError` handling (debug log on failure), consistent with the cached path's approach.
- Refactored `discover_vscode_logs()` to call `_glob_candidate()` instead of using `Path.is_dir()` + inline `glob()`.
- Refactored `_cached_discover_vscode_logs()` cache-miss path to call `_glob_candidate()` instead of inline `sorted(candidate.glob(...))`.

**`tests/copilot_usage/test_vscode_parser.py`**
- Updated platform-default tests to remove now-unnecessary `is_dir` mocks (non-existent paths naturally raise `FileNotFoundError` in `stat()`).
- Added `TestGlobCandidate`: unit tests for the new helper (missing path, file-not-dir, empty dir, matching logs, OSError debug log).
- Added `TestDiscoverVscodeLogsOsError`: verifies `discover_vscode_logs` emits debug logs on `stat()` failure — previously only tested for the cached path.
- Added `TestDiscoverEquivalence`: verifies both discovery functions return identical results for the same input (empty dir, missing path, populated dir).




> [!WARNING]
> <details>
> <summary><strong>⚠️ Firewall blocked 1 domain</strong></summary>
>
> The following domain was blocked by the firewall during workflow execution:
>
> - `astral.sh`
>
> To allow these domains, add them to the `network.allowed` list in your workflow frontmatter:
>
> ```yaml
> network:
>   allowed:
>     - defaults
>     - "astral.sh"
> ```
>
> See [Network Configuration](https://github.github.com/gh-aw/reference/network/) for more information.
>
> </details>


> Generated by [Issue Implementer](https://github.com/microsasa/cli-tools/actions/runs/24500028743/agentic_workflow) · ● 11.2M · [◷](https://github.com/search?q=repo%3Amicrosasa%2Fcli-tools+%22gh-aw-workflow-id%3A+issue-implementer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Issue Implementer, engine: copilot, model: claude-opus-4.6, id: 24500028743, workflow_id: issue-implementer, run: https://github.com/microsasa/cli-tools/actions/runs/24500028743 -->

<!-- gh-aw-workflow-id: issue-implementer -->