### PR TITLE
test: add direct unit tests for `_newest_child_from_ids` (#1005)

### DIFF
--- a/tests/copilot_usage/test_vscode_parser.py
+++ b/tests/copilot_usage/test_vscode_parser.py
@@ -30,6 +30,7 @@ from copilot_usage.vscode_parser import (
     _default_log_candidates,
     _get_cached_vscode_requests,
     _merge_partial,
+    _newest_child_from_ids,
     _parse_vscode_log_from_offset,
     _scan_child_ids,
     _SummaryAccumulator,
@@ -3346,3 +3347,56 @@ class TestParsedTimestampsAreAware:
         assert summary.first_timestamp > aware_dt
         assert summary.last_timestamp is not None
         assert summary.last_timestamp > aware_dt
+
+
+# ---------------------------------------------------------------------------
+# _newest_child_from_ids
+# ---------------------------------------------------------------------------
+
+
+class TestNewestChildFromIds:
+    """Direct unit tests for the ``_newest_child_from_ids`` sentinel selector."""
+
+    _ROOT: Path = Path("/fake")
+
+    def test_empty_child_ids_returns_none_pair(self) -> None:
+        """Empty *child_ids* yields ``(None, None)``."""
+        path, identity = _newest_child_from_ids(self._ROOT, frozenset())
+        assert path is None
+        assert identity is None
+
+    def test_single_entry(self) -> None:
+        """A single child is always selected."""
+        child_ids: frozenset[tuple[str, tuple[int, int]]] = frozenset(
+            {("window1", (1000, 512))}
+        )
+        path, identity = _newest_child_from_ids(self._ROOT, child_ids)
+        assert path == self._ROOT / "window1"
+        assert identity == (1000, 512)
+
+    def test_multiple_entries_distinct_mtime(self) -> None:
+        """The child with the highest ``st_mtime_ns`` wins."""
+        child_ids: frozenset[tuple[str, tuple[int, int]]] = frozenset(
+            {("window1", (100, 0)), ("window2", (200, 0))}
+        )
+        path, identity = _newest_child_from_ids(self._ROOT, child_ids)
+        assert path == self._ROOT / "window2"
+        assert identity == (200, 0)
+
+    def test_tie_breaking_by_name_same_mtime(self) -> None:
+        """When ``st_mtime_ns`` is identical, the lexicographically largest name wins."""
+        child_ids: frozenset[tuple[str, tuple[int, int]]] = frozenset(
+            {("window1", (100, 0)), ("window2", (100, 0))}
+        )
+        path, identity = _newest_child_from_ids(self._ROOT, child_ids)
+        assert path == self._ROOT / "window2"
+        assert identity == (100, 0)
+
+    def test_natural_sort_surprise(self) -> None:
+        """Lexicographic ordering: ``"window2" > "window10"`` (``'2' > '1'``)."""
+        child_ids: frozenset[tuple[str, tuple[int, int]]] = frozenset(
+            {("window10", (100, 0)), ("window2", (100, 0))}
+        )
+        path, identity = _newest_child_from_ids(self._ROOT, child_ids)
+        assert path == self._ROOT / "window2"
+        assert identity == (100, 0)


### PR DESCRIPTION
Closes #1005

## Summary

Adds a `TestNewestChildFromIds` class in `tests/copilot_usage/test_vscode_parser.py` with 5 focused unit tests for the `_newest_child_from_ids` sentinel selector function.

## Test scenarios

| Test | Input | Verified behavior |
|---|---|---|
| `test_empty_child_ids_returns_none_pair` | `frozenset()` | Returns `(None, None)` |
| `test_single_entry` | Single child | Always selected |
| `test_multiple_entries_distinct_mtime` | Distinct mtimes | Highest `st_mtime_ns` wins |
| `test_tie_breaking_by_name_same_mtime` | Same mtime | Lexicographically largest name wins |
| `test_natural_sort_surprise` | `"window10"` vs `"window2"` | `"window2"` wins — documents intentional lexicographic (not natural) sort |

All tests are pure in-memory (no disk I/O) and do not interact with module-level caches.




> Generated by [Issue Implementer](https://github.com/microsasa/cli-tools/actions/runs/24630993001/agentic_workflow) · ● 4.3M · [◷](https://github.com/search?q=repo%3Amicrosasa%2Fcli-tools+%22gh-aw-workflow-id%3A+issue-implementer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Issue Implementer, engine: copilot, model: claude-opus-4.6, id: 24630993001, workflow_id: issue-implementer, run: https://github.com/microsasa/cli-tools/actions/runs/24630993001 -->

<!-- gh-aw-workflow-id: issue-implementer -->