### PR TITLE
fix: guard `_FileChangeHandler` data race and update `_discover_with_identity` docstring (#971)

### DIFF
--- a/src/copilot_usage/cli.py
+++ b/src/copilot_usage/cli.py
@@ -254,12 +254,15 @@ class _FileChangeHandler:
     def __init__(self, change_event: threading.Event) -> None:
         self._change_event = change_event
         self._last_trigger = 0.0
+        self._lock = threading.Lock()
 
     def dispatch(self, event: object) -> None:
         now = time.monotonic()
-        if now - self._last_trigger > _WATCHDOG_DEBOUNCE_SECS:
+        with self._lock:
+            if now - self._last_trigger <= _WATCHDOG_DEBOUNCE_SECS:
+                return
             self._last_trigger = now
-            self._change_event.set()
+        self._change_event.set()
 
 
 class _Stoppable(Protocol):

--- a/src/copilot_usage/parser.py
+++ b/src/copilot_usage/parser.py
@@ -389,6 +389,10 @@ def _discover_with_identity(
     skipped entirely.
     When *include_plan* is ``False``, the ``plan_file_id`` element is
     always ``None`` — useful for callers that only need event ordering.
+    Note that on a cache miss the full scan is always performed with plan
+    discovery enabled so that subsequent ``include_plan=True`` calls
+    (e.g. from :func:`get_all_sessions`) can benefit from the cached
+    plan paths.
     """
     root = (base_path or DEFAULT_SESSION_PATH).resolve()
 

--- a/tests/copilot_usage/test_cli.py
+++ b/tests/copilot_usage/test_cli.py
@@ -941,8 +941,55 @@ class TestFileChangeHandler:
         handler.dispatch(object())
         assert event.is_set()
 
+    def test_concurrent_dispatch_sets_event_at_most_once(self) -> None:
+        """Concurrent dispatch calls within the debounce window set the event at most once."""
+        import time as _time
 
-# ---------------------------------------------------------------------------
+        from copilot_usage.cli import (
+            _FileChangeHandler,
+        )
+
+        event = threading.Event()
+        handler = _FileChangeHandler(event)
+
+        # Prime the handler so _last_trigger is "now", then clear the event.
+        handler.dispatch(object())
+        assert event.is_set()
+        event.clear()
+
+        # Reset _last_trigger to a value that makes the debounce window expire,
+        # so both threads believe they should fire.
+        handler._last_trigger = _time.monotonic() - 10.0
+
+        set_count: list[int] = [0]
+        count_lock = threading.Lock()
+        original_set = event.set
+
+        def counting_set() -> None:
+            with count_lock:
+                set_count[0] += 1
+            original_set()
+
+        event.set = counting_set  # type: ignore[assignment]
+
+        barrier = threading.Barrier(2)
+
+        def worker() -> None:
+            barrier.wait()
+            handler.dispatch(object())
+
+        t1 = threading.Thread(target=worker)
+        t2 = threading.Thread(target=worker)
+        t1.start()
+        t2.start()
+        t1.join(timeout=5.0)
+        t2.join(timeout=5.0)
+
+        assert set_count[0] == 1, (
+            f"Expected change_event.set() exactly once, got {set_count[0]}"
+        )
+
+
 # Issue #59 — untested branches
 # ---------------------------------------------------------------------------
 

--- a/tests/copilot_usage/test_cli.py
+++ b/tests/copilot_usage/test_cli.py
@@ -942,7 +942,13 @@ class TestFileChangeHandler:
         assert event.is_set()
 
     def test_concurrent_dispatch_sets_event_at_most_once(self) -> None:
-        """Concurrent dispatch calls within the debounce window set the event at most once."""
+        """Concurrent dispatch calls within the debounce window set the event at most once.
+
+        Holds ``handler._lock`` before starting workers so both threads
+        queue at the lock inside ``dispatch()``, then releases — making
+        the contention deterministic rather than relying on a lucky
+        interleaving.
+        """
         import time as _time
 
         from copilot_usage.cli import (
@@ -957,8 +963,7 @@ class TestFileChangeHandler:
         assert event.is_set()
         event.clear()
 
-        # Reset _last_trigger to a value that makes the debounce window expire,
-        # so both threads believe they should fire.
+        # Reset _last_trigger so both threads see an expired debounce window.
         handler._last_trigger = _time.monotonic() - 10.0
 
         set_count: list[int] = [0]
@@ -972,7 +977,10 @@ class TestFileChangeHandler:
 
         event.set = counting_set  # type: ignore[assignment]
 
-        barrier = threading.Barrier(2)
+        # Hold handler's lock so both workers block inside dispatch().
+        handler._lock.acquire()
+
+        barrier = threading.Barrier(2, timeout=5.0)
 
         def worker() -> None:
             barrier.wait()
@@ -982,8 +990,17 @@ class TestFileChangeHandler:
         t2 = threading.Thread(target=worker)
         t1.start()
         t2.start()
+
+        # Give threads time to pass the barrier and block at the lock.
+        _time.sleep(0.1)
+
+        # Release; the two workers now contend serially.
+        handler._lock.release()
+
         t1.join(timeout=5.0)
         t2.join(timeout=5.0)
+        assert not t1.is_alive(), "Thread 1 did not finish"
+        assert not t2.is_alive(), "Thread 2 did not finish"
 
         assert set_count[0] == 1, (
             f"Expected change_event.set() exactly once, got {set_count[0]}"


### PR DESCRIPTION
Closes #971

## Changes

### 1. `_FileChangeHandler.dispatch` data race (Item 2)

Added a `threading.Lock` to guard the read-modify-write of `_last_trigger` in `dispatch()`. Without the lock, two concurrent watchdog threads could both pass the debounce check before either writes the new value, causing a spurious double `set()`. The lock ensures at most one thread fires per debounce window.

### 2. `_discover_with_identity` docstring (Item 3)

Added a note to the `include_plan=False` paragraph explaining that on a cache miss the full scan is always performed with plan discovery enabled, so subsequent `include_plan=True` calls benefit from cached plan paths.

### 3. Stale `pyright` suppression (Item 1) — not applicable

The issue stated `test_vscode_report.py` has no private symbol accesses, but the file imports `_DAILY_ACTIVITY_LIMIT` from `vscode_report`. Removing the comment causes a pyright `reportPrivateUsage` error, so the suppression is correct and remains.

## Testing

- Added `test_concurrent_dispatch_sets_event_at_most_once` — spawns two threads that race through `dispatch()` after the debounce window expires and asserts `change_event.set()` is called exactly once.
- All checks pass: `make check` (lint ✅, pyright ✅, bandit ✅, unit tests 99% coverage ✅, e2e 86 passed ✅).




> Generated by [Issue Implementer](https://github.com/microsasa/cli-tools/actions/runs/24596869261/agentic_workflow) · ● 8.4M · [◷](https://github.com/search?q=repo%3Amicrosasa%2Fcli-tools+%22gh-aw-workflow-id%3A+issue-implementer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Issue Implementer, engine: copilot, model: claude-opus-4.6, id: 24596869261, workflow_id: issue-implementer, run: https://github.com/microsasa/cli-tools/actions/runs/24596869261 -->

<!-- gh-aw-workflow-id: issue-implementer -->