### PR TITLE
Add `Final` annotations to module-level cache containers (#970)

### DIFF
--- a/src/copilot_usage/parser.py
+++ b/src/copilot_usage/parser.py
@@ -77,7 +77,7 @@ class _DiscoveryCache:
 # Module-level discovery cache: root_path → _DiscoveryCache.
 # Avoids redundant inner os.scandir calls when the root directory
 # has not changed (no sessions added or removed).
-_DISCOVERY_CACHE: dict[Path, _DiscoveryCache] = {}
+_DISCOVERY_CACHE: Final[dict[Path, _DiscoveryCache]] = {}
 
 # On cache hits, probe at most this many sessions without a cached
 # plan.md for a newly-created file.  The probe window rotates via
@@ -117,7 +117,7 @@ class _CachedSession:
 # Uses OrderedDict for LRU eviction: most-recently-used entries are at
 # the back, least-recently-used at the front.
 _MAX_CACHED_SESSIONS: Final[int] = 512
-_SESSION_CACHE: OrderedDict[Path, _CachedSession] = OrderedDict()
+_SESSION_CACHE: Final[OrderedDict[Path, _CachedSession]] = OrderedDict()
 
 
 def _insert_session_entry(
@@ -141,7 +141,7 @@ class _CachedEvents:
 # Uses OrderedDict for LRU eviction: most-recently-used entries are at
 # the back, least-recently-used at the front.
 _MAX_CACHED_EVENTS: Final[int] = 32
-_EVENTS_CACHE: OrderedDict[Path, _CachedEvents] = OrderedDict()
+_EVENTS_CACHE: Final[OrderedDict[Path, _CachedEvents]] = OrderedDict()
 
 # Persists config file identity between invocations so that the
 # _read_config_model lru_cache is only cleared when the file changes.

--- a/src/copilot_usage/vscode_parser.py
+++ b/src/copilot_usage/vscode_parser.py
@@ -150,7 +150,7 @@ class _VSCodeDiscoveryCache:
     log_paths: tuple[Path, ...]
 
 
-_VSCODE_DISCOVERY_CACHE: dict[Path, _VSCodeDiscoveryCache] = {}
+_VSCODE_DISCOVERY_CACHE: Final[dict[Path, _VSCodeDiscoveryCache]] = {}
 
 
 def _scan_child_ids(root: Path) -> _ChildIds:
@@ -361,7 +361,7 @@ class _CachedVSCodeLog:
     requests: tuple[VSCodeRequest, ...]
 
 
-_VSCODE_LOG_CACHE: OrderedDict[Path, _CachedVSCodeLog] = OrderedDict()
+_VSCODE_LOG_CACHE: Final[OrderedDict[Path, _CachedVSCodeLog]] = OrderedDict()
 
 
 # ---------------------------------------------------------------------------
@@ -398,7 +398,7 @@ class _CachedFileSummary:
     partial: VSCodeLogSummary
 
 
-_PER_FILE_SUMMARY_CACHE: OrderedDict[Path, _CachedFileSummary] = OrderedDict()
+_PER_FILE_SUMMARY_CACHE: Final[OrderedDict[Path, _CachedFileSummary]] = OrderedDict()
 
 
 _FILE_ID_UNSET: Final = "unset"


### PR DESCRIPTION
Closes #970

## Changes

Adds `Final[...]` annotations to six module-level cache containers that are mutated in-place but never rebound:

**`src/copilot_usage/parser.py`**
- `_DISCOVERY_CACHE` → `Final[dict[Path, _DiscoveryCache]]`
- `_SESSION_CACHE` → `Final[OrderedDict[Path, _CachedSession]]`
- `_EVENTS_CACHE` → `Final[OrderedDict[Path, _CachedEvents]]`

**`src/copilot_usage/vscode_parser.py`**
- `_VSCODE_DISCOVERY_CACHE` → `Final[dict[Path, _VSCodeDiscoveryCache]]`
- `_VSCODE_LOG_CACHE` → `Final[OrderedDict[Path, _CachedVSCodeLog]]`
- `_PER_FILE_SUMMARY_CACHE` → `Final[OrderedDict[Path, _CachedFileSummary]]`

This aligns these containers with the adjacent numeric limits (e.g. `_MAX_CACHED_SESSIONS: Final[int]`) that are already correctly annotated with `Final`.

## Verification

`make check` passes cleanly — lint, pyright strict, bandit, unit tests (99% coverage), and e2e tests all green.




> [!WARNING]
> <details>
> <summary><strong>⚠️ Firewall blocked 1 domain</strong></summary>
>
> The following domain was blocked by the firewall during workflow execution:
>
> - `astral.sh`
>
> To allow these domains, add them to the `network.allowed` list in your workflow frontmatter:
>
> ```yaml
> network:
>   allowed:
>     - defaults
>     - "astral.sh"
> ```
>
> See [Network Configuration](https://github.github.com/gh-aw/reference/network/) for more information.
>
> </details>


> Generated by [Issue Implementer](https://github.com/microsasa/cli-tools/actions/runs/24596709584/agentic_workflow) · ● 3.1M · [◷](https://github.com/search?q=repo%3Amicrosasa%2Fcli-tools+%22gh-aw-workflow-id%3A+issue-implementer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Issue Implementer, engine: copilot, model: claude-opus-4.6, id: 24596709584, workflow_id: issue-implementer, run: https://github.com/microsasa/cli-tools/actions/runs/24596709584 -->

<!-- gh-aw-workflow-id: issue-implementer -->