### PR TITLE
security: add CODEOWNERS and explicit permissions on ci.yml (P1)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,9 +1,10 @@
 # Code owners for sensitive paths.
 # Requires matching "Require review from Code Owners" in branch protection.
 # See: https://docs.github.com/repositories/managing-your-repositorys-settings-and-security/customizing-your-repository/about-code-owners
-
-# Catch-all fallback
-*                           @microsasa
+#
+# No catch-all — we intentionally scope codeowner review to security-sensitive
+# paths only, so autonomous pipeline PRs touching src/, tests/, docs/ etc.
+# are not gated.
 
 # CI, agent workflows, and action pinning — any change is security-sensitive
 /.github/                   @microsasa

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,17 @@
+# Code owners for sensitive paths.
+# Requires matching "Require review from Code Owners" in branch protection.
+# See: https://docs.github.com/repositories/managing-your-repositorys-settings-and-security/customizing-your-repository/about-code-owners
+
+# Catch-all fallback
+*                           @microsasa
+
+# CI, agent workflows, and action pinning — any change is security-sensitive
+/.github/                   @microsasa
+/.github/workflows/         @microsasa
+/.github/aw/                @microsasa
+/.github/dependabot.yml     @microsasa
+/.github/CODEOWNERS         @microsasa
+
+# Dependency manifests — lockfile tampering or dep confusion risk
+/pyproject.toml             @microsasa
+/uv.lock                    @microsasa

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,9 @@ on:
     branches: [main]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   check:
     runs-on: ubuntu-latest


### PR DESCRIPTION
P1 remediation from security audit #92.

## Changes

### CODEOWNERS (audit H7)
Add `.github/CODEOWNERS` requiring @microsasa review on:
- `/.github/**` — all workflows, dependabot config, codeowners itself
- `/.github/aw/` — action lock file
- `/pyproject.toml`, `/uv.lock` — dependency manifests

**Scoped intentionally** — no catch-all, so autonomous pipeline PRs touching `src/`, `tests/`, `docs/`, etc. are unaffected.

Prevents silent modification of security-sensitive paths by any contributor with write access.

### Explicit `ci.yml` permissions (audit H4)
Add `permissions: { contents: read }` at workflow level. Pins the workflow to read-only regardless of the repo's default workflow permissions setting.

Defense-in-depth: if the repo default is ever toggled to read-write, `ci.yml` stays read-only.

`ci.yml` only runs tests + coverage; no writes needed.

## Manual repo setup
✅ **Done** — `require_code_owner_reviews: true` enabled on `main` branch protection (via API). Takes effect once this PR merges and CODEOWNERS lands on `main`.

## Refs
Refs #92 (meta — do NOT close)