### PR TITLE
fix: prevent plan-only fast path from leaking cache reference (#984)

### DIFF
--- a/src/copilot_usage/parser.py
+++ b/src/copilot_usage/parser.py
@@ -161,7 +161,7 @@ class _SortedSessionsCache:
 
     root: Path
     fingerprint: frozenset[tuple[Path, tuple[int, int] | None]]
-    summaries: list[SessionSummary]
+    summaries: tuple[SessionSummary, ...]
 
 
 def _build_fingerprint(
@@ -1199,9 +1199,9 @@ def get_all_sessions(base_path: Path | None = None) -> list[SessionSummary]:
             for s in _sorted_sessions_cache.summaries
         ]
         _sorted_sessions_cache = _SortedSessionsCache(
-            resolved_root, _sorted_sessions_cache.fingerprint, new_sorted
+            resolved_root, _sorted_sessions_cache.fingerprint, tuple(new_sorted)
         )
-        return new_sorted
+        return list(new_sorted)
 
     # Fingerprint fallback: when the discovery cache missed but the
     # discovered session set is identical, skip the O(n log n) sort.
@@ -1215,6 +1215,6 @@ def get_all_sessions(base_path: Path | None = None) -> list[SessionSummary]:
 
     summaries.sort(key=session_sort_key, reverse=True)
     _sorted_sessions_cache = _SortedSessionsCache(
-        resolved_root, current_fingerprint, list(summaries)
+        resolved_root, current_fingerprint, tuple(summaries)
     )
     return summaries

--- a/src/copilot_usage/parser.py
+++ b/src/copilot_usage/parser.py
@@ -1201,7 +1201,7 @@ def get_all_sessions(base_path: Path | None = None) -> list[SessionSummary]:
         _sorted_sessions_cache = _SortedSessionsCache(
             resolved_root, _sorted_sessions_cache.fingerprint, tuple(new_sorted)
         )
-        return list(new_sorted)
+        return new_sorted
 
     # Fingerprint fallback: when the discovery cache missed but the
     # discovered session set is identical, skip the O(n log n) sort.

--- a/tests/copilot_usage/test_parser.py
+++ b/tests/copilot_usage/test_parser.py
@@ -2884,17 +2884,29 @@ class TestGetAllSessions:
         plan = tmp_path / "a" / "plan.md"
         _write_events(s1, _START_EVENT, _USER_MSG, _ASSISTANT_MSG)
         plan.write_text("# Initial plan\n", encoding="utf-8")
+        initial_plan_identity = safe_file_identity(plan)
 
         # First call: primes the cache (normal sort path).
         first = get_all_sessions(tmp_path)
         assert len(first) == 1
+        first_name = first[0].name
 
         # Change plan.md so the second call hits the plan-only fast path.
-        plan.write_text("# Updated plan\n", encoding="utf-8")
+        # Use different-sized content and explicitly bump mtime so the file
+        # identity changes even on filesystems with coarse timestamp resolution.
+        plan.write_text("# Updated plan with more detail\n", encoding="utf-8")
+        plan_stat = plan.stat()
+        os.utime(
+            plan,
+            ns=(plan_stat.st_atime_ns, max(time.time_ns(), plan_stat.st_mtime_ns + 1)),
+        )
+        assert safe_file_identity(plan) != initial_plan_identity
 
         # Second call: exercises the plan-only fast path.
         second = get_all_sessions(tmp_path)
         assert len(second) == 1
+        second_name = second[0].name
+        assert second_name != first_name
 
         # Mutate the returned list — must not affect the cache.
         second.pop()

--- a/tests/copilot_usage/test_parser.py
+++ b/tests/copilot_usage/test_parser.py
@@ -2873,6 +2873,37 @@ class TestGetAllSessions:
         returned_paths = {s.events_path for s in result}
         assert returned_paths == {s1, s2}
 
+    def test_plan_only_path_does_not_leak_cache_reference(self, tmp_path: Path) -> None:
+        """Mutating the list returned by the plan-only fast path must not corrupt the cache.
+
+        Regression test for issue #984: the plan-only fast path previously
+        returned the same list object stored in ``_SortedSessionsCache``,
+        allowing callers to silently corrupt the cached sort order.
+        """
+        s1 = tmp_path / "a" / "events.jsonl"
+        plan = tmp_path / "a" / "plan.md"
+        _write_events(s1, _START_EVENT, _USER_MSG, _ASSISTANT_MSG)
+        plan.write_text("# Initial plan\n", encoding="utf-8")
+
+        # First call: primes the cache (normal sort path).
+        first = get_all_sessions(tmp_path)
+        assert len(first) == 1
+
+        # Change plan.md so the second call hits the plan-only fast path.
+        plan.write_text("# Updated plan\n", encoding="utf-8")
+
+        # Second call: exercises the plan-only fast path.
+        second = get_all_sessions(tmp_path)
+        assert len(second) == 1
+
+        # Mutate the returned list — must not affect the cache.
+        second.pop()
+        assert len(second) == 0
+
+        # Third call: should still return the correct result from cache.
+        third = get_all_sessions(tmp_path)
+        assert len(third) == 1
+
 
 # ---------------------------------------------------------------------------
 # Real data smoke test (against ~/.copilot/session-state/)
@@ -9425,7 +9456,7 @@ class TestSortedSessionsCacheIsFrozen:
         cache = _SortedSessionsCache(
             root=Path("sessions"),
             fingerprint=frozenset(),
-            summaries=[],
+            summaries=(),
         )
         with pytest.raises(dataclasses.FrozenInstanceError):
             cache.root = Path("/other")  # type: ignore[misc]


### PR DESCRIPTION
Closes #984

## Summary

The plan-only fast path in `get_all_sessions` returned the same `list` object stored in `_SortedSessionsCache.summaries`, breaking the copy-on-return contract. If a caller mutated the returned list, it would silently corrupt the cache.

## Changes

### `src/copilot_usage/parser.py`
- Changed `_SortedSessionsCache.summaries` from `list[SessionSummary]` to `tuple[SessionSummary, ...]` — enforces immutability at the type level, matching the pattern used by `_CachedEvents.events` and `_VSCodeDiscoveryCache.log_paths`
- Plan-only fast path now stores `tuple(new_sorted)` in the cache and returns `list(new_sorted)`
- Normal sort path now stores `tuple(summaries)` instead of `list(summaries)`

### `tests/copilot_usage/test_parser.py`
- Added `test_plan_only_path_does_not_leak_cache_reference` regression test that:
  1. Primes the cache with an initial call
  2. Changes `plan.md` to trigger the plan-only fast path
  3. Mutates the returned list (`pop()`)
  4. Verifies a subsequent call returns the correct (uncorrupted) result
- Fixed existing test that constructed `_SortedSessionsCache` with `[]` → `()` to match the new type




> Generated by [Issue Implementer](https://github.com/microsasa/cli-tools/actions/runs/24607426652/agentic_workflow) · ● 7.2M · [◷](https://github.com/search?q=repo%3Amicrosasa%2Fcli-tools+%22gh-aw-workflow-id%3A+issue-implementer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Issue Implementer, engine: copilot, model: claude-opus-4.6, id: 24607426652, workflow_id: issue-implementer, run: https://github.com/microsasa/cli-tools/actions/runs/24607426652 -->

<!-- gh-aw-workflow-id: issue-implementer -->