### PR TITLE
fix: separate `_PER_FILE_SUMMARY_CACHE` limit from `_VSCODE_LOG_CACHE` (#961)

### DIFF
--- a/src/copilot_usage/docs/implementation.md
+++ b/src/copilot_usage/docs/implementation.md
@@ -505,8 +505,8 @@ The `CCREQ_RE` regex in `vscode_parser.py` extracts: timestamp, request ID, mode
 | Cache | Key | Purpose | Invalidation |
 |---|---|---|---|
 | `_VSCODE_DISCOVERY_CACHE` | Candidate root `Path` | Skips glob when the root directory identity and cached newest-child sentinel are unchanged | Replaced when `root_id` (root dir identity) changes or `newest_child_id` (the cached most-recently-modified child dir identity) changes; changes under older/non-sentinel child dirs may not invalidate until the root changes or the cache is cleared |
-| `_VSCODE_LOG_CACHE` | Log file `Path` | Skips re-parsing a log file whose `(mtime_ns, size)` is unchanged | LRU eviction at `_MAX_CACHED_VSCODE_LOGS` (64); entry replaced when file identity changes |
-| `_PER_FILE_SUMMARY_CACHE` | Log file `Path` | Caches per-file aggregation (`VSCodeLogSummary`) keyed by `Path`, validated by file identity | LRU eviction at `_MAX_CACHED_VSCODE_LOGS` (64); entry replaced when file identity changes |
+| `_VSCODE_LOG_CACHE` | Log file `Path` | Skips re-parsing a log file whose `(mtime_ns, size)` is unchanged | LRU eviction at `_MAX_CACHED_VSCODE_REQUESTS` (64); entry replaced when file identity changes |
+| `_PER_FILE_SUMMARY_CACHE` | Log file `Path` | Caches per-file aggregation (`VSCodeLogSummary`) keyed by `Path`, validated by file identity | LRU eviction at `_MAX_CACHED_FILE_SUMMARIES` (256); entry replaced when file identity changes |
 | `_vscode_summary_cache` | `frozenset[tuple[Path, file_id]]` | Full `VSCodeLogSummary` for the entire set of discovered files | Replaced when the combined identity set changes; only populated when all discovered logs were successfully parsed (transient read failures do not produce a stale cache) |
 
 The two per-file caches (`_VSCODE_LOG_CACHE` and `_PER_FILE_SUMMARY_CACHE`) use `OrderedDict` with LRU insertion via the shared `lru_insert()` helper from `_fs_utils.py`. On a cache hit, entries are moved to the end via `move_to_end()` to maintain recency order.

--- a/src/copilot_usage/vscode_parser.py
+++ b/src/copilot_usage/vscode_parser.py
@@ -366,7 +366,8 @@ def parse_vscode_log(log_path: Path) -> list[VSCodeRequest]:
 # the back, least-recently-used at the front.
 # ---------------------------------------------------------------------------
 
-_MAX_CACHED_VSCODE_LOGS: Final[int] = 64
+_MAX_CACHED_VSCODE_REQUESTS: Final[int] = 64
+_MAX_CACHED_FILE_SUMMARIES: Final[int] = 256
 
 
 @dataclass(frozen=True, slots=True)
@@ -435,7 +436,7 @@ def _get_cached_vscode_requests(
     On the first call for a given *log_path*, delegates to
     :func:`parse_vscode_log` and stores the result.  Subsequent calls
     return the cached tuple as long as the file identity is unchanged.
-    The cache is bounded to :data:`_MAX_CACHED_VSCODE_LOGS` entries;
+    The cache is bounded to :data:`_MAX_CACHED_VSCODE_REQUESTS` entries;
     the **least-recently used** entry is evicted when the limit is
     reached.
 
@@ -460,7 +461,7 @@ def _get_cached_vscode_requests(
         _VSCODE_LOG_CACHE,
         log_path,
         _CachedVSCodeLog(file_id=resolved_id, requests=requests),
-        _MAX_CACHED_VSCODE_LOGS,
+        _MAX_CACHED_VSCODE_REQUESTS,
     )
     return requests
 
@@ -668,7 +669,7 @@ def get_vscode_summary(base_path: Path | None = None) -> VSCodeLogSummary:
                 _PER_FILE_SUMMARY_CACHE,
                 log_path,
                 _CachedFileSummary(file_id, partial_summary),
-                _MAX_CACHED_VSCODE_LOGS,
+                _MAX_CACHED_FILE_SUMMARIES,
             )
             _merge_partial(acc, partial_summary)
         acc.log_files_parsed += 1

--- a/tests/copilot_usage/test_vscode_parser.py
+++ b/tests/copilot_usage/test_vscode_parser.py
@@ -15,7 +15,8 @@ from copilot_usage._fs_utils import safe_file_identity
 from copilot_usage.cli import main
 from copilot_usage.vscode_parser import (
     _CCREQ_RE,  # pyright: ignore[reportPrivateUsage]
-    _MAX_CACHED_VSCODE_LOGS,  # pyright: ignore[reportPrivateUsage]
+    _MAX_CACHED_FILE_SUMMARIES,  # pyright: ignore[reportPrivateUsage]
+    _MAX_CACHED_VSCODE_REQUESTS,  # pyright: ignore[reportPrivateUsage]
     _PER_FILE_SUMMARY_CACHE,  # pyright: ignore[reportPrivateUsage]
     _VSCODE_DISCOVERY_CACHE,  # pyright: ignore[reportPrivateUsage]
     _VSCODE_LOG_CACHE,  # pyright: ignore[reportPrivateUsage]
@@ -1323,9 +1324,9 @@ class TestVscodeLogCache:
         assert len(second) == 2
 
     def test_lru_eviction(self, tmp_path: Path) -> None:
-        """When the cache exceeds _MAX_CACHED_VSCODE_LOGS, the oldest entry is evicted."""
+        """When the cache exceeds _MAX_CACHED_VSCODE_REQUESTS, the oldest entry is evicted."""
         paths: list[Path] = []
-        for i in range(_MAX_CACHED_VSCODE_LOGS + 1):
+        for i in range(_MAX_CACHED_VSCODE_REQUESTS + 1):
             p = tmp_path / f"log_{i}.log"
             p.write_text(_make_log_line(req_idx=i))
             paths.append(p)
@@ -1335,7 +1336,7 @@ class TestVscodeLogCache:
 
         # The first entry should have been evicted.
         assert paths[0] not in _VSCODE_LOG_CACHE
-        assert len(_VSCODE_LOG_CACHE) == _MAX_CACHED_VSCODE_LOGS
+        assert len(_VSCODE_LOG_CACHE) == _MAX_CACHED_VSCODE_REQUESTS
 
     def test_lru_promotion_on_access(self, tmp_path: Path) -> None:
         """Accessing a cached entry moves it to the back (most-recently used)."""
@@ -1749,13 +1750,13 @@ class TestPerFileSummaryCacheLRUEviction:
 
     After removing _BoundedFileSummaryCache, eviction is handled by the
     shared ``lru_insert()`` helper.  This test exercises the integration:
-    writing more than ``_MAX_CACHED_VSCODE_LOGS`` distinct files must
+    writing more than ``_MAX_CACHED_FILE_SUMMARIES`` distinct files must
     evict the oldest entry while the newest survives.
     """
 
     def test_oldest_evicted_newest_survives(self, tmp_path: Path) -> None:
-        """Inserting _MAX_CACHED_VSCODE_LOGS + 1 files evicts the first."""
-        limit = _MAX_CACHED_VSCODE_LOGS
+        """Inserting _MAX_CACHED_FILE_SUMMARIES + 1 files evicts the first."""
+        limit = _MAX_CACHED_FILE_SUMMARIES
 
         # Create limit + 1 log files inside a VS Code log directory layout.
         log_files: list[Path] = []
@@ -1787,6 +1788,68 @@ class TestPerFileSummaryCacheLRUEviction:
         )
         # Cache size must match the configured limit after one eviction.
         assert len(_PER_FILE_SUMMARY_CACHE) == limit
+
+
+# ---------------------------------------------------------------------------
+# Per-file summary cache survives beyond old shared 64-entry limit
+# ---------------------------------------------------------------------------
+
+
+class TestPerFileSummaryCacheSurvivesBeyond64:
+    """Verify that per-file summaries for 70+ files survive across calls.
+
+    Before the fix, ``_PER_FILE_SUMMARY_CACHE`` shared the 64-entry limit
+    of ``_VSCODE_LOG_CACHE``.  With a separate 256-entry limit, all
+    unchanged files should hit the per-file summary cache on the second
+    call and ``parse_vscode_log`` should only be invoked for the one
+    changed file.
+    """
+
+    def test_only_changed_file_reparsed(self, tmp_path: Path) -> None:
+        """With 70+ files, only the changed file triggers parse_vscode_log."""
+        num_files = 75
+
+        # Create 75 log files inside a VS Code log directory layout.
+        log_files: list[Path] = []
+        for i in range(num_files):
+            log_dir = (
+                tmp_path
+                / f"session{i:04d}"
+                / "window1"
+                / "exthost"
+                / "GitHub.copilot-chat"
+            )
+            log_dir.mkdir(parents=True)
+            log_file = log_dir / "GitHub Copilot Chat.log"
+            log_file.write_text(_make_log_line(req_idx=i))
+            log_files.append(log_file)
+
+        # First call: populate caches.  parse_vscode_log called once per file.
+        with patch(
+            "copilot_usage.vscode_parser.parse_vscode_log",
+            wraps=parse_vscode_log,
+        ) as spy:
+            s1 = get_vscode_summary(tmp_path)
+            assert s1.total_requests == num_files
+            assert spy.call_count == num_files
+
+        # Modify exactly one file so its safe_file_identity changes.
+        changed = log_files[0]
+        changed.write_text(
+            _make_log_line(req_idx=0) + "\n" + _make_log_line(req_idx=9999)
+        )
+
+        # Second call: only the changed file should be re-parsed.
+        with patch(
+            "copilot_usage.vscode_parser.parse_vscode_log",
+            wraps=parse_vscode_log,
+        ) as spy:
+            s2 = get_vscode_summary(tmp_path)
+            assert spy.call_count == 1
+            assert spy.call_args is not None
+            assert spy.call_args[0][0] == changed
+        # The changed file now contributes 2 requests.
+        assert s2.total_requests == num_files + 1
 
 
 # ---------------------------------------------------------------------------

--- a/tests/copilot_usage/test_vscode_parser.py
+++ b/tests/copilot_usage/test_vscode_parser.py
@@ -1791,25 +1791,28 @@ class TestPerFileSummaryCacheLRUEviction:
 
 
 # ---------------------------------------------------------------------------
-# Per-file summary cache survives beyond old shared 64-entry limit
+# Per-file summary cache survives beyond the request-cache limit
 # ---------------------------------------------------------------------------
 
 
-class TestPerFileSummaryCacheSurvivesBeyond64:
-    """Verify that per-file summaries for 70+ files survive across calls.
+class TestPerFileSummaryCacheSurvivesBeyondRequestCacheLimit:
+    """Verify that per-file summaries survive when file count exceeds
+    ``_MAX_CACHED_VSCODE_REQUESTS``.
 
-    Before the fix, ``_PER_FILE_SUMMARY_CACHE`` shared the 64-entry limit
-    of ``_VSCODE_LOG_CACHE``.  With a separate 256-entry limit, all
+    Before the fix, ``_PER_FILE_SUMMARY_CACHE`` shared the request-cache
+    limit of ``_VSCODE_LOG_CACHE``.  With a separate, larger limit, all
     unchanged files should hit the per-file summary cache on the second
     call and ``parse_vscode_log`` should only be invoked for the one
     changed file.
     """
 
     def test_only_changed_file_reparsed(self, tmp_path: Path) -> None:
-        """With 70+ files, only the changed file triggers parse_vscode_log."""
-        num_files = 75
+        """With more files than _MAX_CACHED_VSCODE_REQUESTS, only the
+        changed file triggers parse_vscode_log.
+        """
+        num_files = _MAX_CACHED_VSCODE_REQUESTS + 11
+        assert num_files < _MAX_CACHED_FILE_SUMMARIES
 
-        # Create 75 log files inside a VS Code log directory layout.
         log_files: list[Path] = []
         for i in range(num_files):
             log_dir = (


### PR DESCRIPTION
Closes #961

## Problem

`_PER_FILE_SUMMARY_CACHE` and `_VSCODE_LOG_CACHE` shared a single 64-entry limit (`_MAX_CACHED_VSCODE_LOGS`). Per-file summaries are tiny (~hundreds of bytes) while raw request tuples are large. For users with 65+ VS Code log files, the shared limit caused cache thrashing: on every summary invalidation, files beyond position 64 had their per-file summaries evicted and had to be re-aggregated from disk.

## Changes

- **Renamed** `_MAX_CACHED_VSCODE_LOGS` → `_MAX_CACHED_VSCODE_REQUESTS` (64) for the raw request cache
- **Added** `_MAX_CACHED_FILE_SUMMARIES` (256) for the per-file summary cache
- **Updated** both `lru_insert` call sites to use their respective constants
- **Updated** tests and documentation references

## Testing

Added `TestPerFileSummaryCacheSurvivesBeyond64` which:
1. Creates 75 mock log files
2. Calls `get_vscode_summary` once to populate caches
3. Modifies one file (changes its `safe_file_identity`)
4. Calls `get_vscode_summary` a second time
5. Asserts `parse_vscode_log` was called exactly once (only for the changed file)

All checks pass: `make check` ✅ (lint, typecheck, security, 99% coverage)




> Generated by [Issue Implementer](https://github.com/microsasa/cli-tools/actions/runs/24579851999/agentic_workflow) · ● 6.7M · [◷](https://github.com/search?q=repo%3Amicrosasa%2Fcli-tools+%22gh-aw-workflow-id%3A+issue-implementer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Issue Implementer, engine: copilot, model: claude-opus-4.6, id: 24579851999, workflow_id: issue-implementer, run: https://github.com/microsasa/cli-tools/actions/runs/24579851999 -->

<!-- gh-aw-workflow-id: issue-implementer -->