### PR TITLE
fix: remove structurally unreachable `unreadable < 0` branch (#1001)

### DIFF
--- a/src/copilot_usage/vscode_report.py
+++ b/src/copilot_usage/vscode_report.py
@@ -16,7 +16,7 @@ _DAILY_ACTIVITY_LIMIT: Final[int] = 14
 
 
 def _format_log_files_line(summary: VSCodeLogSummary) -> str:
-    """Build the 'Log Files' line, surfacing unreadable or inconsistent counts."""
+    """Build the 'Log Files' line, surfacing unreadable file counts."""
     found = summary.log_files_found
     parsed = summary.log_files_parsed
     unreadable = found - parsed
@@ -26,11 +26,6 @@ def _format_log_files_line(summary: VSCodeLogSummary) -> str:
             f"[bold]Log Files:[/bold]  {parsed}"
             f" ({found} found, "
             f"[red]{unreadable} unreadable[/red])"
-        )
-    if unreadable < 0:
-        return (
-            f"[bold]Log Files:[/bold]  {parsed}"
-            f" ([yellow]{found} found; inconsistent counts[/yellow])"
         )
     return f"[bold]Log Files:[/bold]  {parsed}"
 

--- a/tests/copilot_usage/test_vscode_report.py
+++ b/tests/copilot_usage/test_vscode_report.py
@@ -431,19 +431,3 @@ class TestRenderVscodeSummaryUnreadableFiles:
         assert "Log Files:  4" in log_line
         assert "unreadable" not in log_line
         assert "found" not in log_line
-
-    def test_inconsistent_counts_shown_when_parsed_exceeds_found(self) -> None:
-        """When parsed > found, a yellow warning about inconsistent counts appears."""
-        summary = _make_summary(
-            total_requests=10,
-            log_files_parsed=5,
-            log_files_found=3,
-        )
-        output = _capture(summary)
-        log_line = _strip_ansi(
-            next(line for line in output.splitlines() if "Log Files" in line)
-        )
-        assert "Log Files:  5" in log_line
-        assert "3 found" in log_line
-        assert "inconsistent counts" in log_line
-        assert "unreadable" not in log_line


### PR DESCRIPTION
Closes #1001

## Changes

**`src/copilot_usage/vscode_report.py`**
- Removed the dead `if unreadable < 0:` branch from `_format_log_files_line`. The invariant `parsed ≤ found` is guaranteed by construction in `get_vscode_summary` (parsed starts at 0 and only increments on success, while found = len(logs)), so `unreadable` can never be negative.
- Updated the docstring to drop the "or inconsistent counts" reference.

**`tests/copilot_usage/test_vscode_report.py`**
- Removed `test_inconsistent_counts_shown_when_parsed_exceeds_found` which tested this impossible state.

## Verification

- The two remaining branch tests (`test_unreadable_files_shown_when_found_exceeds_parsed` and `test_happy_path_no_unreadable_annotation`) still pass.
- `make check` passes cleanly: lint ✅, typecheck ✅, security ✅, unit tests (99% coverage) ✅, e2e tests (86 passed) ✅.




> Generated by [Issue Implementer](https://github.com/microsasa/cli-tools/actions/runs/24626444455/agentic_workflow) · ● 3.8M · [◷](https://github.com/search?q=repo%3Amicrosasa%2Fcli-tools+%22gh-aw-workflow-id%3A+issue-implementer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Issue Implementer, engine: copilot, model: claude-opus-4.6, id: 24626444455, workflow_id: issue-implementer, run: https://github.com/microsasa/cli-tools/actions/runs/24626444455 -->

<!-- gh-aw-workflow-id: issue-implementer -->