### PR TITLE
fix: perf batch — model inference bug + 5 perf improvements

### DIFF
--- a/src/copilot_usage/parser.py
+++ b/src/copilot_usage/parser.py
@@ -1052,6 +1052,7 @@ def get_all_sessions(base_path: Path | None = None) -> list[SessionSummary]:
     deferred_events: list[tuple[Path, tuple[int, int] | None, list[SessionEvent]]] = []
     deferred_sessions: list[tuple[Path, _CachedSession]] = []
     cache_hit_paths: list[Path] = []
+    any_events_changed = False
     for events_path, file_id, plan_id in discovered:
         cached = _SESSION_CACHE.get(events_path)
         # Config changes only invalidate cached entries that declared a
@@ -1084,6 +1085,7 @@ def get_all_sessions(base_path: Path | None = None) -> list[SessionSummary]:
                 cache_hit_paths.append(events_path)
             summaries.append(summary)
             continue
+        any_events_changed = True
         try:
             events = parse_events(events_path)
         except OSError as exc:
@@ -1173,6 +1175,29 @@ def get_all_sessions(base_path: Path | None = None) -> list[SessionSummary]:
         and _sorted_sessions_cache.root == resolved_root
     ):
         return list(_sorted_sessions_cache.summaries)
+
+    # Plan-only fast path: discovery cache hit, no events.jsonl changed,
+    # only plan.md names differ.  Sort key is start_time (from events),
+    # so the existing sorted order is still valid — just substitute the
+    # updated summaries by events_path.
+    if (
+        is_cache_hit
+        and not any_events_changed
+        and len(summaries) == len(discovered)
+        and _sorted_sessions_cache is not None
+        and _sorted_sessions_cache.root == resolved_root
+    ):
+        updated: dict[Path, SessionSummary] = {
+            ep: entry.summary for ep, entry in deferred_sessions
+        }
+        new_sorted: list[SessionSummary] = [
+            updated.get(s.events_path, s) if s.events_path is not None else s
+            for s in _sorted_sessions_cache.summaries
+        ]
+        _sorted_sessions_cache = _SortedSessionsCache(
+            resolved_root, _sorted_sessions_cache.fingerprint, new_sorted
+        )
+        return new_sorted
 
     # Fingerprint fallback: when the discovery cache missed but the
     # discovered session set is identical, skip the O(n log n) sort.

--- a/src/copilot_usage/parser.py
+++ b/src/copilot_usage/parser.py
@@ -713,8 +713,6 @@ def _first_pass(events: list[SessionEvent]) -> _FirstPassResult:
                 )
                 continue
             current_model = ev.currentModel or data.currentModel
-            if not current_model and data.modelMetrics:
-                current_model = _infer_model_from_metrics(data.modelMetrics)
             _shutdowns.append((idx, data))
             end_time = ev.timestamp
             model = current_model
@@ -850,7 +848,7 @@ def _build_completed_summary(
         end_time=None if resume.session_resumed else fp.end_time,
         name=name,
         cwd=fp.cwd,
-        model=fp.model,
+        model=fp.model or _infer_model_from_metrics(merged_metrics),
         total_premium_requests=total_premium,
         total_api_duration_ms=total_api_duration,
         model_metrics=merged_metrics,

--- a/src/copilot_usage/render_detail.py
+++ b/src/copilot_usage/render_detail.py
@@ -240,8 +240,11 @@ def _render_shutdown_cycles(
 
     for ts, sd in summary.shutdown_cycles:
         date_str = ts.strftime("%Y-%m-%d %H:%M") if ts else "—"
-        total_requests = sum(mm.requests.count for mm in sd.modelMetrics.values())
-        total_output = sum(mm.usage.outputTokens for mm in sd.modelMetrics.values())
+        total_requests = 0
+        total_output = 0
+        for mm in sd.modelMetrics.values():
+            total_requests += mm.requests.count
+            total_output += mm.usage.outputTokens
         table.add_row(
             date_str,
             str(sd.totalPremiumRequests),

--- a/src/copilot_usage/vscode_parser.py
+++ b/src/copilot_usage/vscode_parser.py
@@ -576,16 +576,17 @@ def _merge_partial(acc: _SummaryAccumulator, partial: VSCodeLogSummary) -> None:
 def _finalize_summary(acc: _SummaryAccumulator) -> VSCodeLogSummary:
     """Convert a mutable accumulator into a frozen ``VSCodeLogSummary``.
 
-    Plain ``dict`` values are passed to the constructor;
-    ``VSCodeLogSummary.__post_init__`` wraps them in ``MappingProxyType``.
+    Accumulator ``defaultdict`` fields are passed directly;
+    ``VSCodeLogSummary.__post_init__`` copies them once into
+    ``MappingProxyType`` wrappers.
     """
     return VSCodeLogSummary(
         total_requests=acc.total_requests,
         total_duration_ms=acc.total_duration_ms,
-        requests_by_model=dict(acc.requests_by_model),
-        duration_by_model=dict(acc.duration_by_model),
-        requests_by_category=dict(acc.requests_by_category),
-        requests_by_date=dict(acc.requests_by_date),
+        requests_by_model=acc.requests_by_model,
+        duration_by_model=acc.duration_by_model,
+        requests_by_category=acc.requests_by_category,
+        requests_by_date=acc.requests_by_date,
         first_timestamp=acc.first_timestamp,
         last_timestamp=acc.last_timestamp,
         log_files_parsed=acc.log_files_parsed,

--- a/src/copilot_usage/vscode_parser.py
+++ b/src/copilot_usage/vscode_parser.py
@@ -495,13 +495,17 @@ def _update_vscode_summary(
     dbm = acc.duration_by_model
     rbc = acc.requests_by_category
     rbd = acc.requests_by_date
+    total_req = acc.total_requests
+    total_dur = acc.total_duration_ms
+    first_ts = acc.first_timestamp
+    last_ts = acc.last_timestamp
     last_date_key: str = ""
     last_date_val: date | None = None
 
     for req in requests:
-        acc.total_requests += 1
+        total_req += 1
         dur = req.duration_ms
-        acc.total_duration_ms += dur
+        total_dur += dur
 
         model = req.model
         rbm[model] += 1
@@ -517,12 +521,15 @@ def _update_vscode_summary(
 
         # Timestamp bounds: full min/max scan so callers (especially
         # build_vscode_summary) need not pre-sort their input.
-        first = acc.first_timestamp
-        if first is None or ts < first:
-            acc.first_timestamp = ts
-        last_ts = acc.last_timestamp
+        if first_ts is None or ts < first_ts:
+            first_ts = ts
         if last_ts is None or ts > last_ts:
-            acc.last_timestamp = ts
+            last_ts = ts
+
+    acc.total_requests = total_req
+    acc.total_duration_ms = total_dur
+    acc.first_timestamp = first_ts
+    acc.last_timestamp = last_ts
 
 
 def _merge_partial(acc: _SummaryAccumulator, partial: VSCodeLogSummary) -> None:

--- a/src/copilot_usage/vscode_parser.py
+++ b/src/copilot_usage/vscode_parser.py
@@ -211,29 +211,12 @@ def discover_vscode_logs(base_path: Path | None = None) -> list[Path]:
 
     If only one variant exists on disk the behaviour is identical to before.
     When both exist, files from both are returned and sorted together.
-    """
-    if base_path is not None:
-        if not base_path.is_dir():
-            logger.debug("VS Code logs directory not found: {}", base_path)
-            return []
-        logs = sorted(base_path.glob(_GLOB_PATTERN))
-        logger.debug("Discovered {} VS Code log file(s) under {}", len(logs), base_path)
-        return logs
 
-    candidates = _default_log_candidates()
-    all_logs: list[Path] = []
-    for candidate in candidates:
-        if not candidate.is_dir():
-            logger.debug("VS Code logs directory not found: {}", candidate)
-            continue
-        all_logs.extend(candidate.glob(_GLOB_PATTERN))
-    all_logs.sort()
-    logger.debug(
-        "Discovered {} VS Code log file(s) across {} candidate(s)",
-        len(all_logs),
-        len(candidates),
-    )
-    return all_logs
+    Results are cached per candidate root directory.  Steady-state cost is
+    O(1) — two ``stat`` calls per root (root + newest child sentinel) —
+    instead of a full multi-level glob traversal.
+    """
+    return _cached_discover_vscode_logs(base_path)
 
 
 def _newest_child_from_ids(

--- a/tests/copilot_usage/test_parser.py
+++ b/tests/copilot_usage/test_parser.py
@@ -2476,6 +2476,128 @@ class TestBuildSessionSummaryMultiShutdownResumed:
 
 
 # ---------------------------------------------------------------------------
+# build_session_summary — multi-shutdown model inference from merged metrics
+# ---------------------------------------------------------------------------
+
+
+class TestMultiShutdownModelInference:
+    """When shutdown cycles report different models, the session-level model
+    should be the dominant one across all cycles (highest requests.count in
+    merged metrics), not just whichever shutdown happened last."""
+
+    def test_dominant_model_wins_over_last_shutdown(self, tmp_path: Path) -> None:
+        shutdown_gpt = json.dumps(
+            {
+                "type": "session.shutdown",
+                "data": {
+                    "shutdownType": "routine",
+                    "totalPremiumRequests": 5,
+                    "totalApiDurationMs": 8000,
+                    "sessionStartTime": 0,
+                    "modelMetrics": {
+                        "gpt-4o": {
+                            "requests": {"count": 20, "cost": 10},
+                            "usage": {
+                                "inputTokens": 5000,
+                                "outputTokens": 500,
+                                "cacheReadTokens": 0,
+                                "cacheWriteTokens": 0,
+                            },
+                        }
+                    },
+                },
+                "id": "ev-sd-gpt",
+                "timestamp": "2026-03-07T09:00:00.000Z",
+            }
+        )
+        shutdown_sonnet = json.dumps(
+            {
+                "type": "session.shutdown",
+                "data": {
+                    "shutdownType": "routine",
+                    "totalPremiumRequests": 3,
+                    "totalApiDurationMs": 4000,
+                    "sessionStartTime": 0,
+                    "modelMetrics": {
+                        "claude-sonnet-4": {
+                            "requests": {"count": 5, "cost": 3},
+                            "usage": {
+                                "inputTokens": 2000,
+                                "outputTokens": 200,
+                                "cacheReadTokens": 0,
+                                "cacheWriteTokens": 0,
+                            },
+                        }
+                    },
+                },
+                "id": "ev-sd-sonnet",
+                "timestamp": "2026-03-07T10:00:00.000Z",
+            }
+        )
+        p = tmp_path / "s" / "events.jsonl"
+        _write_events(
+            p,
+            _START_EVENT,
+            _USER_MSG,
+            _ASSISTANT_MSG,
+            shutdown_gpt,
+            _RESUME_EVENT,
+            _POST_RESUME_USER_MSG,
+            _POST_RESUME_ASSISTANT_MSG,
+            shutdown_sonnet,
+        )
+        events = parse_events(p)
+        summary = build_session_summary(events)
+        # gpt-4o had 20 requests vs claude-sonnet-4's 5 — gpt-4o is dominant
+        assert summary.model == "gpt-4o"
+        # Both models present in merged metrics
+        assert "gpt-4o" in summary.model_metrics
+        assert "claude-sonnet-4" in summary.model_metrics
+
+    def test_explicit_current_model_takes_priority(self, tmp_path: Path) -> None:
+        """When a shutdown event has an explicit currentModel, it should take
+        priority over inference from merged metrics."""
+        shutdown_with_model = json.dumps(
+            {
+                "type": "session.shutdown",
+                "data": {
+                    "shutdownType": "routine",
+                    "totalPremiumRequests": 2,
+                    "totalApiDurationMs": 3000,
+                    "sessionStartTime": 0,
+                    "modelMetrics": {
+                        "gpt-4o": {
+                            "requests": {"count": 50, "cost": 25},
+                            "usage": {
+                                "inputTokens": 10000,
+                                "outputTokens": 1000,
+                                "cacheReadTokens": 0,
+                                "cacheWriteTokens": 0,
+                            },
+                        }
+                    },
+                    "currentModel": "claude-sonnet-4",
+                },
+                "id": "ev-sd-explicit",
+                "timestamp": "2026-03-07T09:00:00.000Z",
+                "currentModel": "claude-sonnet-4",
+            }
+        )
+        p = tmp_path / "s" / "events.jsonl"
+        _write_events(
+            p,
+            _START_EVENT,
+            _USER_MSG,
+            _ASSISTANT_MSG,
+            shutdown_with_model,
+        )
+        events = parse_events(p)
+        summary = build_session_summary(events)
+        # Explicit currentModel wins even though gpt-4o has more requests
+        assert summary.model == "claude-sonnet-4"
+
+
+# ---------------------------------------------------------------------------
 # build_session_summary — multi-shutdown code_changes preservation
 # ---------------------------------------------------------------------------
 

--- a/tests/copilot_usage/test_parser.py
+++ b/tests/copilot_usage/test_parser.py
@@ -9134,9 +9134,9 @@ class TestSortedSessionsCacheSkipsRedundantSort:
         with patch.object(_parser_module, "session_sort_key", tracking_key):
             result = get_all_sessions(tmp_path)
 
-        assert len(sort_key_calls) > 0, (
-            "session_sort_key must be called when plan.md changes "
-            "(deferred_sessions is non-empty)"
+        assert len(sort_key_calls) == 0, (
+            "session_sort_key must NOT be called when only plan.md changes "
+            "(sort key is start_time from events, unaffected by plan.md)"
         )
 
         # The session with the new plan.md should carry the extracted name.

--- a/tests/copilot_usage/test_vscode_parser.py
+++ b/tests/copilot_usage/test_vscode_parser.py
@@ -342,7 +342,9 @@ class TestDiscoverVscodeLogs:
     def test_default_windows(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setattr("copilot_usage.vscode_parser.sys.platform", "win32")
         monkeypatch.setenv("APPDATA", r"C:\Users\test\AppData\Roaming")
-        with patch.object(Path, "is_dir", return_value=False):
+        with patch.object(
+            Path, "stat", autospec=True, side_effect=OSError("not found")
+        ):
             result = discover_vscode_logs()
         assert result == []
 
@@ -351,25 +353,27 @@ class TestDiscoverVscodeLogs:
         monkeypatch.setattr("copilot_usage.vscode_parser.sys.platform", "win32")
         monkeypatch.setenv("APPDATA", "")  # empty → falsy
         with patch.object(
-            Path, "is_dir", autospec=True, return_value=False
-        ) as mock_is_dir:
+            Path, "stat", autospec=True, side_effect=OSError("not found")
+        ) as mock_stat:
             result = discover_vscode_logs()
-        mock_is_dir.assert_any_call(
-            Path.home() / "AppData" / "Roaming" / "Code" / "logs"
-        )
+        mock_stat.assert_any_call(Path.home() / "AppData" / "Roaming" / "Code" / "logs")
         assert result == []
 
     def test_default_macos(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setattr("copilot_usage.vscode_parser.sys.platform", "darwin")
         monkeypatch.delenv("APPDATA", raising=False)
-        with patch.object(Path, "is_dir", return_value=False):
+        with patch.object(
+            Path, "stat", autospec=True, side_effect=OSError("not found")
+        ):
             result = discover_vscode_logs()
         assert result == []
 
     def test_default_linux(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setattr("copilot_usage.vscode_parser.sys.platform", "linux")
         monkeypatch.delenv("APPDATA", raising=False)
-        with patch.object(Path, "is_dir", return_value=False):
+        with patch.object(
+            Path, "stat", autospec=True, side_effect=OSError("not found")
+        ):
             result = discover_vscode_logs()
         assert result == []
 
@@ -1489,6 +1493,43 @@ class TestVscodeSummaryCacheSkipsReaggregation:
             assert spy.call_count == 1  # re-aggregated because file changed
 
         assert s2.total_requests == 2
+
+    def test_appended_file_detected_without_discovery_change(
+        self, tmp_path: Path
+    ) -> None:
+        """Appending to a log file is detected even when discovery is cached.
+
+        Regression guard for #898: the stat-before-cache-check pattern in
+        get_vscode_summary is what detects file modifications.  If someone
+        removed those stats to "optimise" the cache-hit path, this test
+        would fail because the summary would show stale data (1 request
+        instead of 2) despite the file having grown.
+        """
+        log_dir = (
+            tmp_path / "20260313T211400" / "window1" / "exthost" / "GitHub.copilot-chat"
+        )
+        log_dir.mkdir(parents=True)
+        log_file = log_dir / "GitHub Copilot Chat.log"
+        log_file.write_text(_make_log_line(req_idx=0))
+
+        s1 = get_vscode_summary(tmp_path)
+        assert s1.total_requests == 1
+
+        # Call again — discovery cache is now warm and unchanged.
+        s1b = get_vscode_summary(tmp_path)
+        assert s1b is s1  # exact same cached object
+
+        # Append to the file (no new files, no directory changes).
+        with log_file.open("a") as f:
+            f.write("\n" + _make_log_line(req_idx=1))
+
+        # Discovery cache is still valid (same root mtime, same sentinel),
+        # but the file-level stat detects the size/mtime change.
+        s2 = get_vscode_summary(tmp_path)
+        assert s2.total_requests == 2, (
+            "Appended request not detected — stat-before-cache-check may "
+            "have been removed (see #898)"
+        )
 
     def test_cache_invalidated_on_new_file(self, tmp_path: Path) -> None:
         """Adding a new log file invalidates the summary cache."""


### PR DESCRIPTION
## Summary

Fixes a correctness bug in model inference for multi-shutdown sessions, plus five performance improvements identified by the perf-analysis agent.

## Changes

### Bug fix
- **#931** — `_first_pass` inferred session model from the last shutdown's metrics ("last wins"), which gave wrong model for display AND pricing when a session spanned multiple models across resume cycles. Now defers to `_build_completed_summary` where merged metrics across all cycles are available. Explicit `currentModel` still takes priority.

### Performance
- **#903** — Merged two separate `sum()` passes over `sd.modelMetrics.values()` into a single loop in `_render_shutdown_cycles`.
- **#904** — Removed redundant `dict()` copies in `_finalize_summary` — was creating dicts from defaultdicts then `__post_init__` immediately called `dict()` again. Now passes defaultdicts directly.
- **#906** — Made public `discover_vscode_logs` delegate to `_cached_discover_vscode_logs` instead of running an uncached glob on every call. Updated all 4 platform tests to mock `stat()` instead of `is_dir()`.
- **#911** — Added plan-only fast path in `get_all_sessions`: when only `plan.md` changed (no `events.jsonl` modifications), substitutes updated names into existing sorted order instead of rebuilding the O(n) fingerprint and O(n log n) sort.
- **#912** — Hoisted `total_requests`, `total_duration_ms`, `first_timestamp`, `last_timestamp` to locals before the per-request loop in `_update_vscode_summary`, matching the pattern already used for dict fields.

### Won't-fix (closed with explanation)
- **#898** — `get_vscode_summary` stats every log file before checking cache. Benchmarked at 0.1–0.2ms for typical file counts. Skipping stats would risk serving stale data when files are modified — freshness over sub-millisecond savings. Added regression test to guard this.

## Testing
- `make check` passes: lint ✅, types ✅, security ✅, 99% coverage ✅, 86 e2e ✅
- New tests for #931: `test_dominant_model_wins_over_last_shutdown`, `test_explicit_current_model_takes_priority`
- New test for #898 freshness: `test_appended_file_detected_without_discovery_change`
- Updated test for #911: `test_sort_runs_after_plan_change` (asserts sort is now skipped)
- Updated 4 platform tests for #906: mock `stat()` instead of `is_dir()`

## Review
Reviewed by three adversarial agents (Codex, Opus 4.6, Sonnet 4.6). Sonnet found 3 stale `is_dir` test mocks — fixed and squashed into #906.

Closes #931
Closes #903
Closes #904
Closes #906
Closes #911
Closes #912