### PR TITLE
fix: show "—" instead of "0" in Requests/Premium Cost for pure-active sessions (#981)

### DIFF
--- a/src/copilot_usage/report.py
+++ b/src/copilot_usage/report.py
@@ -681,19 +681,25 @@ def render_cost_view(
 
         session_output = 0
         if s.model_metrics:
+            # Pure-active sessions (still running, no prior shutdown) have
+            # synthetic zeros in requests/cost — display "—" instead.
+            show_requests = s.has_shutdown_metrics or not s.is_active
             for model_name in sorted(s.model_metrics):
                 mm = s.model_metrics[model_name]
                 session_output += mm.usage.outputTokens
+                requests_display = str(mm.requests.count) if show_requests else "—"
+                premium_display = str(mm.requests.cost) if show_requests else "—"
                 table.add_row(
                     name,
                     model_name,
-                    str(mm.requests.count),
-                    str(mm.requests.cost),
+                    requests_display,
+                    premium_display,
                     model_calls_display,
                     format_tokens(mm.usage.outputTokens),
                 )
-                grand_requests += mm.requests.count
-                grand_premium += mm.requests.cost
+                if show_requests:
+                    grand_requests += mm.requests.count
+                    grand_premium += mm.requests.cost
                 # Only show session-level info once
                 name = ""
                 model_calls_display = ""

--- a/tests/copilot_usage/test_report.py
+++ b/tests/copilot_usage/test_report.py
@@ -2713,6 +2713,35 @@ class TestRenderCostViewPureActiveNoShutdownRow:
         assert "Pure Active" in output
         assert "Since last shutdown" not in output
 
+    def test_pure_active_with_known_model_shows_dash_for_requests(self) -> None:
+        """Pure-active session (has_shutdown_metrics=False) with a known model
+        must show '—' in Requests and Premium Cost columns, not '0'."""
+        session = SessionSummary(
+            session_id="pure-active-with-model",
+            model="claude-sonnet-4",
+            start_time=datetime(2025, 1, 15, 10, 0, tzinfo=UTC),
+            is_active=True,
+            has_shutdown_metrics=False,
+            model_calls=5,
+            active_model_calls=5,
+            active_output_tokens=1200,
+            # model_metrics populated synthetically (as _build_active_summary does)
+            model_metrics={
+                "claude-sonnet-4": ModelMetrics(
+                    requests=RequestMetrics(count=0, cost=0),
+                    usage=TokenUsage(outputTokens=1200),
+                )
+            },
+        )
+        output = _capture_cost_view([session])
+        clean = re.sub(r"\x1b\[[0-9;]*m", "", output)
+        # Must not show "0" in Requests/Premium Cost columns
+        lines = [ln for ln in clean.splitlines() if "claude-sonnet-4" in ln]
+        assert lines, "Expected a per-model row"
+        cols = [c.strip() for c in lines[0].split("│")]
+        assert cols[3] == "—", f"Requests column should be '—', got '{cols[3]}'"
+        assert cols[4] == "—", f"Premium Cost column should be '—', got '{cols[4]}'"
+
     def test_resumed_session_shows_shutdown_row(self) -> None:
         """Resumed session (has_shutdown_metrics=True) must render
         the '↳ Since last shutdown' sub-row."""


### PR DESCRIPTION
Closes #981

## Problem

`render_cost_view` displayed `0` in the **Requests** and **Premium Cost** columns for pure-active sessions (still running, no prior shutdown) when a model name was known. These zeros came from `_build_active_summary`'s default `RequestMetrics(count=0, cost=0)`, not from real shutdown data — misleading users into thinking the session was tracked and found to have zero requests.

Meanwhile, pure-active sessions with an *unknown* model correctly showed `—` via the `else` branch.

## Fix

Added a `show_requests` guard (`s.has_shutdown_metrics or not s.is_active`) in the per-model row loop of `render_cost_view`:

- When `False` (pure-active session), renders `—` for Requests and Premium Cost
- Grand-total accumulation also skips synthetic zeros for these sessions

## Testing

Added `test_pure_active_with_known_model_shows_dash_for_requests` in `TestRenderCostViewPureActiveNoShutdownRow` — verifies that a pure-active session with `model_metrics` populated synthetically shows `—` (not `0`) in the Requests and Premium Cost columns.

All existing tests pass with 99% coverage.




> Generated by [Issue Implementer](https://github.com/microsasa/cli-tools/actions/runs/24600888430/agentic_workflow) · ● 6.3M · [◷](https://github.com/search?q=repo%3Amicrosasa%2Fcli-tools+%22gh-aw-workflow-id%3A+issue-implementer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Issue Implementer, engine: copilot, model: claude-opus-4.6, id: 24600888430, workflow_id: issue-implementer, run: https://github.com/microsasa/cli-tools/actions/runs/24600888430 -->

<!-- gh-aw-workflow-id: issue-implementer -->