### PR TITLE
perf: incremental events.jsonl parsing via byte-offset cache (#732)

### DIFF
--- a/src/copilot_usage/parser.py
+++ b/src/copilot_usage/parser.py
@@ -318,9 +318,13 @@ def get_cached_events(events_path: Path) -> tuple[SessionEvent, ...]:
                 events_path, cached.end_offset
             )
             merged = cached.events + tuple(new_events)
-            inc_id: tuple[int, int] | None = file_id
-            if file_id[1] != safe_end:
-                inc_id = (file_id[0], safe_end)
+            post_inc_id = safe_file_identity(events_path)
+            if post_inc_id is None:
+                inc_id: tuple[int, int] | None = file_id
+            elif post_inc_id[1] == safe_end:
+                inc_id = post_inc_id
+            else:
+                inc_id = (post_inc_id[0], safe_end)
             _insert_events_entry(events_path, inc_id, merged, safe_end)
             return _EVENTS_CACHE[events_path].events
 
@@ -1231,7 +1235,14 @@ def get_all_sessions(base_path: Path | None = None) -> list[SessionSummary]:
         if not events:
             continue
         if len(deferred_events) < _MAX_CACHED_EVENTS:
-            deferred_events.append((events_path, file_id, events, safe_end))
+            post_id = safe_file_identity(events_path)
+            if post_id is None:
+                stored_id = file_id
+            elif post_id[1] == safe_end:
+                stored_id = post_id
+            else:
+                stored_id = (post_id[0], safe_end)
+            deferred_events.append((events_path, stored_id, events, safe_end))
         meta = _build_session_summary_with_meta(
             list(events) if isinstance(events, tuple) else events,
             session_dir=events_path.parent,

--- a/src/copilot_usage/parser.py
+++ b/src/copilot_usage/parser.py
@@ -130,9 +130,17 @@ def _insert_session_entry(
 
 @dataclasses.dataclass(frozen=True, slots=True)
 class _CachedEvents:
-    """Cache entry pairing a file identity with parsed events."""
+    """Cache entry pairing a file identity with parsed events.
+
+    ``end_offset`` is the byte position after the last fully consumed
+    line.  When the file grows (append-only), only bytes after
+    ``end_offset`` need to be parsed — avoiding a full re-read, even if
+    some fully consumed lines were skipped due to parse or validation
+    errors.
+    """
 
     file_id: tuple[int, int] | None
+    end_offset: int
     events: tuple[SessionEvent, ...]
 
 
@@ -177,7 +185,8 @@ _sorted_sessions_cache: _SortedSessionsCache | None = None
 def _insert_events_entry(
     events_path: Path,
     file_id: tuple[int, int] | None,
-    events: list[SessionEvent],
+    events: list[SessionEvent] | tuple[SessionEvent, ...],
+    end_offset: int = 0,
 ) -> None:
     """Insert parsed events into ``_EVENTS_CACHE`` with LRU eviction.
 
@@ -185,28 +194,103 @@ def _insert_events_entry(
     old entry is removed first.  Otherwise, when the cache is full the
     least-recently-used entry (front of the ``OrderedDict``) is evicted.
 
-    The *events* list is converted to a ``tuple`` before storage so
+    The *events* sequence is converted to a ``tuple`` before storage so
     that callers cannot accidentally add, remove, or reorder entries
     in the cache.  This is **container-level** immutability only —
     individual ``SessionEvent`` objects remain mutable and must not
     be modified by callers.
     """
+    stored = events if isinstance(events, tuple) else tuple(events)
     lru_insert(
         _EVENTS_CACHE,
         events_path,
-        _CachedEvents(file_id=file_id, events=tuple(events)),
+        _CachedEvents(file_id=file_id, end_offset=end_offset, events=stored),
         _MAX_CACHED_EVENTS,
     )
+
+
+def _parse_events_from_offset(
+    events_path: Path, offset: int
+) -> tuple[list[SessionEvent], int]:
+    """Parse events from *events_path* starting at byte *offset*.
+
+    Only lines beginning at or after *offset* are decoded and
+    Pydantic-validated.  Complete malformed or invalid lines are skipped
+    with a warning, matching the behaviour of :func:`parse_events`.
+
+    Lines without a trailing newline (possible incomplete write) that
+    fail JSON decoding are treated as still-in-progress and stop
+    parsing — the returned *safe_end* does not advance past them so
+    the caller can retry on the next refresh.
+
+    Returns:
+        ``(new_events, safe_end)`` where *safe_end* is the byte
+        position after the last fully consumed line.  Callers should
+        store this as ``end_offset`` so incomplete trailing lines are
+        retried on the next refresh.
+
+    Raises:
+        OSError: If the file cannot be opened or read.
+    """
+    new_events: list[SessionEvent] = []
+    safe_offset = offset
+    try:
+        with events_path.open("rb") as fh:
+            fh.seek(offset)
+            current_offset = offset
+            for raw_line in fh:
+                line_start = current_offset
+                current_offset += len(raw_line)
+                stripped = raw_line.strip()
+                if not stripped:
+                    safe_offset = current_offset
+                    continue
+                try:
+                    new_events.append(SessionEvent.model_validate_json(stripped))
+                except ValidationError as exc:
+                    errors = exc.errors(include_url=False)
+                    if errors and errors[0].get("type") == "json_invalid":
+                        if not raw_line.endswith(b"\n"):
+                            break
+                        logger.warning(
+                            "{}:offset {} — malformed JSON, skipping",
+                            events_path,
+                            line_start,
+                        )
+                    else:
+                        logger.warning(
+                            "{}:offset {} — validation error ({}), skipping",
+                            events_path,
+                            line_start,
+                            exc.error_count(),
+                        )
+                safe_offset = current_offset
+    except UnicodeDecodeError as exc:
+        logger.warning(
+            "{} — UTF-8 decode error at offset {}; returning {} new events (partial): {}",
+            events_path,
+            safe_offset,
+            len(new_events),
+            exc,
+        )
+    return new_events, safe_offset
 
 
 def get_cached_events(events_path: Path) -> tuple[SessionEvent, ...]:
     """Return parsed events, using cache when file identity is unchanged.
 
-    Delegates to :func:`parse_events` on a cache miss and stores the
-    result keyed by *events_path* with file-identity validation on
-    lookup.  The cache is bounded to :data:`_MAX_CACHED_EVENTS`
-    entries; the **least-recently used** entry is evicted when the
-    limit is reached.
+    On a cache miss (cold start, truncation, or unknown file) the entire
+    file is re-read via :func:`_parse_events_from_offset` at offset 0
+    and the result is stored keyed by *events_path* with file-identity
+    validation on lookup.  The cache is bounded to
+    :data:`_MAX_CACHED_EVENTS` entries; the **least-recently used** entry
+    is evicted when the limit is reached.
+
+    When the file has grown since the last read (append-only pattern),
+    only the newly appended bytes are parsed via
+    :func:`_parse_events_from_offset` and merged with the cached tuple.
+    A full reparse is performed when the file has shrunk (truncation or
+    replacement) or on cold start.
 
     The returned ``tuple`` prevents callers from adding, removing, or
     reordering cached entries (container-level immutability).  Individual
@@ -215,16 +299,41 @@ def get_cached_events(events_path: Path) -> tuple[SessionEvent, ...]:
     ``list(get_cached_events(...))``.
 
     Raises:
-        OSError: Propagated from :func:`parse_events` when the file
-            cannot be opened or read.
+        OSError: Propagated from :func:`_parse_events_from_offset`
+            when the file cannot be opened or read.
     """
     file_id = safe_file_identity(events_path)
     cached = _EVENTS_CACHE.get(events_path)
-    if cached is not None and cached.file_id == file_id:
-        _EVENTS_CACHE.move_to_end(events_path)
-        return cached.events
-    events = parse_events(events_path)
-    _insert_events_entry(events_path, file_id, events)
+
+    if cached is not None and file_id is not None:
+        if cached.file_id == file_id:
+            _EVENTS_CACHE.move_to_end(events_path)
+            return cached.events
+        new_size = file_id[1]
+        # Append-only growth: size grew beyond cached end_offset.
+        # If size == end_offset but mtime changed, the file was rewritten
+        # in-place to the same size — fall through to full reparse.
+        if new_size > cached.end_offset and cached.end_offset > 0:
+            new_events, safe_end = _parse_events_from_offset(
+                events_path, cached.end_offset
+            )
+            merged = cached.events + tuple(new_events)
+            inc_id: tuple[int, int] | None = file_id
+            if file_id[1] != safe_end:
+                inc_id = (file_id[0], safe_end)
+            _insert_events_entry(events_path, inc_id, merged, safe_end)
+            return _EVENTS_CACHE[events_path].events
+
+    # Full reparse: cold start, truncation, same-size rewrite, or unknown.
+    events, safe_end = _parse_events_from_offset(events_path, 0)
+    post_id = safe_file_identity(events_path)
+    if post_id is None:
+        stored_id = file_id
+    elif post_id[1] == safe_end:
+        stored_id = post_id
+    else:
+        stored_id = (post_id[0], safe_end)
+    _insert_events_entry(events_path, stored_id, events, safe_end)
     return _EVENTS_CACHE[events_path].events
 
 
@@ -1053,7 +1162,14 @@ def get_all_sessions(base_path: Path | None = None) -> list[SessionSummary]:
     # Only the newest _MAX_CACHED_EVENTS entries are retained for
     # _EVENTS_CACHE to avoid a temporary memory spike when many sessions
     # are cache-misses.
-    deferred_events: list[tuple[Path, tuple[int, int] | None, list[SessionEvent]]] = []
+    deferred_events: list[
+        tuple[
+            Path,
+            tuple[int, int] | None,
+            list[SessionEvent] | tuple[SessionEvent, ...],
+            int,
+        ]
+    ] = []
     deferred_sessions: list[tuple[Path, _CachedSession]] = []
     cache_hit_paths: list[Path] = []
     any_events_changed = False
@@ -1091,16 +1207,33 @@ def get_all_sessions(base_path: Path | None = None) -> list[SessionSummary]:
             continue
         any_events_changed = True
         try:
-            events = parse_events(events_path)
+            # Incremental path: if we have a cached events entry with a
+            # valid end_offset and the file grew, parse only new bytes.
+            ev_cached = _EVENTS_CACHE.get(events_path)
+            if (
+                ev_cached is not None
+                and file_id is not None
+                and ev_cached.end_offset > 0
+                and file_id[1] > ev_cached.end_offset
+            ):
+                new_events, safe_end = _parse_events_from_offset(
+                    events_path, ev_cached.end_offset
+                )
+                events: list[SessionEvent] | tuple[SessionEvent, ...] = (
+                    ev_cached.events + tuple(new_events)
+                )
+            else:
+                parsed, safe_end = _parse_events_from_offset(events_path, 0)
+                events = parsed
         except OSError as exc:
             logger.warning("Skipping unreadable session {}: {}", events_path, exc)
             continue
         if not events:
             continue
         if len(deferred_events) < _MAX_CACHED_EVENTS:
-            deferred_events.append((events_path, file_id, events))
+            deferred_events.append((events_path, file_id, events, safe_end))
         meta = _build_session_summary_with_meta(
-            events,
+            list(events) if isinstance(events, tuple) else events,
             session_dir=events_path.parent,
             events_path=events_path,
             plan_exists=plan_id is not None,
@@ -1133,8 +1266,8 @@ def get_all_sessions(base_path: Path | None = None) -> list[SessionSummary]:
 
     # Populate _EVENTS_CACHE in oldest→newest order so that the newest
     # sessions sit at the back (MRU) and eviction drops the oldest.
-    for ep, fid, evts in reversed(deferred_events):
-        _insert_events_entry(ep, fid, evts)
+    for ep, fid, evts, se in reversed(deferred_events):
+        _insert_events_entry(ep, fid, evts, se)
 
     # Prune stale cache entries for sessions no longer on disk.
     # Only remove entries rooted under the *current* base_path so that

--- a/tests/copilot_usage/test_parser.py
+++ b/tests/copilot_usage/test_parser.py
@@ -12,7 +12,7 @@ from collections.abc import Iterator
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import SupportsIndex, overload
-from unittest.mock import patch
+from unittest.mock import ANY, patch
 
 import pytest
 from pydantic import ValidationError
@@ -60,6 +60,7 @@ from copilot_usage.parser import (
     _full_scandir_discovery,
     _infer_model_from_metrics,
     _insert_session_entry,
+    _parse_events_from_offset,
     _read_config_model,
     _ResumeInfo,
     _SortedSessionsCache,
@@ -6757,7 +6758,10 @@ class TestSessionCacheMtime:
         self._make_session(tmp_path, "sess-b", "b")
 
         # First call — populates cache; both files must be parsed.
-        with patch("copilot_usage.parser.parse_events", wraps=parse_events) as spy:
+        with patch(
+            "copilot_usage.parser._parse_events_from_offset",
+            wraps=_parse_events_from_offset,
+        ) as spy:
             result1 = get_all_sessions(tmp_path)
             assert len(result1) == 2
             assert spy.call_count == 2
@@ -6788,11 +6792,14 @@ class TestSessionCacheMtime:
         os.utime(p1, ns=(stat.st_atime_ns, stat.st_mtime_ns + 2_000_000_000))
 
         # Second call — only the modified file should be re-parsed.
-        with patch("copilot_usage.parser.parse_events", wraps=parse_events) as spy:
+        with patch(
+            "copilot_usage.parser._parse_events_from_offset",
+            wraps=_parse_events_from_offset,
+        ) as spy:
             result2 = get_all_sessions(tmp_path)
             assert len(result2) == 2
             assert spy.call_count == 1
-            spy.assert_called_once_with(p1)
+            spy.assert_called_once_with(p1, ANY)
 
     def test_cache_returns_correct_summaries(self, tmp_path: Path) -> None:
         """Cached entries produce the same summaries as a fresh parse."""
@@ -7069,7 +7076,10 @@ class TestStalePruningScopedToBasePath:
         get_all_sessions(path_b)
 
         # Third call back to path_a — parse_events should not be called.
-        with patch("copilot_usage.parser.parse_events", wraps=parse_events) as spy:
+        with patch(
+            "copilot_usage.parser._parse_events_from_offset",
+            wraps=_parse_events_from_offset,
+        ) as spy:
             result = get_all_sessions(path_a)
             assert len(result) == 1
             assert spy.call_count == 0
@@ -7257,7 +7267,10 @@ class TestActiveSessionCaching:
         # First call — must parse
         with (
             patch("copilot_usage.parser._CONFIG_PATH", config),
-            patch("copilot_usage.parser.parse_events", wraps=parse_events) as spy,
+            patch(
+                "copilot_usage.parser._parse_events_from_offset",
+                wraps=_parse_events_from_offset,
+            ) as spy,
         ):
             result1 = get_all_sessions(tmp_path)
             assert len(result1) == 1
@@ -7267,7 +7280,10 @@ class TestActiveSessionCaching:
         # Second call — no file changes, should use cache
         with (
             patch("copilot_usage.parser._CONFIG_PATH", config),
-            patch("copilot_usage.parser.parse_events", wraps=parse_events) as spy,
+            patch(
+                "copilot_usage.parser._parse_events_from_offset",
+                wraps=_parse_events_from_offset,
+            ) as spy,
         ):
             result2 = get_all_sessions(tmp_path)
             assert len(result2) == 1
@@ -7294,7 +7310,10 @@ class TestActiveSessionCaching:
             config.write_text('{"model": "claude-sonnet-4"}', encoding="utf-8")
 
             # Second call should re-parse because config model changed
-            with patch("copilot_usage.parser.parse_events", wraps=parse_events) as spy:
+            with patch(
+                "copilot_usage.parser._parse_events_from_offset",
+                wraps=_parse_events_from_offset,
+            ) as spy:
                 result2 = get_all_sessions(tmp_path / "sessions")
                 assert len(result2) == 1
                 assert result2[0].model == "claude-sonnet-4"
@@ -7315,7 +7334,10 @@ class TestActiveSessionCaching:
             get_all_sessions(tmp_path / "sessions")
 
             # Second call — same config, same file → cache hit
-            with patch("copilot_usage.parser.parse_events", wraps=parse_events) as spy:
+            with patch(
+                "copilot_usage.parser._parse_events_from_offset",
+                wraps=_parse_events_from_offset,
+            ) as spy:
                 result = get_all_sessions(tmp_path / "sessions")
                 assert len(result) == 1
                 assert result[0].model == "gpt-5.1"
@@ -7358,7 +7380,10 @@ class TestActiveSessionCaching:
             # Now create a config with a model
             config.write_text('{"model": "gpt-5.1"}', encoding="utf-8")
 
-            with patch("copilot_usage.parser.parse_events", wraps=parse_events) as spy:
+            with patch(
+                "copilot_usage.parser._parse_events_from_offset",
+                wraps=_parse_events_from_offset,
+            ) as spy:
                 result2 = get_all_sessions(tmp_path / "sessions")
                 assert len(result2) == 1
                 assert result2[0].model == "gpt-5.1"
@@ -7387,7 +7412,10 @@ class TestActiveSessionCaching:
             # Change config — should NOT trigger re-parse
             config.write_text('{"model": "gpt-5.2"}', encoding="utf-8")
 
-            with patch("copilot_usage.parser.parse_events", wraps=parse_events) as spy:
+            with patch(
+                "copilot_usage.parser._parse_events_from_offset",
+                wraps=_parse_events_from_offset,
+            ) as spy:
                 result2 = get_all_sessions(tmp_path / "sessions")
                 assert len(result2) == 1
                 assert result2[0].model == "claude-sonnet-4"
@@ -7416,7 +7444,10 @@ class TestActiveSessionCaching:
             # Delete the config file — config_model should now be None
             config.unlink()
 
-            with patch("copilot_usage.parser.parse_events", wraps=parse_events) as spy:
+            with patch(
+                "copilot_usage.parser._parse_events_from_offset",
+                wraps=_parse_events_from_offset,
+            ) as spy:
                 result2 = get_all_sessions(tmp_path / "sessions")
                 assert len(result2) == 1
                 assert result2[0].model is None  # config-sourced model gone
@@ -7451,7 +7482,10 @@ class TestActiveSessionCaching:
             plan.write_text("# Renamed\n", encoding="utf-8")
             config.write_text('{"model": "claude-sonnet-4"}', encoding="utf-8")
 
-            with patch("copilot_usage.parser.parse_events", wraps=parse_events) as spy:
+            with patch(
+                "copilot_usage.parser._parse_events_from_offset",
+                wraps=_parse_events_from_offset,
+            ) as spy:
                 result2 = get_all_sessions(tmp_path / "sessions")
                 assert len(result2) == 1
                 # Full re-parse must have occurred (config staleness wins)
@@ -7492,7 +7526,10 @@ class TestActiveSessionCaching:
             # Change ONLY plan.md — config stays the same
             plan.write_text("# Renamed\n", encoding="utf-8")
 
-            with patch("copilot_usage.parser.parse_events", wraps=parse_events) as spy:
+            with patch(
+                "copilot_usage.parser._parse_events_from_offset",
+                wraps=_parse_events_from_offset,
+            ) as spy:
                 result2 = get_all_sessions(tmp_path / "sessions")
                 assert len(result2) == 1
                 # Plan-only fast path — no re-parse
@@ -7573,7 +7610,10 @@ class TestGetCachedEvents:
         first = get_cached_events(p)
         assert len(first) == 1_001  # 1 start + 1000 user messages
 
-        with patch("copilot_usage.parser.parse_events", wraps=parse_events) as spy:
+        with patch(
+            "copilot_usage.parser._parse_events_from_offset",
+            wraps=_parse_events_from_offset,
+        ) as spy:
             second = get_cached_events(p)
             assert spy.call_count == 0
 
@@ -7640,7 +7680,10 @@ class TestGetCachedEvents:
         first = get_cached_events(p)
 
         # Subsequent reads must not call parse_events at all
-        with patch("copilot_usage.parser.parse_events", wraps=parse_events) as spy:
+        with patch(
+            "copilot_usage.parser._parse_events_from_offset",
+            wraps=_parse_events_from_offset,
+        ) as spy:
             second = get_cached_events(p)
             third = get_cached_events(p)
             assert spy.call_count == 0
@@ -7710,7 +7753,10 @@ class TestGetAllSessionsPopulatesEventsCache:
         — parse_events is called only once per session, not twice."""
         p = self._make_session(tmp_path, "sess-a", "a")
 
-        with patch("copilot_usage.parser.parse_events", wraps=parse_events) as spy:
+        with patch(
+            "copilot_usage.parser._parse_events_from_offset",
+            wraps=_parse_events_from_offset,
+        ) as spy:
             get_all_sessions(tmp_path)
             assert spy.call_count == 1  # single parse during get_all_sessions
 
@@ -7786,7 +7832,10 @@ class TestGetAllSessionsEventsCacheOverflow:
         excluded_path = paths[0]
         assert excluded_path not in _EVENTS_CACHE
 
-        with patch("copilot_usage.parser.parse_events", wraps=parse_events) as spy:
+        with patch(
+            "copilot_usage.parser._parse_events_from_offset",
+            wraps=_parse_events_from_offset,
+        ) as spy:
             events = get_cached_events(excluded_path)
             spy.assert_called_once()  # cache miss → re-parse
 
@@ -8169,7 +8218,10 @@ class TestEventsCacheLimitCoversTypicalSessions:
 
         # Now call get_cached_events for every session and assert that
         # parse_events is *never* invoked (all hits come from cache).
-        with patch("copilot_usage.parser.parse_events", wraps=parse_events) as spy:
+        with patch(
+            "copilot_usage.parser._parse_events_from_offset",
+            wraps=_parse_events_from_offset,
+        ) as spy:
             for ep in paths:
                 get_cached_events(ep)
             assert spy.call_count == 0
@@ -9567,3 +9619,222 @@ class TestDetectResumeFrozensetPreFilter:
             }
         )
         assert expected == _DETECT_RESUME_EVENT_TYPES
+
+
+# ---------------------------------------------------------------------------
+# Incremental events.jsonl parsing
+# ---------------------------------------------------------------------------
+
+
+def _make_event_line(
+    event_type: str, event_id: str, ts: str = "2026-05-01T10:00:00.000Z"
+) -> str:
+    """Build a minimal JSON event line."""
+    if event_type == "session.start":
+        return json.dumps(
+            {
+                "type": "session.start",
+                "data": {
+                    "sessionId": event_id,
+                    "version": "1.0.0",
+                    "startTime": ts,
+                },
+                "id": event_id,
+                "timestamp": ts,
+            }
+        )
+    if event_type == "assistant.message":
+        return json.dumps(
+            {
+                "type": "assistant.message",
+                "data": {
+                    "messageId": event_id,
+                    "content": "hello",
+                    "toolRequests": [],
+                    "interactionId": "int-1",
+                    "outputTokens": 10,
+                },
+                "id": event_id,
+                "timestamp": ts,
+            }
+        )
+    msg = f"unknown event type: {event_type}"
+    raise ValueError(msg)
+
+
+class TestParseEventsFromOffset:
+    """Tests for :func:`_parse_events_from_offset`."""
+
+    def test_full_parse_from_zero(self, tmp_path: Path) -> None:
+        """Offset 0 parses the entire file."""
+        p = tmp_path / "events.jsonl"
+        lines = [
+            _make_event_line("session.start", "s1") + "\n",
+            _make_event_line("assistant.message", "m1") + "\n",
+        ]
+        p.write_text("".join(lines), encoding="utf-8")
+
+        events, safe_end = _parse_events_from_offset(p, 0)
+        assert len(events) == 2
+        assert safe_end == p.stat().st_size
+
+    def test_incremental_from_offset(self, tmp_path: Path) -> None:
+        """Parsing from a mid-file offset returns only new events."""
+        p = tmp_path / "events.jsonl"
+        line1 = _make_event_line("session.start", "s1") + "\n"
+        line2 = _make_event_line("assistant.message", "m1") + "\n"
+        p.write_text(line1 + line2, encoding="utf-8")
+
+        offset = len(line1.encode("utf-8"))
+        events, safe_end = _parse_events_from_offset(p, offset)
+        assert len(events) == 1
+        assert events[0].type == "assistant.message"
+        assert safe_end == p.stat().st_size
+
+    def test_incomplete_trailing_line_excluded(self, tmp_path: Path) -> None:
+        """A line without a trailing newline is NOT included in results."""
+        p = tmp_path / "events.jsonl"
+        line1 = _make_event_line("session.start", "s1") + "\n"
+        # Write incomplete second line (no trailing newline, malformed JSON)
+        p.write_bytes(line1.encode("utf-8") + b'{"type":"assistant')
+
+        events, safe_end = _parse_events_from_offset(p, 0)
+        assert len(events) == 1
+        # safe_end should not include the incomplete line
+        assert safe_end == len(line1.encode("utf-8"))
+
+    def test_blank_lines_skipped(self, tmp_path: Path) -> None:
+        """Blank and whitespace-only lines advance safe_end but produce no events."""
+        p = tmp_path / "events.jsonl"
+        line1 = _make_event_line("session.start", "s1") + "\n"
+        p.write_text(line1 + "\n\n  \n", encoding="utf-8")
+
+        events, safe_end = _parse_events_from_offset(p, 0)
+        assert len(events) == 1
+        assert safe_end == p.stat().st_size
+
+    def test_malformed_complete_line_skipped(self, tmp_path: Path) -> None:
+        """A malformed but newline-terminated line is skipped; parsing continues."""
+        p = tmp_path / "events.jsonl"
+        line1 = _make_event_line("session.start", "s1") + "\n"
+        bad_line = "{not valid json}\n"
+        line3 = _make_event_line("assistant.message", "m1") + "\n"
+        p.write_text(line1 + bad_line + line3, encoding="utf-8")
+
+        events, safe_end = _parse_events_from_offset(p, 0)
+        assert len(events) == 2
+        assert safe_end == p.stat().st_size
+
+
+class TestIncrementalEventsCaching:
+    """Tests for incremental cache behaviour in get_cached_events."""
+
+    def _make_events_file(self, tmp_path: Path, lines: list[str]) -> Path:
+        p = tmp_path / "events.jsonl"
+        p.write_text("".join(lines), encoding="utf-8")
+        return p
+
+    def setup_method(self) -> None:
+        _EVENTS_CACHE.clear()
+
+    def test_append_uses_incremental_path(self, tmp_path: Path) -> None:
+        """Appending to a file triggers incremental parse, not full re-read."""
+        line1 = _make_event_line("session.start", "s1") + "\n"
+        p = self._make_events_file(tmp_path, [line1])
+
+        first = get_cached_events(p)
+        assert len(first) == 1
+
+        # Append a new event
+        line2 = _make_event_line("assistant.message", "m1") + "\n"
+        with p.open("a", encoding="utf-8") as fh:
+            fh.write(line2)
+
+        # Bump mtime to ensure cache invalidation
+        import os
+
+        stat = p.stat()
+        os.utime(p, ns=(stat.st_atime_ns, stat.st_mtime_ns + 2_000_000_000))
+
+        with patch(
+            "copilot_usage.parser._parse_events_from_offset",
+            wraps=_parse_events_from_offset,
+        ) as spy:
+            second = get_cached_events(p)
+            assert len(second) == 2
+            # Should be called with the offset of the first line's end
+            spy.assert_called_once()
+            call_offset = spy.call_args[0][1]
+            assert call_offset == len(line1.encode("utf-8"))
+
+    def test_truncation_triggers_full_reparse(self, tmp_path: Path) -> None:
+        """Shrinking a file triggers a full reparse from offset 0."""
+        line1 = _make_event_line("session.start", "s1") + "\n"
+        line2 = _make_event_line("assistant.message", "m1") + "\n"
+        p = self._make_events_file(tmp_path, [line1, line2])
+
+        first = get_cached_events(p)
+        assert len(first) == 2
+
+        # Truncate: rewrite with only one line
+        p.write_text(line1, encoding="utf-8")
+
+        import os
+
+        stat = p.stat()
+        os.utime(p, ns=(stat.st_atime_ns, stat.st_mtime_ns + 2_000_000_000))
+
+        with patch(
+            "copilot_usage.parser._parse_events_from_offset",
+            wraps=_parse_events_from_offset,
+        ) as spy:
+            second = get_cached_events(p)
+            assert len(second) == 1
+            spy.assert_called_once()
+            call_offset = spy.call_args[0][1]
+            assert call_offset == 0  # Full reparse
+
+    def test_same_size_rewrite_triggers_full_reparse(self, tmp_path: Path) -> None:
+        """File rewritten to the exact same size triggers full reparse."""
+        line1 = _make_event_line("session.start", "s1") + "\n"
+        p = self._make_events_file(tmp_path, [line1])
+
+        first = get_cached_events(p)
+        assert len(first) == 1
+        original_size = p.stat().st_size
+
+        # Rewrite with a different event of the exact same byte length
+        line2 = _make_event_line("session.start", "s2") + "\n"
+        # Pad or trim to match original size
+        line2_bytes = line2.encode("utf-8")
+        if len(line2_bytes) < original_size:
+            line2_bytes += b" " * (original_size - len(line2_bytes))
+        elif len(line2_bytes) > original_size:
+            line2_bytes = line2_bytes[:original_size]
+        p.write_bytes(line2_bytes)
+        assert p.stat().st_size == original_size
+
+        import os
+
+        stat = p.stat()
+        os.utime(p, ns=(stat.st_atime_ns, stat.st_mtime_ns + 2_000_000_000))
+
+        with patch(
+            "copilot_usage.parser._parse_events_from_offset",
+            wraps=_parse_events_from_offset,
+        ) as spy:
+            _second = get_cached_events(p)
+            spy.assert_called_once()
+            call_offset = spy.call_args[0][1]
+            # Must be a full reparse (offset 0) because size didn't grow
+            assert call_offset == 0
+
+    def test_cached_end_offset_stored(self, tmp_path: Path) -> None:
+        """After parsing, the cache entry stores end_offset."""
+        line1 = _make_event_line("session.start", "s1") + "\n"
+        p = self._make_events_file(tmp_path, [line1])
+
+        get_cached_events(p)
+        entry = _EVENTS_CACHE[p]
+        assert entry.end_offset == len(line1.encode("utf-8"))
+        assert entry.end_offset > 0

--- a/tests/copilot_usage/test_parser.py
+++ b/tests/copilot_usage/test_parser.py
@@ -9724,6 +9724,46 @@ class TestParseEventsFromOffset:
         assert len(events) == 2
         assert safe_end == p.stat().st_size
 
+    def test_validation_error_line_skipped(self, tmp_path: Path) -> None:
+        """Valid JSON that fails Pydantic validation is skipped with a warning."""
+        p = tmp_path / "events.jsonl"
+        line1 = _make_event_line("session.start", "s1") + "\n"
+        # Valid JSON but timestamp is not a valid datetime → validation error
+        bad_line = '{"type": "session.start", "data": {}, "id": "x", "timestamp": "not-a-date"}\n'
+        line3 = _make_event_line("assistant.message", "m1") + "\n"
+        p.write_text(line1 + bad_line + line3, encoding="utf-8")
+
+        events, safe_end = _parse_events_from_offset(p, 0)
+        # bad_line fails validation — skipped
+        assert len(events) == 2
+        assert safe_end == p.stat().st_size
+
+    def test_unicode_decode_error_returns_partial(self, tmp_path: Path) -> None:
+        """A UnicodeDecodeError stops parsing and returns events so far."""
+        p = tmp_path / "events.jsonl"
+        line1 = _make_event_line("session.start", "s1") + "\n"
+        line2 = _make_event_line("assistant.message", "m1") + "\n"
+        p.write_text(line1 + line2, encoding="utf-8")
+
+        from copilot_usage.models import SessionEvent as _SE
+
+        real_validate = _SE.model_validate_json
+        call_count = [0]
+
+        @classmethod  # type: ignore[misc]
+        def _boom(
+            cls: type[object], *args: str | bytes | bytearray, **kwargs: object
+        ) -> object:
+            call_count[0] += 1
+            if call_count[0] == 2:
+                raise UnicodeDecodeError("utf-8", b"", 0, 1, "simulated")
+            return real_validate(args[0], **kwargs)  # type: ignore[arg-type]
+
+        with patch.object(_SE, "model_validate_json", _boom):
+            events, safe_end = _parse_events_from_offset(p, 0)
+            assert len(events) == 1
+            assert safe_end == len(line1.encode("utf-8"))
+
 
 class TestIncrementalEventsCaching:
     """Tests for incremental cache behaviour in get_cached_events."""
@@ -9837,3 +9877,172 @@ class TestIncrementalEventsCaching:
         entry = _EVENTS_CACHE[p]
         assert entry.end_offset == len(line1.encode("utf-8"))
         assert entry.end_offset > 0
+
+    def test_file_deleted_during_incremental_parse(self, tmp_path: Path) -> None:
+        """If file is deleted between parse and post-stat, falls back to pre-parse file_id."""
+        line1 = _make_event_line("session.start", "s1") + "\n"
+        p = self._make_events_file(tmp_path, [line1])
+
+        # Prime cache
+        get_cached_events(p)
+
+        # Append and bump mtime
+        line2 = _make_event_line("assistant.message", "m1") + "\n"
+        with p.open("a", encoding="utf-8") as fh:
+            fh.write(line2)
+        import os
+
+        stat = p.stat()
+        os.utime(p, ns=(stat.st_atime_ns, stat.st_mtime_ns + 2_000_000_000))
+
+        # Make post-parse stat return None (simulate deletion mid-parse)
+        original = safe_file_identity
+        call_count = [0]
+
+        def _fake_identity(path: Path) -> tuple[int, int] | None:
+            if path == p and call_count[0] > 0:
+                return None
+            call_count[0] += 1
+            return original(path)
+
+        with patch(
+            "copilot_usage.parser.safe_file_identity", side_effect=_fake_identity
+        ):
+            result = get_cached_events(p)
+            assert len(result) == 2
+
+    def test_file_grew_during_incremental_parse(self, tmp_path: Path) -> None:
+        """If file grows during incremental parse, stored id uses post-parse mtime with safe_end."""
+        line1 = _make_event_line("session.start", "s1") + "\n"
+        p = self._make_events_file(tmp_path, [line1])
+
+        get_cached_events(p)
+
+        line2 = _make_event_line("assistant.message", "m1") + "\n"
+        with p.open("a", encoding="utf-8") as fh:
+            fh.write(line2)
+        import os
+
+        stat = p.stat()
+        os.utime(p, ns=(stat.st_atime_ns, stat.st_mtime_ns + 2_000_000_000))
+        expected_safe_end = len(line1.encode("utf-8")) + len(line2.encode("utf-8"))
+
+        # Make post-parse stat return a larger size (simulating growth during parse)
+        original = safe_file_identity
+        inflate = [True]
+
+        def _bigger_identity(path: Path) -> tuple[int, int] | None:
+            result = original(path)
+            if path == p and result is not None and inflate[0]:
+                inflate[0] = False
+                return (result[0], result[1] + 100)
+            return result
+
+        with patch(
+            "copilot_usage.parser.safe_file_identity", side_effect=_bigger_identity
+        ):
+            result = get_cached_events(p)
+            assert len(result) == 2
+            entry = _EVENTS_CACHE[p]
+            assert entry.end_offset == expected_safe_end
+
+    def test_file_deleted_during_cold_start(self, tmp_path: Path) -> None:
+        """If file is deleted during cold-start full reparse, falls back to pre-parse file_id."""
+        line1 = _make_event_line("session.start", "s1") + "\n"
+        p = self._make_events_file(tmp_path, [line1])
+
+        original = safe_file_identity
+        call_count = [0]
+
+        def _delete_on_second(path: Path) -> tuple[int, int] | None:
+            result = original(path)
+            if path == p:
+                call_count[0] += 1
+                if call_count[0] > 1:
+                    return None
+            return result
+
+        with patch(
+            "copilot_usage.parser.safe_file_identity", side_effect=_delete_on_second
+        ):
+            result = get_cached_events(p)
+            assert len(result) == 1
+
+    def test_file_grew_during_cold_start(self, tmp_path: Path) -> None:
+        """If file grows during cold-start, stored id uses post-parse mtime with safe_end."""
+        line1 = _make_event_line("session.start", "s1") + "\n"
+        p = self._make_events_file(tmp_path, [line1])
+
+        original = safe_file_identity
+        call_count = [0]
+
+        def _bigger_on_second(path: Path) -> tuple[int, int] | None:
+            result = original(path)
+            if path == p:
+                call_count[0] += 1
+                if call_count[0] > 1 and result is not None:
+                    return (result[0], result[1] + 100)
+            return result
+
+        with patch(
+            "copilot_usage.parser.safe_file_identity", side_effect=_bigger_on_second
+        ):
+            result = get_cached_events(p)
+            assert len(result) == 1
+            entry = _EVENTS_CACHE[p]
+            assert entry.end_offset == len(line1.encode("utf-8"))
+
+
+class TestGetAllSessionsPostParseStat:
+    """Tests for get_all_sessions post-parse stat edge cases."""
+
+    def setup_method(self) -> None:
+        _EVENTS_CACHE.clear()
+        _SESSION_CACHE.clear()
+        _DISCOVERY_CACHE.clear()
+
+    def test_file_deleted_during_parse(self, tmp_path: Path) -> None:
+        """If file vanishes during parse, stored_id falls back to discovery file_id."""
+        p = _make_completed_session(tmp_path, "sess-a", "a")
+
+        original = safe_file_identity
+        call_count = [0]
+
+        def _none_on_second(path: Path) -> tuple[int, int] | None:
+            if path == p:
+                call_count[0] += 1
+                if call_count[0] > 1:
+                    return None
+            return original(path)
+
+        with patch(
+            "copilot_usage.parser.safe_file_identity", side_effect=_none_on_second
+        ):
+            result = get_all_sessions(tmp_path)
+            assert len(result) == 1
+
+    def test_file_grew_during_parse(self, tmp_path: Path) -> None:
+        """If file grows during parse, stored_id uses post-parse mtime with safe_end."""
+        p = _make_completed_session(tmp_path, "sess-a", "a")
+
+        original = safe_file_identity
+        call_count = [0]
+
+        def _bigger_on_second(path: Path) -> tuple[int, int] | None:
+            result = original(path)
+            if path == p:
+                call_count[0] += 1
+                if call_count[0] > 1 and result is not None:
+                    return (result[0], result[1] + 200)
+            return result
+
+        with patch(
+            "copilot_usage.parser.safe_file_identity", side_effect=_bigger_on_second
+        ):
+            result = get_all_sessions(tmp_path)
+            assert len(result) == 1
+            entry = _EVENTS_CACHE[p]
+            assert entry.end_offset > 0
+            # stored file_id size should NOT be the inflated value
+            assert entry.file_id is not None
+            assert entry.file_id[1] == entry.end_offset

--- a/tests/copilot_usage/test_parser.py
+++ b/tests/copilot_usage/test_parser.py
@@ -6841,12 +6841,11 @@ class TestSessionCacheMtime:
             "copilot_usage.parser.safe_file_identity", wraps=safe_file_identity
         ) as spy:
             get_all_sessions(tmp_path)
-            # safe_file_identity called once for _CONFIG_PATH and once for
-            # the root directory (discovery cache check).  events.jsonl is
-            # stat'd directly (not via safe_file_identity) and plan.md does
-            # not exist so its absence is detected via os.scandir dir
-            # listing — no stat call is issued.
-            assert spy.call_count == 2
+            # safe_file_identity called once for _CONFIG_PATH, once for
+            # the root directory (discovery cache check), and once after
+            # parsing to capture the post-parse file identity for the
+            # events cache.
+            assert spy.call_count == 3
 
     def test_resumed_session_is_cached(self, tmp_path: Path) -> None:
         """A session that resumed after shutdown IS cached with config_model=None (model from shutdown)."""

--- a/tests/copilot_usage/test_parser.py
+++ b/tests/copilot_usage/test_parser.py
@@ -9927,15 +9927,19 @@ class TestIncrementalEventsCaching:
         os.utime(p, ns=(stat.st_atime_ns, stat.st_mtime_ns + 2_000_000_000))
         expected_safe_end = len(line1.encode("utf-8")) + len(line2.encode("utf-8"))
 
-        # Make post-parse stat return a larger size (simulating growth during parse)
+        # Make post-parse stat return a larger size (simulating growth during parse).
+        # The incremental path calls safe_file_identity twice for this file:
+        # once at the top (pre-parse) and once after _parse_events_from_offset
+        # (post-parse). We inflate only the second call.
         original = safe_file_identity
-        inflate = [True]
+        call_count_for_p = [0]
 
         def _bigger_identity(path: Path) -> tuple[int, int] | None:
             result = original(path)
-            if path == p and result is not None and inflate[0]:
-                inflate[0] = False
-                return (result[0], result[1] + 100)
+            if path == p and result is not None:
+                call_count_for_p[0] += 1
+                if call_count_for_p[0] == 2:
+                    return (result[0], result[1] + 100)
             return result
 
         with patch(


### PR DESCRIPTION
Closes #732
Supersedes #736

## Problem

`get_cached_events` re-parsed the entire `events.jsonl` from the start whenever `(st_mtime_ns, st_size)` changed — even though these files are append-only. For a 10,000-event session with 5 new events per refresh, this meant O(10,000) parse cost on every change.

## Solution

- Added `end_offset: int` to `_CachedEvents` — byte position after last consumed line
- Added `_parse_events_from_offset(path, offset)` — seeks to byte offset, parses only new lines
- Updated `get_cached_events()` with three paths:
  - **Unchanged file** (`file_id` match): cache hit, O(1)
  - **Append-only growth** (`new_size > end_offset`): incremental parse, O(new events only)
  - **Cold start / truncation / same-size rewrite**: full reparse from offset 0
- Updated `get_all_sessions()` to check `_EVENTS_CACHE` for incremental path

| Scenario | Before | After |
|---|---|---|
| 10k-event session, 5 new events | O(10,000) | O(5) |
| Cold start | O(N) | O(N) |
| Unchanged file | O(1) | O(1) |

## Bugs fixed from #736 review

1. **Same-size rewrite**: strict `>` guard prevents stale cache on in-place rewrites
2. **Same bug in get_all_sessions**: same fix applied
3. **UnicodeDecodeError offset**: logs accurate byte boundary, not misleading position

## Tests

- 9 new tests: `TestParseEventsFromOffset` (5) + `TestIncrementalEventsCaching` (4)
- 15 existing test spies updated from `parse_events` to `_parse_events_from_offset`
- All 1447 tests pass, 99% coverage, pyright clean