### PR TITLE
perf(parser): add frozenset pre-filter to `_detect_resume` (#967)

### DIFF
--- a/src/copilot_usage/parser.py
+++ b/src/copilot_usage/parser.py
@@ -743,6 +743,16 @@ def _first_pass(events: list[SessionEvent]) -> _FirstPassResult:
     )
 
 
+_DETECT_RESUME_EVENT_TYPES: Final[frozenset[str]] = frozenset(
+    {
+        EventType.ASSISTANT_MESSAGE,
+        EventType.USER_MESSAGE,
+        EventType.ASSISTANT_TURN_START,
+        EventType.SESSION_RESUME,
+    }
+)
+
+
 def _detect_resume(
     events: list[SessionEvent],
     all_shutdowns: tuple[tuple[int, SessionShutdownData], ...],
@@ -767,6 +777,8 @@ def _detect_resume(
     for i in range(last_shutdown_idx + 1, len(events)):
         ev = events[i]
         etype = ev.type
+        if etype not in _DETECT_RESUME_EVENT_TYPES:
+            continue
         if etype == EventType.ASSISTANT_MESSAGE:
             session_resumed = True
             if (tokens := _extract_output_tokens(ev)) is not None:

--- a/tests/copilot_usage/test_parser.py
+++ b/tests/copilot_usage/test_parser.py
@@ -8493,7 +8493,8 @@ class TestDetectResumeElifShortCircuit:
     5 comparisons per interesting event (1 for the ``in`` membership test plus
     up to 4 for the elif branches) and exactly 2 for the most common
     ``ASSISTANT_MESSAGE`` case (1 membership + 1 branch match).  Uninteresting
-    events are skipped via an O(1) hash lookup with no ``__eq__`` calls.
+    events are skipped via an O(1) hash lookup with no additional branch
+    comparisons (``__eq__`` is only invoked on rare hash collisions).
     """
 
     def test_comparison_count_500_assistant_messages(self, tmp_path: Path) -> None:
@@ -8501,9 +8502,9 @@ class TestDetectResumeElifShortCircuit:
 
         Uses a spy wrapper around ``ev.type`` access to count the total number
         of equality comparisons performed inside the _detect_resume loop.
-        With the frozenset pre-filter, each interesting event costs at most 2
-        __eq__ calls: one for the ``in`` membership test and one for the
-        if/elif branch match.
+        With the frozenset pre-filter, each interesting event typically costs 2
+        ``__eq__`` calls: one for the ``in`` membership test and one for the
+        if/elif branch match (rare hash collisions may add a few more).
         """
         # Build a minimal session: start → user → shutdown → 500 assistant msgs
         start_raw = json.dumps(

--- a/tests/copilot_usage/test_parser.py
+++ b/tests/copilot_usage/test_parser.py
@@ -37,6 +37,7 @@ from copilot_usage.models import (
     UserMessageData,
 )
 from copilot_usage.parser import (
+    _DETECT_RESUME_EVENT_TYPES,
     _DISCOVERY_CACHE,
     _EVENTS_CACHE,
     _FIRST_PASS_EVENT_TYPES,
@@ -8493,10 +8494,13 @@ class TestDetectResumeElifShortCircuit:
     """
 
     def test_comparison_count_500_assistant_messages(self, tmp_path: Path) -> None:
-        """500 post-shutdown ASSISTANT_MESSAGE events → ≤ 500 type comparisons.
+        """500 post-shutdown ASSISTANT_MESSAGE events → ≤ 1000 type comparisons.
 
         Uses a spy wrapper around ``ev.type`` access to count the total number
         of equality comparisons performed inside the _detect_resume loop.
+        With the frozenset pre-filter, each interesting event costs at most 2
+        __eq__ calls: one for the ``in`` membership test and one for the
+        if/elif branch match.
         """
         # Build a minimal session: start → user → shutdown → 500 assistant msgs
         start_raw = json.dumps(
@@ -8590,13 +8594,13 @@ class TestDetectResumeElifShortCircuit:
         assert result.post_shutdown_turn_starts == 0
         assert result.post_shutdown_user_messages == 0
 
-        # Performance: with an elif chain, ASSISTANT_MESSAGE is the first
-        # branch so each event needs exactly 1 comparison → 500 total.
-        # Allow a small margin for any non-assistant events (there are none
-        # here, but be robust).
-        assert eq_count <= 500, (
-            f"Expected ≤ 500 ev.type comparisons for 500 ASSISTANT_MESSAGE "
-            f"events with if/elif chain, got {eq_count}"
+        # Performance: with the frozenset pre-filter and elif chain,
+        # ASSISTANT_MESSAGE events cost at most 2 __eq__ calls each
+        # (1 for frozenset membership + 1 for the first elif branch).
+        # 500 events × 2 = 1000 maximum.
+        assert eq_count <= 1000, (
+            f"Expected ≤ 1000 ev.type comparisons for 500 ASSISTANT_MESSAGE "
+            f"events with frozenset pre-filter + if/elif chain, got {eq_count}"
         )
 
     def test_correctness_mixed_post_shutdown_events(self, tmp_path: Path) -> None:
@@ -9299,3 +9303,98 @@ class TestSortedSessionsCacheIsFrozen:
         )
         with pytest.raises(dataclasses.FrozenInstanceError):
             cache.root = Path("/other")  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# Issue #967 — _detect_resume: frozenset pre-filter for uninteresting events
+# ---------------------------------------------------------------------------
+
+
+class TestDetectResumeFrozensetPreFilter:
+    """Verify the _DETECT_RESUME_EVENT_TYPES frozenset pre-filter.
+
+    The frozenset guard skips events whose type is not one of the four
+    checked inside the if/elif chain, replacing 4 string comparisons
+    with a single O(1) hash lookup for each uninteresting event.
+    """
+
+    def test_many_tool_events_skipped_correctly(self, tmp_path: Path) -> None:
+        """≥100 tool events after shutdown are skipped; resume info is correct.
+
+        Builds a synthetic event list with a session.shutdown at index K
+        followed by ≥100 tool.execution_complete events, a user.message,
+        and a session.resume.  Asserts the returned _ResumeInfo has
+        session_resumed=True, post_shutdown_user_messages=1, and a
+        non-None last_resume_time.
+        """
+        num_tool_events = 120
+
+        tool_events = [
+            json.dumps(
+                {
+                    "type": "tool.execution_complete",
+                    "data": {
+                        "toolCallId": f"tc-{i}",
+                        "model": "claude-sonnet-4",
+                        "interactionId": "int-1",
+                        "success": True,
+                    },
+                    "id": f"ev-tool-{i}",
+                    "timestamp": "2026-03-07T11:01:00.000Z",
+                }
+            )
+            for i in range(num_tool_events)
+        ]
+
+        post_user = json.dumps(
+            {
+                "type": "user.message",
+                "data": {
+                    "content": "continue",
+                    "transformedContent": "continue",
+                    "attachments": [],
+                    "interactionId": "int-2",
+                },
+                "id": "ev-user-post",
+                "timestamp": "2026-03-07T12:00:30.000Z",
+            }
+        )
+        resume_ev = json.dumps(
+            {
+                "type": "session.resume",
+                "data": {},
+                "id": "ev-resume-967",
+                "timestamp": "2026-03-07T12:00:00.000Z",
+            }
+        )
+
+        p = tmp_path / "s" / "events.jsonl"
+        _write_events(
+            p,
+            _START_EVENT,
+            _USER_MSG,
+            _SHUTDOWN_EVENT,
+            *tool_events,
+            post_user,
+            resume_ev,
+        )
+        events = parse_events(p)
+        fp = _first_pass(events)
+        result = _detect_resume(events, fp.all_shutdowns)
+
+        assert result.session_resumed is True
+        assert result.post_shutdown_user_messages == 1
+        assert result.last_resume_time is not None
+        assert result.last_resume_time == datetime(2026, 3, 7, 12, 0, tzinfo=UTC)
+
+    def test_constant_contains_exactly_four_types(self) -> None:
+        """_DETECT_RESUME_EVENT_TYPES must contain exactly the 4 checked types."""
+        expected = frozenset(
+            {
+                EventType.ASSISTANT_MESSAGE,
+                EventType.USER_MESSAGE,
+                EventType.ASSISTANT_TURN_START,
+                EventType.SESSION_RESUME,
+            }
+        )
+        assert expected == _DETECT_RESUME_EVENT_TYPES

--- a/tests/copilot_usage/test_parser.py
+++ b/tests/copilot_usage/test_parser.py
@@ -9349,6 +9349,14 @@ class TestDetectResumeFrozensetPreFilter:
             for i in range(num_tool_events)
         ]
 
+        resume_ev = json.dumps(
+            {
+                "type": "session.resume",
+                "data": {},
+                "id": "ev-resume-967",
+                "timestamp": "2026-03-07T12:00:00.000Z",
+            }
+        )
         post_user = json.dumps(
             {
                 "type": "user.message",
@@ -9362,14 +9370,6 @@ class TestDetectResumeFrozensetPreFilter:
                 "timestamp": "2026-03-07T12:00:30.000Z",
             }
         )
-        resume_ev = json.dumps(
-            {
-                "type": "session.resume",
-                "data": {},
-                "id": "ev-resume-967",
-                "timestamp": "2026-03-07T12:00:00.000Z",
-            }
-        )
 
         p = tmp_path / "s" / "events.jsonl"
         _write_events(
@@ -9378,8 +9378,8 @@ class TestDetectResumeFrozensetPreFilter:
             _USER_MSG,
             _SHUTDOWN_EVENT,
             *tool_events,
-            post_user,
             resume_ev,
+            post_user,
         )
         events = parse_events(p)
         fp = _first_pass(events)

--- a/tests/copilot_usage/test_parser.py
+++ b/tests/copilot_usage/test_parser.py
@@ -8489,8 +8489,11 @@ class TestDetectResumeElifShortCircuit:
     """Verify _detect_resume uses a short-circuiting if/elif chain.
 
     With the old implementation, every event triggered 5 unconditional ``if``
-    checks.  The new ``if/elif`` chain should evaluate at most 4 comparisons
-    per event and exactly 1 for the most common ``ASSISTANT_MESSAGE`` case.
+    checks.  The ``if/elif`` chain with frozenset pre-filter evaluates at most
+    5 comparisons per interesting event (1 for the ``in`` membership test plus
+    up to 4 for the elif branches) and exactly 2 for the most common
+    ``ASSISTANT_MESSAGE`` case (1 membership + 1 branch match).  Uninteresting
+    events are skipped via an O(1) hash lookup with no ``__eq__`` calls.
     """
 
     def test_comparison_count_500_assistant_messages(self, tmp_path: Path) -> None:


### PR DESCRIPTION
Closes #967

## Changes

**`src/copilot_usage/parser.py`**
- Added `_DETECT_RESUME_EVENT_TYPES` module-level `Final[frozenset[str]]` constant containing the 4 event types checked in `_detect_resume`: `ASSISTANT_MESSAGE`, `USER_MESSAGE`, `ASSISTANT_TURN_START`, `SESSION_RESUME`.
- Added an early-continue guard (`if etype not in _DETECT_RESUME_EVENT_TYPES: continue`) at the top of the hot loop, mirroring the existing `_FIRST_PASS_EVENT_TYPES` pattern in `_first_pass`.

**`tests/copilot_usage/test_parser.py`**
- Added `TestDetectResumeFrozensetPreFilter` with two tests:
  - `test_many_tool_events_skipped_correctly`: builds 120 `tool.execution_complete` events after shutdown + a `user.message` + `session.resume`, asserts correct `_ResumeInfo` (`session_resumed=True`, `post_shutdown_user_messages=1`, non-None `last_resume_time`).
  - `test_constant_contains_exactly_four_types`: asserts `_DETECT_RESUME_EVENT_TYPES` matches the expected frozenset.
- Updated `TestDetectResumeElifShortCircuit.test_comparison_count_500_assistant_messages` assertion from ≤500 to ≤1000 to account for the additional `__eq__` call from the frozenset membership check (1 for `in` + 1 for `if/elif` = 2 per event).

## Performance Impact

For resumed sessions with N post-shutdown tool calls, iteration cost drops from **4N** string comparisons to **N** O(1) hash lookups for uninteresting events. A cold load of 200 sessions each with 200 post-shutdown tool calls reduces wasted comparisons from ~160,000 to ~40,000 hash lookups.




> Generated by [Issue Implementer](https://github.com/microsasa/cli-tools/actions/runs/24586740400/agentic_workflow) · ● 10.2M · [◷](https://github.com/search?q=repo%3Amicrosasa%2Fcli-tools+%22gh-aw-workflow-id%3A+issue-implementer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Issue Implementer, engine: copilot, model: claude-opus-4.6, id: 24586740400, workflow_id: issue-implementer, run: https://github.com/microsasa/cli-tools/actions/runs/24586740400 -->

<!-- gh-aw-workflow-id: issue-implementer -->