### PR TITLE
fix(vscode_report): use `format_duration` for Avg Duration column (#946)

### DIFF
--- a/src/copilot_usage/vscode_report.py
+++ b/src/copilot_usage/vscode_report.py
@@ -82,7 +82,7 @@ def render_vscode_summary(
                 model,
                 pricing.tier.value,
                 f"{count:,}",
-                f"{avg_ms:,}ms",
+                format_duration(avg_ms),
                 format_duration(total_ms),
             )
 

--- a/tests/copilot_usage/test_vscode_report.py
+++ b/tests/copilot_usage/test_vscode_report.py
@@ -159,7 +159,7 @@ class TestRenderVscodeSummaryPerModelTable:
             duration_by_model={"gpt-4o-mini": 2000},
         )
         output = _capture(summary)
-        # avg_ms = 2000 // 4 = 500
+        # avg_ms = 2000 // 4 = 500; format_duration(500) also returns "500ms"
         assert "500ms" in output
 
     def test_avg_ms_division_by_zero_guard(self) -> None:
@@ -221,6 +221,30 @@ class TestRenderVscodeSummaryPerModelTable:
         assert gpt_line.count("500ms") == 2
         # claude-opus-4.6 has no duration entry → 0ms avg and 0ms total
         assert opus_line.count("0ms") == 2
+
+    def test_avg_duration_over_one_minute_formatted_human_readable(self) -> None:
+        """Avg ≥ 60 000 ms renders as human-readable (e.g. '1m'), not raw ms."""
+        summary = _make_summary(
+            total_requests=2,
+            requests_by_model={"gpt-4o-mini": 2},
+            duration_by_model={"gpt-4o-mini": 120_000},
+        )
+        output = _capture(summary)
+        # avg_ms = 120_000 // 2 = 60_000 → format_duration → "1m"
+        assert "1m" in output
+        assert "60,000ms" not in output
+
+    def test_avg_duration_seconds_range_formatted(self) -> None:
+        """Avg in the seconds range renders as e.g. '5s', not raw '5,000ms'."""
+        summary = _make_summary(
+            total_requests=2,
+            requests_by_model={"gpt-4o-mini": 2},
+            duration_by_model={"gpt-4o-mini": 10_000},
+        )
+        output = _capture(summary)
+        # avg_ms = 10_000 // 2 = 5_000 → format_duration → "5s"
+        assert "5s" in output
+        assert "5,000ms" not in output
 
     def test_empty_requests_by_model_table_absent(self) -> None:
         summary = _make_summary(total_requests=5, requests_by_model={})


### PR DESCRIPTION
Closes #946

## Problem

The "Avg Duration" column in the per-model breakdown table used a raw millisecond format string (`f"{avg_ms:,}ms"`), producing unreadable values like `120,000ms` for longer averages, while the adjacent "Total Duration" column already used the shared `format_duration` helper.

## Fix

Replaced the raw format string on line 85 of `vscode_report.py` with `format_duration(avg_ms)`. No import changes needed — `format_duration` was already imported.

| avg_ms | Before | After |
|--------|--------|-------|
| 500 | `500ms` | `500ms` |
| 5000 | `5,000ms` | `5s` |
| 60000 | `60,000ms` | `1m` |

## Tests

- **`test_avg_ms_calculation`** — clarified comment that `format_duration(500)` also returns `"500ms"`, so the assertion is still valid
- **`test_avg_duration_over_one_minute_formatted_human_readable`** (new) — avg = 60,000 ms → asserts `"1m"` in output, `"60,000ms"` absent
- **`test_avg_duration_seconds_range_formatted`** (new) — avg = 5,000 ms → asserts `"5s"` in output, `"5,000ms"` absent

All checks pass (`make check` — lint, typecheck, security, unit + e2e tests at 99% coverage).




> Generated by [Issue Implementer](https://github.com/microsasa/cli-tools/actions/runs/24520667694/agentic_workflow) · ● 4.4M · [◷](https://github.com/search?q=repo%3Amicrosasa%2Fcli-tools+%22gh-aw-workflow-id%3A+issue-implementer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Issue Implementer, engine: copilot, model: claude-opus-4.6, id: 24520667694, workflow_id: issue-implementer, run: https://github.com/microsasa/cli-tools/actions/runs/24520667694 -->

<!-- gh-aw-workflow-id: issue-implementer -->