### PR TITLE
security: SHA-pin manual workflows and prune dead lock entries (P0)

### DIFF
--- a/.github/aw/actions-lock.json
+++ b/.github/aw/actions-lock.json
@@ -1,10 +1,5 @@
 {
   "entries": {
-    "actions/github-script@v8": {
-      "repo": "actions/github-script",
-      "version": "v8",
-      "sha": "ed597411d8f924073f98dfc5c65a23a2325f34cd"
-    },
     "actions/github-script@v9": {
       "repo": "actions/github-script",
       "version": "v9",
@@ -14,11 +9,6 @@
       "repo": "github/gh-aw-actions/setup",
       "version": "v0.68.3",
       "sha": "ba90f2186d7ad780ec640f364005fa24e797b360"
-    },
-    "github/gh-aw/actions/setup@v0.58.1": {
-      "repo": "github/gh-aw/actions/setup",
-      "version": "v0.58.1",
-      "sha": "fa061e89469ef007881d22d3af5a8c9e62363a0d"
     }
   }
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,10 +8,10 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
-      - uses: astral-sh/setup-uv@v7
+      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
       - run: uv sync
       - run: make ci
       - name: Check diff coverage (new/changed lines ≥ 90%)

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -13,8 +13,8 @@ jobs:
       contents: read
       actions: read
     steps:
-      - uses: actions/checkout@v6
-      - uses: github/codeql-action/init@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: github/codeql-action/init@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
         with:
           languages: python
-      - uses: github/codeql-action/analyze@v4
+      - uses: github/codeql-action/analyze@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -19,12 +19,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Install gh-aw extension
         uses: github/gh-aw/actions/setup-cli@5a06d310cf45161bde77d070065a1e1489fc411c # v0.68.1
         with:
           version: v0.68.1
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
       - name: Install Python dependencies
         run: uv sync

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -10,5 +10,5 @@ jobs:
   review:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/dependency-review-action@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4.9.0

--- a/.github/workflows/pipeline-orchestrator.yml
+++ b/.github/workflows/pipeline-orchestrator.yml
@@ -57,7 +57,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
           token: ${{ secrets.GH_AW_WRITE_TOKEN }}


### PR DESCRIPTION
Addresses all items in #1014 (rescoped) as part of the P0 response to audit #92.

## Changes

### SHA-pinned manual workflow actions (#1014 item 4)
Pinned tag refs to immutable commit SHAs in 5 workflows:
- `ci.yml`: checkout@v6, setup-uv@v7
- `codeql.yml`: checkout@v6, codeql-action/init@v4, codeql-action/analyze@v4
- `copilot-setup-steps.yml`: checkout@v6, setup-uv@v7 (setup-cli line intentionally untouched)
- `dependency-review.yml`: checkout@v6, dependency-review-action@v4.9.0
- `pipeline-orchestrator.yml`: checkout@v6

### Pruned dead lock file entries (#1014 items 1 and 3)
Removed unused entries from `actions-lock.json`:
- `actions/github-script@v8` — zero references
- `github/gh-aw/actions/setup@v0.58.1` — zero references

### Not in this PR
Original item #2 from #1014 (bump gh-aw-actions/setup v0.68.3 → v0.68.7) has been split out to #1021 because it is blocked on an upstream gh-aw CLI release. This PR fully addresses all currently unblocked P0 items.

## Verification
- All SHAs verified via GitHub API (tag-to-commit resolution including annotated tag peeling)
- `gh aw compile` clean, no diff vs committed `.lock.yml` files
- Triple-reviewed by Codex, Sonnet 4.6, Opus 4.6 — all clean

## Issue linkage
Closes #1014
Refs #92 (meta audit — do NOT close)
Refs #1021 (blocked sibling P0 — do NOT close)