### PR TITLE
fix: add `__all__` to cli.py and move deferred import in interactive.py (#1006)

### DIFF
--- a/src/copilot_usage/cli.py
+++ b/src/copilot_usage/cli.py
@@ -43,6 +43,10 @@ from copilot_usage.report import (
     render_summary,
 )
 
+__all__: Final[list[str]] = [
+    "main",
+]
+
 type _View = Literal["home", "detail", "cost"]
 
 # (format_string, has_explicit_time) pairs — single source of truth.

--- a/src/copilot_usage/interactive.py
+++ b/src/copilot_usage/interactive.py
@@ -4,6 +4,7 @@ Contains rendering, file-watching, and input helpers used by the
 interactive Rich-based session loop in :mod:`copilot_usage.cli`.
 """
 
+import sys
 import threading
 import time
 from pathlib import Path
@@ -83,8 +84,6 @@ def draw_home(console: Console, sessions: list[SessionSummary]) -> None:
 
 def write_prompt(prompt: str) -> None:
     """Write the prompt to stdout without a trailing newline and flush immediately."""
-    import sys
-
     sys.stdout.write(prompt)
     sys.stdout.flush()
 


### PR DESCRIPTION
Closes #1006

## Changes

### `src/copilot_usage/cli.py`
- Added `__all__: Final[list[str]] = ["main"]` after the import block, matching the convention used by every other module in the package.

### `src/copilot_usage/interactive.py`
- Moved `import sys` from inside `write_prompt()` to the top-level stdlib imports block (alphabetically between `import threading` and `import time` → now `sys`, `threading`, `time`).
- Removed the deferred `import sys` from the `write_prompt` function body.

## Verification
- `make check` passes: lint ✅, pyright ✅, bandit ✅, unit tests (99% coverage) ✅, e2e tests (86 passed) ✅
- No test modifications required — existing `test_cli.py` and `test_packaging.py` continue to pass.




> Generated by [Issue Implementer](https://github.com/microsasa/cli-tools/actions/runs/24631197774/agentic_workflow) · ● 4.2M · [◷](https://github.com/search?q=repo%3Amicrosasa%2Fcli-tools+%22gh-aw-workflow-id%3A+issue-implementer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Issue Implementer, engine: copilot, model: claude-opus-4.6, id: 24631197774, workflow_id: issue-implementer, run: https://github.com/microsasa/cli-tools/actions/runs/24631197774 -->

<!-- gh-aw-workflow-id: issue-implementer -->