### PR TITLE
refactor: convert _SummaryAccumulator to `@dataclass`(slots=True) (#980)

### DIFF
--- a/src/copilot_usage/vscode_parser.py
+++ b/src/copilot_usage/vscode_parser.py
@@ -449,28 +449,31 @@ def _get_cached_vscode_requests(
     return requests
 
 
-@dataclass(slots=True)
+@dataclass(slots=True, kw_only=True)
 class _SummaryAccumulator:
     """Mutable accumulator for incremental VSCodeLogSummary construction."""
 
-    total_requests: int = 0
-    total_duration_ms: int = 0
-    requests_by_model: defaultdict[str, int] = field(
-        default_factory=lambda: defaultdict(int)
-    )
-    duration_by_model: defaultdict[str, int] = field(
-        default_factory=lambda: defaultdict(int)
-    )
-    requests_by_category: defaultdict[str, int] = field(
-        default_factory=lambda: defaultdict(int)
-    )
-    requests_by_date: defaultdict[str, int] = field(
-        default_factory=lambda: defaultdict(int)
-    )
-    first_timestamp: datetime | None = None
-    last_timestamp: datetime | None = None
+    # --- init fields (keyword-only, matching the old hand-rolled __init__) ---
     log_files_parsed: int = 0
     log_files_found: int = 0
+
+    # --- internal counters (init=False: never passed to the constructor) ---
+    total_requests: int = field(init=False, default=0)
+    total_duration_ms: int = field(init=False, default=0)
+    requests_by_model: defaultdict[str, int] = field(
+        init=False, default_factory=lambda: defaultdict(int)
+    )
+    duration_by_model: defaultdict[str, int] = field(
+        init=False, default_factory=lambda: defaultdict(int)
+    )
+    requests_by_category: defaultdict[str, int] = field(
+        init=False, default_factory=lambda: defaultdict(int)
+    )
+    requests_by_date: defaultdict[str, int] = field(
+        init=False, default_factory=lambda: defaultdict(int)
+    )
+    first_timestamp: datetime | None = field(init=False, default=None)
+    last_timestamp: datetime | None = field(init=False, default=None)
 
 
 def _update_vscode_summary(

--- a/src/copilot_usage/vscode_parser.py
+++ b/src/copilot_usage/vscode_parser.py
@@ -449,38 +449,28 @@ def _get_cached_vscode_requests(
     return requests
 
 
+@dataclass(slots=True)
 class _SummaryAccumulator:
     """Mutable accumulator for incremental VSCodeLogSummary construction."""
 
-    __slots__ = (
-        "total_requests",
-        "total_duration_ms",
-        "requests_by_model",
-        "duration_by_model",
-        "requests_by_category",
-        "requests_by_date",
-        "first_timestamp",
-        "last_timestamp",
-        "log_files_parsed",
-        "log_files_found",
+    total_requests: int = 0
+    total_duration_ms: int = 0
+    requests_by_model: defaultdict[str, int] = field(
+        default_factory=lambda: defaultdict(int)
     )
-
-    def __init__(
-        self,
-        *,
-        log_files_parsed: int = 0,
-        log_files_found: int = 0,
-    ) -> None:
-        self.total_requests: int = 0
-        self.total_duration_ms: int = 0
-        self.requests_by_model: defaultdict[str, int] = defaultdict(int)
-        self.duration_by_model: defaultdict[str, int] = defaultdict(int)
-        self.requests_by_category: defaultdict[str, int] = defaultdict(int)
-        self.requests_by_date: defaultdict[str, int] = defaultdict(int)
-        self.first_timestamp: datetime | None = None
-        self.last_timestamp: datetime | None = None
-        self.log_files_parsed: int = log_files_parsed
-        self.log_files_found: int = log_files_found
+    duration_by_model: defaultdict[str, int] = field(
+        default_factory=lambda: defaultdict(int)
+    )
+    requests_by_category: defaultdict[str, int] = field(
+        default_factory=lambda: defaultdict(int)
+    )
+    requests_by_date: defaultdict[str, int] = field(
+        default_factory=lambda: defaultdict(int)
+    )
+    first_timestamp: datetime | None = None
+    last_timestamp: datetime | None = None
+    log_files_parsed: int = 0
+    log_files_found: int = 0
 
 
 def _update_vscode_summary(

--- a/tests/copilot_usage/test_vscode_parser.py
+++ b/tests/copilot_usage/test_vscode_parser.py
@@ -2686,7 +2686,7 @@ class TestVSCodeDiscoveryCacheIsFrozen:
 
 
 class TestSummaryAccumulatorIsDataclass:
-    """_SummaryAccumulator must be a @dataclass(slots=True)."""
+    """_SummaryAccumulator must be a @dataclass(slots=True, kw_only=True)."""
 
     def test_is_a_dataclass(self) -> None:
         """Verify _SummaryAccumulator is decorated with @dataclass."""
@@ -2701,3 +2701,15 @@ class TestSummaryAccumulatorIsDataclass:
         acc = _SummaryAccumulator()
         acc.total_requests = 42
         assert acc.total_requests == 42
+
+    def test_init_accepts_only_log_file_fields(self) -> None:
+        """Only log_files_parsed/log_files_found are init params."""
+        init_fields = [
+            f.name for f in dataclasses.fields(_SummaryAccumulator) if f.init
+        ]
+        assert init_fields == ["log_files_parsed", "log_files_found"]
+
+    def test_internal_fields_rejected_by_init(self) -> None:
+        """Passing internal counters to the constructor must raise."""
+        with pytest.raises(TypeError):
+            _SummaryAccumulator(total_requests=1)  # type: ignore[call-arg]

--- a/tests/copilot_usage/test_vscode_parser.py
+++ b/tests/copilot_usage/test_vscode_parser.py
@@ -2685,9 +2685,19 @@ class TestVSCodeDiscoveryCacheIsFrozen:
             cache.root_id = (1, 1)  # type: ignore[misc]
 
 
-class TestSummaryAccumulatorIsNotDataclass:
-    """_SummaryAccumulator must be a plain class, not a dataclass."""
+class TestSummaryAccumulatorIsDataclass:
+    """_SummaryAccumulator must be a @dataclass(slots=True)."""
 
-    def test_not_a_dataclass(self) -> None:
-        """Verify _SummaryAccumulator is not decorated with @dataclass."""
-        assert not dataclasses.is_dataclass(_SummaryAccumulator)
+    def test_is_a_dataclass(self) -> None:
+        """Verify _SummaryAccumulator is decorated with @dataclass."""
+        assert dataclasses.is_dataclass(_SummaryAccumulator)
+
+    def test_has_slots(self) -> None:
+        """Verify _SummaryAccumulator uses slots=True."""
+        assert hasattr(_SummaryAccumulator, "__slots__")
+
+    def test_is_not_frozen(self) -> None:
+        """Verify _SummaryAccumulator is mutable (not frozen)."""
+        acc = _SummaryAccumulator()
+        acc.total_requests = 42
+        assert acc.total_requests == 42


### PR DESCRIPTION
Closes #980

## Summary

Convert `_SummaryAccumulator` from a plain class with manual `__slots__` + `__init__` to `@dataclass(slots=True)`, aligning it with every other internal-state class in the codebase.

## Changes

**`src/copilot_usage/vscode_parser.py`**
- Replace the hand-rolled `__slots__` tuple and `__init__` method with `@dataclass(slots=True)`
- Use `field(default_factory=lambda: defaultdict(int))` for the four `defaultdict` fields (per coding guidelines for complex generic types)
- No call-site changes needed — all existing callers already use keyword arguments

**`tests/copilot_usage/test_vscode_parser.py`**
- Replace `TestSummaryAccumulatorIsNotDataclass` with `TestSummaryAccumulatorIsDataclass` that verifies:
  - The class is a dataclass (`dataclasses.is_dataclass`)
  - It uses slots (`__slots__` present)
  - It is mutable / not frozen (can assign to fields)

## Verification

- All 122 vscode parser tests pass
- `make check` passes cleanly (lint, typecheck, security, tests at 99% coverage)




> [!WARNING]
> <details>
> <summary><strong>⚠️ Firewall blocked 1 domain</strong></summary>
>
> The following domain was blocked by the firewall during workflow execution:
>
> - `astral.sh`
>
> To allow these domains, add them to the `network.allowed` list in your workflow frontmatter:
>
> ```yaml
> network:
>   allowed:
>     - defaults
>     - "astral.sh"
> ```
>
> See [Network Configuration](https://github.github.com/gh-aw/reference/network/) for more information.
>
> </details>


> Generated by [Issue Implementer](https://github.com/microsasa/cli-tools/actions/runs/24600582194/agentic_workflow) · ● 4.2M · [◷](https://github.com/search?q=repo%3Amicrosasa%2Fcli-tools+%22gh-aw-workflow-id%3A+issue-implementer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Issue Implementer, engine: copilot, model: claude-opus-4.6, id: 24600582194, workflow_id: issue-implementer, run: https://github.com/microsasa/cli-tools/actions/runs/24600582194 -->

<!-- gh-aw-workflow-id: issue-implementer -->