### PR TITLE
perf(vscode_parser): replace `ts.date()` with ymd-tuple in `_update_vscode_summary` (#960)

### DIFF
--- a/src/copilot_usage/vscode_parser.py
+++ b/src/copilot_usage/vscode_parser.py
@@ -8,7 +8,7 @@ import types
 from collections import OrderedDict, defaultdict
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
-from datetime import date, datetime
+from datetime import datetime
 from pathlib import Path
 from typing import Final, Literal
 
@@ -622,7 +622,7 @@ def _update_vscode_summary(
     first_ts = acc.first_timestamp
     last_ts = acc.last_timestamp
     last_date_key: str = ""
-    last_date_val: date | None = None
+    last_date_val: tuple[int, int, int] | None = None
 
     for req in requests:
         total_req += 1
@@ -635,10 +635,11 @@ def _update_vscode_summary(
         rbc[req.category] += 1
 
         ts = req.timestamp
-        ts_date = ts.date()
-        if last_date_val is None or ts_date != last_date_val:
-            last_date_key = ts_date.isoformat()
-            last_date_val = ts_date
+        ts_ymd = (ts.year, ts.month, ts.day)
+        if last_date_val is None or ts_ymd != last_date_val:
+            y, m, d = ts_ymd
+            last_date_key = f"{y:04d}-{m:02d}-{d:02d}"
+            last_date_val = ts_ymd
         rbd[last_date_key] += 1
 
         # Timestamp bounds: full min/max scan so callers (especially

--- a/tests/copilot_usage/test_vscode_parser.py
+++ b/tests/copilot_usage/test_vscode_parser.py
@@ -5,7 +5,7 @@
 import dataclasses
 import os
 import re
-from datetime import datetime
+from datetime import date, datetime
 from pathlib import Path
 from unittest.mock import patch
 
@@ -2911,6 +2911,72 @@ class TestUpdateVscodeSummaryLargeScale:
         assert acc.total_duration_ms == 0
         assert acc.first_timestamp is None
         assert acc.last_timestamp is None
+
+
+class TestUpdateVscodeSummarySameDateNoDateAlloc:
+    """Verify the date-bucketing fast path avoids per-iteration ``date()`` calls.
+
+    All requests share the same calendar day so only one date key should
+    appear and ``datetime.date()`` should be called at most once (for the
+    first distinct date boundary).
+    """
+
+    @staticmethod
+    def _same_day_requests(n: int = 500) -> list[VSCodeRequest]:
+        """Build *n* requests all on the same calendar day."""
+        base = datetime(2026, 4, 15, 10, 0, 0)
+        return [
+            VSCodeRequest(
+                timestamp=base.replace(second=i % 60, minute=i % 60),
+                request_id=f"sd{i:05d}",
+                model="gpt-4o",
+                duration_ms=100,
+                category="inline",
+            )
+            for i in range(n)
+        ]
+
+    def test_single_date_key(self) -> None:
+        """requests_by_date contains exactly one key for same-day input."""
+        requests = self._same_day_requests(500)
+        acc = _SummaryAccumulator()
+        _update_vscode_summary(acc, requests)
+
+        assert dict(acc.requests_by_date) == {"2026-04-15": 500}
+
+    def test_no_per_iteration_date_alloc(self) -> None:
+        """``datetime.date()`` is never called by the optimised loop."""
+        date_call_count = 0
+        base = datetime(2026, 4, 15, 10, 0, 0)
+
+        class _SpyDatetime(datetime):
+            """Subclass that counts ``.date()`` invocations."""
+
+            def date(self) -> date:
+                nonlocal date_call_count
+                date_call_count += 1
+                return super().date()
+
+        requests = [
+            VSCodeRequest(
+                timestamp=_SpyDatetime(
+                    base.year, base.month, base.day, 10, i % 60, i % 60
+                ),
+                request_id=f"spy{i:05d}",
+                model="gpt-4o",
+                duration_ms=100,
+                category="inline",
+            )
+            for i in range(200)
+        ]
+        acc = _SummaryAccumulator()
+        _update_vscode_summary(acc, requests)
+
+        assert date_call_count == 0, (
+            f"datetime.date() called {date_call_count} times; "
+            "expected 0 after ymd-tuple optimisation"
+        )
+        assert acc.total_requests == 200
 
 
 class TestVSCodeDiscoveryCacheIsFrozen:

--- a/tests/copilot_usage/test_vscode_parser.py
+++ b/tests/copilot_usage/test_vscode_parser.py
@@ -2917,8 +2917,8 @@ class TestUpdateVscodeSummarySameDateNoDateAlloc:
     """Verify the date-bucketing fast path avoids per-iteration ``date()`` calls.
 
     All requests share the same calendar day so only one date key should
-    appear and ``datetime.date()`` should be called at most once (for the
-    first distinct date boundary).
+    appear and ``datetime.date()`` should not be called at all under the
+    ymd-tuple optimisation.
     """
 
     @staticmethod


### PR DESCRIPTION
## Summary

Replace per-iteration `datetime.date()` call with `(year, month, day)` integer-tuple comparison in `_update_vscode_summary`'s inner loop. The ISO date string is now built via f-string only on date boundaries, eliminating O(N−D) unnecessary `date` object allocations per file (N = requests, D = distinct dates).

## Changes

**`src/copilot_usage/vscode_parser.py`**
- Replace `ts.date()` → `(ts.year, ts.month, ts.day)` tuple comparison
- Change `last_date_val` type from `date | None` to `tuple[int, int, int] | None`
- Build ISO key with `f"{y:04d}-{m:02d}-{d:02d}"` only on date boundary
- Remove unused `date` import

**`tests/copilot_usage/test_vscode_parser.py`**
- Add `TestUpdateVscodeSummarySameDateNoDateAlloc` class with two tests:
  - `test_single_date_key` — 500 same-day requests produce exactly one date key
  - `test_no_per_iteration_date_alloc` — datetime subclass spy confirms `date()` is never called

## Verification

- `ruff check` / `ruff format` ✅
- `pyright` (0 errors) ✅
- All 118 vscode_parser tests pass ✅

Closes #960




> Generated by [Issue Implementer](https://github.com/microsasa/cli-tools/actions/runs/24570877511/agentic_workflow) · ● 9.7M · [◷](https://github.com/search?q=repo%3Amicrosasa%2Fcli-tools+%22gh-aw-workflow-id%3A+issue-implementer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Issue Implementer, engine: copilot, model: claude-opus-4.6, id: 24570877511, workflow_id: issue-implementer, run: https://github.com/microsasa/cli-tools/actions/runs/24570877511 -->

<!-- gh-aw-workflow-id: issue-implementer -->