### PR TITLE
refactor: extract interactive mode helpers from cli.py (#925)

### DIFF
--- a/src/copilot_usage/cli.py
+++ b/src/copilot_usage/cli.py
@@ -7,19 +7,28 @@ plus an interactive Rich-based session when invoked without a subcommand.
 import select
 import sys
 import threading
-import time
 from dataclasses import dataclass
 from datetime import datetime, time as dt_time
 from pathlib import Path
-from typing import Final, Literal, Protocol, cast
+from typing import Final, Literal
 
 import click
 from loguru import logger
 from rich.console import Console
-from rich.table import Table
-from rich.text import Text
 
 from copilot_usage import __version__
+from copilot_usage.interactive import (
+    FileChangeEventHandler as _FileChangeEventHandler,  # noqa: F401  # pyright: ignore[reportUnusedImport]
+    FileChangeHandler as _FileChangeHandler,  # noqa: F401  # pyright: ignore[reportUnusedImport]
+    Stoppable as _Stoppable,  # noqa: F401  # pyright: ignore[reportUnusedImport]
+    build_session_index as _build_session_index,
+    draw_home as _draw_home,
+    print_version_header as _print_version_header,
+    render_session_list as _render_session_list,  # noqa: F401  # pyright: ignore[reportUnusedImport]
+    start_observer as _start_observer,
+    stop_observer as _stop_observer,
+    write_prompt as _write_prompt,
+)
 from copilot_usage.logging_config import setup_logging
 from copilot_usage.models import SessionSummary, ensure_aware, ensure_aware_opt
 from copilot_usage.parser import (
@@ -29,11 +38,9 @@ from copilot_usage.parser import (
 )
 from copilot_usage.report import (
     render_cost_view,
-    render_full_summary,
     render_live_sessions,
     render_session_detail,
     render_summary,
-    session_display_name,
 )
 
 type _View = Literal["home", "detail", "cost"]
@@ -45,10 +52,6 @@ _FORMAT_SPECS: Final[list[tuple[str, bool]]] = [
 ]
 
 _DATE_FORMATS: Final[list[str]] = [fmt for fmt, _ in _FORMAT_SPECS]
-
-_WATCHDOG_DEBOUNCE_SECS: Final[float] = (
-    2.0  # Prevents rapid redraws during tool-use bursts
-)
 
 
 @dataclass(frozen=True, slots=True)
@@ -143,18 +146,6 @@ def _validate_since_until(
     return aware_since, aware_until
 
 
-def _print_version_header(target: Console | None = None) -> None:
-    """Print 'Copilot Usage' left-aligned with version right-aligned."""
-    c = target or console
-    title = "Copilot Usage"
-    version_text = f"v{__version__}"
-    header = Text()
-    header.append(title, style="bold")
-    header.append(" " * max(1, c.width - len(title) - len(version_text)))
-    header.append(version_text, style="dim")
-    c.print(header)
-
-
 # ---------------------------------------------------------------------------
 # Interactive mode helpers
 # ---------------------------------------------------------------------------
@@ -163,23 +154,6 @@ _HOME_PROMPT: Final[str] = (
     "\nEnter session # for detail, [c] cost, [r] refresh, [q] quit: "
 )
 _BACK_PROMPT: Final[str] = "\nPress Enter to go back... "
-
-
-def _render_session_list(console: Console, sessions: list[SessionSummary]) -> None:
-    """Print a numbered list of sessions for interactive selection."""
-    table = Table(title="Sessions", border_style="cyan")
-    table.add_column("#", style="bold cyan", justify="right", width=4)
-    table.add_column("Name", style="bold", max_width=40)
-    table.add_column("Model")
-    table.add_column("Status")
-
-    for idx, s in enumerate(sessions, start=1):
-        name = session_display_name(s)
-        model = s.model or "—"
-        status = "🟢 Active" if s.is_active else "Completed"
-        table.add_row(str(idx), name, model, status)
-
-    console.print(table)
 
 
 def _show_session_by_index(
@@ -206,21 +180,6 @@ def _show_session_by_index(
     render_session_detail(events, s, target_console=console)
 
 
-def _draw_home(console: Console, sessions: list[SessionSummary]) -> None:
-    """Clear screen and render the home view."""
-    console.clear()
-    _print_version_header(console)
-    render_full_summary(sessions, target_console=console)
-    console.print()
-    _render_session_list(console, sessions)
-
-
-def _write_prompt(prompt: str) -> None:
-    """Write prompt to stdout without a newline wait."""
-    sys.stdout.write(prompt)
-    sys.stdout.flush()
-
-
 def _read_line_nonblocking(timeout: float = 0.5) -> str | None:
     """Return a line from stdin if available within *timeout*, else None.
 
@@ -234,88 +193,6 @@ def _read_line_nonblocking(timeout: float = 0.5) -> str | None:
             raise EOFError("stdin closed")
         return line.strip()
     return None
-
-
-class _FileChangeEventHandler(Protocol):
-    """Protocol for minimal filesystem event handlers used with watchdog."""
-
-    def dispatch(self, event: object) -> None:
-        """Handle a filesystem event."""
-
-
-class _FileChangeHandler:
-    """Watchdog-compatible handler that triggers refresh on session-state changes.
-
-    Implements the :class:`_FileChangeEventHandler` ``dispatch(event)``
-    Protocol expected by watchdog observers, without importing the heavy
-    ``watchdog`` package at module level.
-    """
-
-    def __init__(self, change_event: threading.Event) -> None:
-        self._change_event = change_event
-        self._last_trigger = 0.0
-        self._lock = threading.Lock()
-
-    def dispatch(self, event: object) -> None:
-        now = time.monotonic()
-        with self._lock:
-            if now - self._last_trigger <= _WATCHDOG_DEBOUNCE_SECS:
-                return
-            self._last_trigger = now
-        self._change_event.set()
-
-
-class _Stoppable(Protocol):
-    """Minimal interface for a watchdog-style observer."""
-
-    def stop(self) -> None: ...
-    def join(self, timeout: float | None = None) -> None: ...
-    def is_alive(self) -> bool: ...
-
-
-def _start_observer(
-    session_path: Path, change_event: threading.Event
-) -> _Stoppable | None:
-    """Start a watchdog observer monitoring *session_path* for changes.
-
-    Returns ``None`` when the observer cannot be started (e.g. inotify
-    watch limit exhausted, unsupported filesystem). The caller should
-    treat a ``None`` return as "auto-refresh unavailable" and continue
-    without it.
-    """
-    from watchdog.observers import Observer
-
-    handler: _FileChangeEventHandler = _FileChangeHandler(change_event)
-    observer = Observer()
-    observer.schedule(handler, str(session_path), recursive=True)  # pyright: ignore[reportArgumentType]
-    observer.daemon = True
-    try:
-        observer.start()
-    except (OSError, RuntimeError) as exc:
-        logger.warning("File watcher unavailable (auto-refresh disabled): {}", exc)
-        # Best-effort cleanup in case the observer partially started
-        try:
-            if observer.is_alive():
-                observer.stop()
-                observer.join(timeout=2)
-        except (OSError, RuntimeError) as cleanup_exc:
-            logger.opt(exception=cleanup_exc).debug(
-                "Failed to clean up file watcher after start failure"
-            )
-        return None
-    return cast(_Stoppable, observer)
-
-
-def _stop_observer(observer: _Stoppable | None) -> None:
-    """Stop a watchdog observer if running."""
-    if observer is not None:
-        observer.stop()
-        observer.join(timeout=2)
-
-
-def _build_session_index(sessions: list[SessionSummary]) -> dict[str, int]:
-    """Return a mapping from session_id to list index for O(1) lookup."""
-    return {s.session_id: i for i, s in enumerate(sessions)}
 
 
 def _interactive_loop(path: Path | None) -> None:

--- a/src/copilot_usage/docs/architecture.md
+++ b/src/copilot_usage/docs/architecture.md
@@ -33,7 +33,8 @@ Monorepo containing Python CLI utilities that share tooling, CI, and common depe
 
 | Module | Responsibility |
 |--------|---------------|
-| `cli.py` | Click command group — routes commands to parser/report functions, handles CLI options, error display. Also contains the interactive loop (invoked when no subcommand is given) with watchdog-based auto-refresh (2-second debounce). |
+| `cli.py` | Click command group — routes commands to parser/report functions, handles CLI options, error display. Contains the interactive loop (invoked when no subcommand is given) which uses helpers from `interactive.py`. |
+| `interactive.py` | Interactive-mode UI helpers — session list rendering, file-watching (watchdog with 2-second debounce), version header, and session index building. Extracted from `cli.py` to separate interactive concerns from CLI routing. |
 | `parser.py` | Discovers sessions, reads events.jsonl line by line, builds SessionSummary per session via focused helpers: `_first_pass()` (extract identity/shutdowns/counters/post-shutdown resume data in a single pass), `_build_completed_summary()`, `_build_active_summary()`. |
 | `models.py` | Pydantic v2 models for all event types + SessionSummary aggregate (includes model_calls and user_messages fields). Runtime validation at parse boundary. |
 | `report.py` | Rich-formatted terminal output — summary tables (with Model Calls and User Msgs columns), live view, premium request breakdown. Shows raw counts and `~`-prefixed premium cost estimates for live/active sessions; historical post-shutdown views display exact API-provided numbers. |

--- a/src/copilot_usage/interactive.py
+++ b/src/copilot_usage/interactive.py
@@ -21,7 +21,7 @@ from copilot_usage.report import (
     session_display_name,
 )
 
-__all__: list[str] = []
+__all__: Final[list[str]] = []
 
 WATCHDOG_DEBOUNCE_SECS: Final[float] = (
     2.0  # Prevents rapid redraws during tool-use bursts
@@ -69,7 +69,7 @@ def draw_home(console: Console, sessions: list[SessionSummary]) -> None:
 
 
 def write_prompt(prompt: str) -> None:
-    """Write prompt to stdout without a newline wait."""
+    """Write the prompt to stdout without a trailing newline and flush immediately."""
     import sys
 
     sys.stdout.write(prompt)

--- a/src/copilot_usage/interactive.py
+++ b/src/copilot_usage/interactive.py
@@ -1,0 +1,158 @@
+"""Interactive-mode UI helpers for copilot-usage.
+
+Contains rendering, file-watching, and input helpers used by the
+interactive Rich-based session loop in :mod:`copilot_usage.cli`.
+"""
+
+import threading
+import time
+from pathlib import Path
+from typing import Final, Protocol, cast
+
+from loguru import logger
+from rich.console import Console
+from rich.table import Table
+from rich.text import Text
+
+from copilot_usage import __version__
+from copilot_usage.models import SessionSummary
+from copilot_usage.report import (
+    render_full_summary,
+    session_display_name,
+)
+
+__all__: list[str] = []
+
+WATCHDOG_DEBOUNCE_SECS: Final[float] = (
+    2.0  # Prevents rapid redraws during tool-use bursts
+)
+
+console: Final[Console] = Console()
+
+
+def print_version_header(target: Console | None = None) -> None:
+    """Print 'Copilot Usage' left-aligned with version right-aligned."""
+    c = target or console
+    title = "Copilot Usage"
+    version_text = f"v{__version__}"
+    header = Text()
+    header.append(title, style="bold")
+    header.append(" " * max(1, c.width - len(title) - len(version_text)))
+    header.append(version_text, style="dim")
+    c.print(header)
+
+
+def render_session_list(console: Console, sessions: list[SessionSummary]) -> None:
+    """Print a numbered list of sessions for interactive selection."""
+    table = Table(title="Sessions", border_style="cyan")
+    table.add_column("#", style="bold cyan", justify="right", width=4)
+    table.add_column("Name", style="bold", max_width=40)
+    table.add_column("Model")
+    table.add_column("Status")
+
+    for idx, s in enumerate(sessions, start=1):
+        name = session_display_name(s)
+        model = s.model or "—"
+        status = "🟢 Active" if s.is_active else "Completed"
+        table.add_row(str(idx), name, model, status)
+
+    console.print(table)
+
+
+def draw_home(console: Console, sessions: list[SessionSummary]) -> None:
+    """Clear screen and render the home view."""
+    console.clear()
+    print_version_header(console)
+    render_full_summary(sessions, target_console=console)
+    console.print()
+    render_session_list(console, sessions)
+
+
+def write_prompt(prompt: str) -> None:
+    """Write prompt to stdout without a newline wait."""
+    import sys
+
+    sys.stdout.write(prompt)
+    sys.stdout.flush()
+
+
+class FileChangeEventHandler(Protocol):
+    """Protocol for minimal filesystem event handlers used with watchdog."""
+
+    def dispatch(self, event: object) -> None:
+        """Handle a filesystem event."""
+
+
+class FileChangeHandler:
+    """Watchdog-compatible handler that triggers refresh on session-state changes.
+
+    Implements the :class:`FileChangeEventHandler` ``dispatch(event)``
+    Protocol expected by watchdog observers, without importing the heavy
+    ``watchdog`` package at module level.
+    """
+
+    def __init__(self, change_event: threading.Event) -> None:
+        self._change_event = change_event
+        self._last_trigger = 0.0
+        self._lock = threading.Lock()
+
+    def dispatch(self, event: object) -> None:
+        now = time.monotonic()
+        with self._lock:
+            if now - self._last_trigger <= WATCHDOG_DEBOUNCE_SECS:
+                return
+            self._last_trigger = now
+        self._change_event.set()
+
+
+class Stoppable(Protocol):
+    """Minimal interface for a watchdog-style observer."""
+
+    def stop(self) -> None: ...
+    def join(self, timeout: float | None = None) -> None: ...
+    def is_alive(self) -> bool: ...
+
+
+def start_observer(
+    session_path: Path, change_event: threading.Event
+) -> Stoppable | None:
+    """Start a watchdog observer monitoring *session_path* for changes.
+
+    Returns ``None`` when the observer cannot be started (e.g. inotify
+    watch limit exhausted, unsupported filesystem). The caller should
+    treat a ``None`` return as "auto-refresh unavailable" and continue
+    without it.
+    """
+    from watchdog.observers import Observer
+
+    handler: FileChangeEventHandler = FileChangeHandler(change_event)
+    observer = Observer()
+    observer.schedule(handler, str(session_path), recursive=True)  # pyright: ignore[reportArgumentType]
+    observer.daemon = True
+    try:
+        observer.start()
+    except (OSError, RuntimeError) as exc:
+        logger.warning("File watcher unavailable (auto-refresh disabled): {}", exc)
+        # Best-effort cleanup in case the observer partially started
+        try:
+            if observer.is_alive():
+                observer.stop()
+                observer.join(timeout=2)
+        except (OSError, RuntimeError) as cleanup_exc:
+            logger.opt(exception=cleanup_exc).debug(
+                "Failed to clean up file watcher after start failure"
+            )
+        return None
+    return cast(Stoppable, observer)
+
+
+def stop_observer(observer: Stoppable | None) -> None:
+    """Stop a watchdog observer if running."""
+    if observer is not None:
+        observer.stop()
+        observer.join(timeout=2)
+
+
+def build_session_index(sessions: list[SessionSummary]) -> dict[str, int]:
+    """Return a mapping from session_id to list index for O(1) lookup."""
+    return {s.session_id: i for i, s in enumerate(sessions)}

--- a/src/copilot_usage/interactive.py
+++ b/src/copilot_usage/interactive.py
@@ -21,7 +21,20 @@ from copilot_usage.report import (
     session_display_name,
 )
 
-__all__: Final[list[str]] = []
+__all__: Final[list[str]] = [
+    "WATCHDOG_DEBOUNCE_SECS",
+    "console",
+    "print_version_header",
+    "render_session_list",
+    "draw_home",
+    "write_prompt",
+    "FileChangeEventHandler",
+    "FileChangeHandler",
+    "Stoppable",
+    "start_observer",
+    "stop_observer",
+    "build_session_index",
+]
 
 WATCHDOG_DEBOUNCE_SECS: Final[float] = (
     2.0  # Prevents rapid redraws during tool-use bursts


### PR DESCRIPTION
Closes #925

## Summary

Extracts interactive-mode UI helpers from `cli.py` into a new `interactive.py` module, separating rendering/file-watching concerns from CLI routing.

## Changes

### New: `src/copilot_usage/interactive.py` (~160 lines)
- `print_version_header()` — version header rendering
- `render_session_list()` — numbered session table
- `draw_home()` — home view composition
- `write_prompt()` — non-blocking prompt output
- `FileChangeHandler` / `FileChangeEventHandler` / `Stoppable` — watchdog protocols and handler
- `start_observer()` / `stop_observer()` — watchdog lifecycle
- `build_session_index()` — O(1) session-ID lookup

### Updated: `src/copilot_usage/cli.py` (681 → 557 lines)
- Imports helpers from `interactive.py`, re-exporting them under original private names for backward compatibility
- Retains: Click commands, date parsing helpers, `_interactive_loop`, `_read_line_nonblocking`, `_show_session_by_index`

### Updated: `src/copilot_usage/docs/architecture.md`
- Added `interactive.py` to the Components table
- Updated `cli.py` description to reference the new module

## Design Decisions

- **`_interactive_loop` stays in `cli.py`**: Tests extensively monkey-patch helpers on the `copilot_usage.cli` module namespace, and `_interactive_loop` resolves those names from its own module's globals. Moving the loop would break all monkey-patch-based tests without changing test code.
- **`_read_line_nonblocking` and `_show_session_by_index` stay in `cli.py`**: Tests use `patch("copilot_usage.cli.sys.stdin", ...)` and `patch("copilot_usage.cli.get_cached_events", ...)` which require these functions to resolve dependencies from the `cli` module namespace.
- **Public names in `interactive.py`**: Functions use public names (no underscore prefix) to satisfy pyright's strict mode, with aliases to private names in `cli.py` for backward compatibility.

## Verification

- `make check` passes (lint ✅, typecheck ✅, security ✅, unit tests ✅ 99% coverage, e2e ✅ 86 passed)
- All existing tests pass unchanged
- No test files were modified




> Generated by [Issue Implementer](https://github.com/microsasa/cli-tools/actions/runs/24625603026/agentic_workflow) · ● 40.7M · [◷](https://github.com/search?q=repo%3Amicrosasa%2Fcli-tools+%22gh-aw-workflow-id%3A+issue-implementer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Issue Implementer, engine: copilot, model: claude-opus-4.6, id: 24625603026, workflow_id: issue-implementer, run: https://github.com/microsasa/cli-tools/actions/runs/24625603026 -->

<!-- gh-aw-workflow-id: issue-implementer -->