### PR TITLE
revert: remove fix-forward instructions from PR #786 (#926)

### DIFF
--- a/.github/workflows/issue-implementer.md
+++ b/.github/workflows/issue-implementer.md
@@ -49,14 +49,6 @@ Read `.github/copilot-instructions.md` and follow all referenced guidelines for 
 
 Read all files in the repository. Read issue #${{ github.event.inputs.issue_number }} to understand what needs to be fixed. Implement the fix following the spec in the issue, including any testing requirements.
 
-**Self-review before pushing**: After implementing, audit your own changes for common reviewer findings:
-- **Docstrings**: Does every changed/new function have an accurate docstring? Do existing docstrings still match the new behavior?
-- **Test assertions**: Does each test actually verify what its name/docstring claims? Are assertions specific (exact match, not substring)?
-- **Dead references**: If you renamed or removed something, grep for stale references in docs, comments, imports, and tests
-- **Parallel code paths**: If you fixed a bug or added a guard, check sibling functions/paths for the same gap
-- **Naming consistency**: Do test names, variable names, and comments all match the current behavior?
-Fix any issues you find.
-
 Then run `make fix` to auto-fix lint and format issues, then run `make check` to verify all checks pass (lint, type check, security, tests):
 
 ```

--- a/.github/workflows/review-responder.md
+++ b/.github/workflows/review-responder.md
@@ -70,18 +70,10 @@ This workflow addresses unresolved review comments on a pull request.
    c. Make the requested fix in the code
    d. Reply to the comment thread using `reply_to_pull_request_review_comment` with the comment's `databaseId` as the `comment_id`
 
-5. **Fix-forward scan**: After addressing all comments, review what you just fixed and identify the *class* of each issue (e.g., "stale docstring", "missing assertion", "TOCTOU race", "dead code"). For each class, scan ALL files changed in this PR for other instances of the same problem. Common patterns to check:
-   - If you fixed a stale/inaccurate docstring → audit every docstring in the changed functions
-   - If you fixed a weak test assertion → check sibling tests for similar assertion gaps
-   - If you fixed a bug in one code path → check parallel code paths for the same bug
-   - If you removed dead code → grep for similar dead references elsewhere
-   - If you fixed a naming mismatch → check all related names/comments for consistency
-   Fix any additional instances you find. This prevents the reviewer from flagging the same class of issue in the next round.
+5. Run `make fix` to auto-fix lint and format issues, then run `make check` to verify all checks pass: `make fix && make check`
 
-6. Run `make fix` to auto-fix lint and format issues, then run `make check` to verify all checks pass: `make fix && make check`
+6. If CI checks fail, fix the issues and re-run until they pass. Do not push broken code.
 
-7. If CI checks fail, fix the issues and re-run until they pass. Do not push broken code.
-
-8. Push all changes in a single commit with message "fix: address review comments".
+7. Push all changes in a single commit with message "fix: address review comments".
 
 If a review comment requests a change that would be architecturally significant or you're unsure about, reply to the thread explaining your concern rather than making the change blindly.


### PR DESCRIPTION
## Summary

Removes the fix-forward scan and self-review checklist instructions added in PR #786. These had no measurable impact on agent behavior.

### Evidence

**Review-responder fix-forward scan** (from issue #926):
- 79 merged PRs analyzed over 8 days post-implementation
- Zero change in avg review rounds (0.23 → 0.23), clean merge rate (82% → 85%), or stuck PRs (2 → 2)
- PRs #830, #852, #865 showed the responder ignoring the scan entirely

**Issue-implementer self-review checklist** (fresh analysis):
- ~75 implementer PRs since Apr 6; ~25 (33%) got flagged by Copilot reviewer
- PR #989 (8 rounds): 5 stale docstrings — a literal checklist item, not caught
- PR #953 (5 rounds): inaccurate doc descriptions — a literal checklist item, not caught
- The implementer never performed the self-review despite the instruction

### Changes

- `review-responder.md`: Removed fix-forward scan step, renumbered remaining steps
- `issue-implementer.md`: Removed self-review checklist block

Net: -19 lines of prompt text that added token cost with zero behavioral effect.

Closes #926