### PR TITLE
fix: guard parse_token_int against IEEE 754 special floats (#875)

### DIFF
--- a/src/copilot_usage/models.py
+++ b/src/copilot_usage/models.py
@@ -6,6 +6,7 @@ flexible fallback for unknown ones.
 """
 
 import builtins
+import math
 from datetime import UTC, datetime
 from enum import StrEnum
 from pathlib import Path
@@ -220,6 +221,7 @@ def parse_token_int(raw: object) -> int | None:
     Rules:
 
     - ``bool`` / ``str`` → ``None`` (invalid, not coerced)
+    - IEEE 754 special ``float`` (``inf``, ``-inf``, ``nan``) → ``None``
     - non-whole ``float`` → ``None``
     - zero or negative ``int`` / ``float`` → ``None``
     - positive whole-number ``float`` → coerced to ``int``
@@ -229,6 +231,8 @@ def parse_token_int(raw: object) -> int | None:
     if isinstance(raw, (bool, str)):
         return None
     if isinstance(raw, float):
+        if not math.isfinite(raw):
+            return None
         if not raw.is_integer():
             return None
         tokens = int(raw)

--- a/tests/copilot_usage/test_parser.py
+++ b/tests/copilot_usage/test_parser.py
@@ -4948,6 +4948,11 @@ class TestExtractOutputTokens:
         )
         assert _extract_output_tokens(ev) is None
 
+    @pytest.mark.parametrize("special", [float("inf"), float("nan"), float("-inf")])
+    def test_returns_none_for_ieee_special_floats(self, special: float) -> None:
+        """IEEE 754 special floats (inf, nan, -inf) are not valid token counts."""
+        assert _extract_output_tokens(_make_assistant_event(special)) is None
+
 
 _EXTRACT_TOKENS_CASES: list[tuple[str, object, int | None]] = [
     ("valid_int", 42, 42),
@@ -5021,6 +5026,9 @@ _EQUIVALENCE_CASES: list[tuple[str, object]] = [
     ("large_positive_int", 1234),
     ("whole_float", 1234.0),
     ("fractional_float", 3.14),
+    ("float_inf", float("inf")),
+    ("float_neg_inf", float("-inf")),
+    ("float_nan", float("nan")),
 ]
 
 


### PR DESCRIPTION
Closes #875

## Problem

`parse_token_int` in `models.py` only rejected `float('inf')` and `float('nan')` incidentally — `float.is_integer()` happens to return `False` for both, but this was undocumented and fragile. The issue requested an explicit guard so the contract is clear and future refactors don't silently regress.

## Changes

### Validator fix (`src/copilot_usage/models.py`)
- Added `import math` and an explicit `math.isfinite(raw)` guard in `parse_token_int` **before** the `is_integer()` check
- Updated the docstring to document the IEEE 754 special float → `None` rule

### Tests (`tests/copilot_usage/test_parser.py`)
- Added parametrized `test_returns_none_for_ieee_special_floats` to `TestExtractOutputTokens` covering `inf`, `nan`, `-inf`
- Extended `_EQUIVALENCE_CASES` with `float('inf')`, `float('-inf')`, and `float('nan')` so the cross-check between `_extract_output_tokens` and `AssistantMessageData` covers these values

### Pre-existing tests
- `test_models.py::TestSanitizeNonNumericTokens::test_special_float_maps_to_zero` already existed and continues to pass

## Verification

`make check V=1` passes: lint ✅, pyright ✅, bandit ✅, unit tests (99% coverage) ✅, e2e tests ✅




> Generated by [Issue Implementer](https://github.com/microsasa/cli-tools/actions/runs/24623916475/agentic_workflow) · ● 10.5M · [◷](https://github.com/search?q=repo%3Amicrosasa%2Fcli-tools+%22gh-aw-workflow-id%3A+issue-implementer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Issue Implementer, engine: copilot, model: claude-opus-4.6, id: 24623916475, workflow_id: issue-implementer, run: https://github.com/microsasa/cli-tools/actions/runs/24623916475 -->

<!-- gh-aw-workflow-id: issue-implementer -->