### PR TITLE
fix(vscode_parser): replace _SummaryAccumulator dataclass with plain class (#949)

### DIFF
--- a/src/copilot_usage/vscode_parser.py
+++ b/src/copilot_usage/vscode_parser.py
@@ -465,28 +465,38 @@ def _get_cached_vscode_requests(
     return requests
 
 
-@dataclass(slots=True)
 class _SummaryAccumulator:
     """Mutable accumulator for incremental VSCodeLogSummary construction."""
 
-    total_requests: int = 0
-    total_duration_ms: int = 0
-    requests_by_model: defaultdict[str, int] = field(
-        default_factory=lambda: defaultdict(int)
+    __slots__ = (
+        "total_requests",
+        "total_duration_ms",
+        "requests_by_model",
+        "duration_by_model",
+        "requests_by_category",
+        "requests_by_date",
+        "first_timestamp",
+        "last_timestamp",
+        "log_files_parsed",
+        "log_files_found",
     )
-    duration_by_model: defaultdict[str, int] = field(
-        default_factory=lambda: defaultdict(int)
-    )
-    requests_by_category: defaultdict[str, int] = field(
-        default_factory=lambda: defaultdict(int)
-    )
-    requests_by_date: defaultdict[str, int] = field(
-        default_factory=lambda: defaultdict(int)
-    )
-    first_timestamp: datetime | None = None
-    last_timestamp: datetime | None = None
-    log_files_parsed: int = 0
-    log_files_found: int = 0
+
+    def __init__(
+        self,
+        *,
+        log_files_parsed: int = 0,
+        log_files_found: int = 0,
+    ) -> None:
+        self.total_requests: int = 0
+        self.total_duration_ms: int = 0
+        self.requests_by_model: defaultdict[str, int] = defaultdict(int)
+        self.duration_by_model: defaultdict[str, int] = defaultdict(int)
+        self.requests_by_category: defaultdict[str, int] = defaultdict(int)
+        self.requests_by_date: defaultdict[str, int] = defaultdict(int)
+        self.first_timestamp: datetime | None = None
+        self.last_timestamp: datetime | None = None
+        self.log_files_parsed: int = log_files_parsed
+        self.log_files_found: int = log_files_found
 
 
 def _update_vscode_summary(

--- a/tests/copilot_usage/test_vscode_parser.py
+++ b/tests/copilot_usage/test_vscode_parser.py
@@ -1921,10 +1921,9 @@ class TestMergePartialTimestamps:
 
     def test_empty_partial_leaves_accumulator_timestamps_unchanged(self) -> None:
         """Merging a partial with None timestamps must not reset the accumulator."""
-        acc = _SummaryAccumulator(  # pyright: ignore[reportPrivateUsage]
-            first_timestamp=datetime(2026, 3, 13, 10, 0, 0),
-            last_timestamp=datetime(2026, 3, 14, 18, 0, 0),
-        )
+        acc = _SummaryAccumulator()  # pyright: ignore[reportPrivateUsage]
+        acc.first_timestamp = datetime(2026, 3, 13, 10, 0, 0)
+        acc.last_timestamp = datetime(2026, 3, 14, 18, 0, 0)
         empty_partial = VSCodeLogSummary()  # timestamps default to None
         _merge_partial(acc, empty_partial)  # pyright: ignore[reportPrivateUsage]
         assert acc.first_timestamp == datetime(2026, 3, 13, 10, 0, 0)
@@ -1943,10 +1942,9 @@ class TestMergePartialTimestamps:
 
     def test_older_partial_updates_first_timestamp(self) -> None:
         """A partial with an earlier first_timestamp should update the accumulator."""
-        acc = _SummaryAccumulator(  # pyright: ignore[reportPrivateUsage]
-            first_timestamp=datetime(2026, 3, 14, 10, 0, 0),
-            last_timestamp=datetime(2026, 3, 14, 18, 0, 0),
-        )
+        acc = _SummaryAccumulator()  # pyright: ignore[reportPrivateUsage]
+        acc.first_timestamp = datetime(2026, 3, 14, 10, 0, 0)
+        acc.last_timestamp = datetime(2026, 3, 14, 18, 0, 0)
         older = VSCodeLogSummary(
             first_timestamp=datetime(2026, 3, 13, 8, 0, 0),
             last_timestamp=datetime(2026, 3, 13, 12, 0, 0),
@@ -1958,10 +1956,9 @@ class TestMergePartialTimestamps:
 
     def test_newer_partial_does_not_update_first_timestamp(self) -> None:
         """A partial newer than the accumulator must not alter first_timestamp."""
-        acc = _SummaryAccumulator(  # pyright: ignore[reportPrivateUsage]
-            first_timestamp=datetime(2026, 3, 13, 8, 0, 0),
-            last_timestamp=datetime(2026, 3, 14, 18, 0, 0),
-        )
+        acc = _SummaryAccumulator()  # pyright: ignore[reportPrivateUsage]
+        acc.first_timestamp = datetime(2026, 3, 13, 8, 0, 0)
+        acc.last_timestamp = datetime(2026, 3, 14, 18, 0, 0)
         newer = VSCodeLogSummary(
             first_timestamp=datetime(2026, 3, 15, 10, 0, 0),
             last_timestamp=datetime(2026, 3, 15, 20, 0, 0),
@@ -1973,10 +1970,9 @@ class TestMergePartialTimestamps:
 
     def test_counters_are_additive_not_replaced(self) -> None:
         """Counter dicts must be summed, not overwritten, by _merge_partial."""
-        acc = _SummaryAccumulator(  # pyright: ignore[reportPrivateUsage]
-            total_requests=10,
-            total_duration_ms=5000,
-        )
+        acc = _SummaryAccumulator()  # pyright: ignore[reportPrivateUsage]
+        acc.total_requests = 10
+        acc.total_duration_ms = 5000
         acc.requests_by_model["gpt-4o"] += 5
         acc.duration_by_model["gpt-4o"] += 3000
         acc.requests_by_category["panel"] += 4
@@ -2453,3 +2449,13 @@ class TestVSCodeDiscoveryCacheIsFrozen:
         )
         with pytest.raises(dataclasses.FrozenInstanceError):
             cache.root_id = (1, 1)  # type: ignore[misc]
+
+
+class TestSummaryAccumulatorIsNotDataclass:
+    """_SummaryAccumulator must be a plain class, not a dataclass."""
+
+    def test_not_a_dataclass(self) -> None:
+        """Verify _SummaryAccumulator is not decorated with @dataclass."""
+        assert not dataclasses.is_dataclass(
+            _SummaryAccumulator  # pyright: ignore[reportPrivateUsage]
+        )


### PR DESCRIPTION
Closes #949

## Changes

Replace `@dataclass(slots=True)` on `_SummaryAccumulator` with a plain class using explicit `__slots__` and `__init__`, making its mutability intentional per the frozen-dataclass coding guideline.

### What changed

- **`src/copilot_usage/vscode_parser.py`**: Converted `_SummaryAccumulator` from a mutable `@dataclass(slots=True)` to a plain class with explicit `__slots__` tuple and a keyword-only `__init__` accepting only `log_files_parsed` and `log_files_found`.
- **`tests/copilot_usage/test_vscode_parser.py`**: Updated test call sites that previously passed `first_timestamp`, `last_timestamp`, `total_requests`, and `total_duration_ms` as constructor kwargs — these now set attributes after construction.
- **Regression test**: Added `TestSummaryAccumulatorIsNotDataclass` to verify `dataclasses.is_dataclass(_SummaryAccumulator)` returns `False`.

### Verification

- All existing tests pass (99% coverage)
- E2E tests pass (86 passed)
- pyright strict mode passes (0 errors)
- ruff lint and format clean
- bandit security scan clean




> Generated by [Issue Implementer](https://github.com/microsasa/cli-tools/actions/runs/24532131531/agentic_workflow) · ● 6.6M · [◷](https://github.com/search?q=repo%3Amicrosasa%2Fcli-tools+%22gh-aw-workflow-id%3A+issue-implementer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Issue Implementer, engine: copilot, model: claude-opus-4.6, id: 24532131531, workflow_id: issue-implementer, run: https://github.com/microsasa/cli-tools/actions/runs/24532131531 -->

<!-- gh-aw-workflow-id: issue-implementer -->