### PR TITLE
fix: guard `active_user_messages`/`active_output_tokens` in `_build_completed_summary` (#992)

### DIFF
--- a/src/copilot_usage/parser.py
+++ b/src/copilot_usage/parser.py
@@ -957,8 +957,12 @@ def _build_completed_summary(
         active_model_calls=(
             resume.post_shutdown_turn_starts if resume.session_resumed else 0
         ),
-        active_user_messages=resume.post_shutdown_user_messages,
-        active_output_tokens=resume.post_shutdown_output_tokens,
+        active_user_messages=(
+            resume.post_shutdown_user_messages if resume.session_resumed else 0
+        ),
+        active_output_tokens=(
+            resume.post_shutdown_output_tokens if resume.session_resumed else 0
+        ),
         shutdown_cycles=shutdown_cycles,
         events_path=events_path,
     )

--- a/tests/copilot_usage/test_parser.py
+++ b/tests/copilot_usage/test_parser.py
@@ -6470,6 +6470,34 @@ class TestResumeDetectionDirect:
         assert fp.last_resume_time is None
         assert fp.post_shutdown_user_messages == 1
 
+    def test_completed_session_zeroes_active_counters_despite_post_shutdown_values(
+        self, tmp_path: Path
+    ) -> None:
+        """_build_completed_summary must zero active counters when session_resumed=False."""
+        from copilot_usage.models import has_active_period_stats
+
+        p = tmp_path / "s" / "events.jsonl"
+        _write_events(p, _START_EVENT, _USER_MSG, _SHUTDOWN_EVENT)
+        events = parse_events(p)
+        fp = _first_pass(events)
+
+        # Manually construct a _ResumeInfo with session_resumed=False but
+        # non-zero post-shutdown counters — the invariant violation scenario.
+        resume = _ResumeInfo(
+            session_resumed=False,
+            post_shutdown_output_tokens=500,
+            post_shutdown_turn_starts=3,
+            post_shutdown_user_messages=2,
+            last_resume_time=None,
+        )
+        summary = _build_completed_summary(fp, name=None, resume=resume, events=events)
+
+        assert summary.is_active is False
+        assert summary.active_model_calls == 0  # already guarded
+        assert summary.active_user_messages == 0  # must be 0 regardless
+        assert summary.active_output_tokens == 0  # must be 0 regardless
+        assert not has_active_period_stats(summary)
+
 
 # ---------------------------------------------------------------------------
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #992

## Problem

In `_build_completed_summary`, `active_model_calls` has an explicit `if resume.session_resumed else 0` guard, but `active_user_messages` and `active_output_tokens` rely on an **implicit invariant** — that `_first_pass` never increments these counters without also setting `session_resumed=True`. A future refactor could break this invariant, causing double-counted tokens, spurious "↳ Since last shutdown" rows, and incorrect `has_active_period_stats()` results.

## Fix

Apply the same guard consistently to all three active-period counters:

```python
active_user_messages=(
    resume.post_shutdown_user_messages if resume.session_resumed else 0
),
active_output_tokens=(
    resume.post_shutdown_output_tokens if resume.session_resumed else 0
),
```

This is a no-op for current code paths but makes the contract explicit and self-documenting.

## Testing

Added `test_completed_session_zeroes_active_counters_despite_post_shutdown_values` to `TestResumeDetectionDirect` — constructs a synthetic `_ResumeInfo` with `session_resumed=False` but non-zero post-shutdown counters and verifies the built summary zeros them out. Without the fix, this test fails.




> Generated by [Issue Implementer](https://github.com/microsasa/cli-tools/actions/runs/24621665151/agentic_workflow) · ● 6.1M · [◷](https://github.com/search?q=repo%3Amicrosasa%2Fcli-tools+%22gh-aw-workflow-id%3A+issue-implementer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Issue Implementer, engine: copilot, model: claude-opus-4.6, id: 24621665151, workflow_id: issue-implementer, run: https://github.com/microsasa/cli-tools/actions/runs/24621665151 -->

<!-- gh-aw-workflow-id: issue-implementer -->