### PR TITLE
fix: remove `console` from `interactive.__all__` and add missing modules to packaging test (#1011)

### DIFF
--- a/src/copilot_usage/interactive.py
+++ b/src/copilot_usage/interactive.py
@@ -24,7 +24,6 @@ from copilot_usage.report import (
 
 __all__: Final[list[str]] = [
     "WATCHDOG_DEBOUNCE_SECS",
-    "console",
     "print_version_header",
     "render_session_list",
     "draw_home",

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -12,6 +12,8 @@ import pytest
 _PUBLIC_MODULES: list[str] = [
     "copilot_usage._formatting",
     "copilot_usage._fs_utils",
+    "copilot_usage.cli",
+    "copilot_usage.interactive",
     "copilot_usage.logging_config",
     "copilot_usage.models",
     "copilot_usage.parser",


### PR DESCRIPTION
Closes #1011

## Changes

1. **Removed `"console"` from `interactive.py.__all__`** — The `console: Final[Console]` singleton is an internal implementation detail used only within `interactive.py`. It was never imported by `cli.py` or any external caller, so exporting it leaked an internal global.

2. **Added `copilot_usage.interactive` and `copilot_usage.cli` to `_PUBLIC_MODULES` in `tests/test_packaging.py`** — These modules were missing from the parametrized `test_all_names_importable` test, which meant typos or accidental exports in their `__all__` lists would go undetected.

## Verification

- `make check` passes cleanly (lint, typecheck, security, unit tests at 99% coverage, e2e tests)
- The existing `test_all_names_importable` now covers both `interactive` and `cli` modules




> Generated by [Issue Implementer](https://github.com/microsasa/cli-tools/actions/runs/24637833578/agentic_workflow) · ● 2.4M · [◷](https://github.com/search?q=repo%3Amicrosasa%2Fcli-tools+%22gh-aw-workflow-id%3A+issue-implementer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Issue Implementer, engine: copilot, model: claude-opus-4.6, id: 24637833578, workflow_id: issue-implementer, run: https://github.com/microsasa/cli-tools/actions/runs/24637833578 -->

<!-- gh-aw-workflow-id: issue-implementer -->