### PR TITLE
security: extend CODEOWNERS to Makefile and scripts/ (H2 mitigation)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -16,3 +16,9 @@
 # Dependency manifests — lockfile tampering or dep confusion risk
 /pyproject.toml             @microsasa
 /uv.lock                    @microsasa
+
+# Build glue and release scripts — executed by CI (`make ci`) and by humans.
+# Malicious changes here bypass application-layer review since they run
+# during build/test and could exfiltrate secrets or publish bad artifacts.
+/Makefile                   @microsasa
+/scripts/                   @microsasa


### PR DESCRIPTION
Caps auto-merge blast radius for build/release paths without killing pipeline autonomy.

## Context

Audit #92 finding **H2** originally proposed adding a human-only `ready-for-auto-approve` label gate on `quality-gate` to prevent prompt-injection-driven auto-APPROVE. That fix breaks the pipeline's core value proposition (no-human-in-the-loop).

This PR implements the reframed fix: cap blast radius by **path**, not by **approval**.

## Change

Extend `.github/CODEOWNERS` to cover:
- `/Makefile` — executed by `ci.yml` via `make ci`; a malicious target runs arbitrary code in CI.
- `/scripts/` — currently contains `hold-for-merge.sh` and `release-from-merge.sh`; release-gating logic. Compromise means shipping bad artifacts.

## Defense in depth (all 3 active after this merges)

1. **Option A** — trusted input boundary. Only `@microsasa` has triage role, so only `@microsasa` can apply the `aw` label. Pipeline ignores external issues/PRs. (Verified: all 20 most recent `aw` issues authored by @microsasa.)
2. **Option B** — runtime sanitization. gh-aw v0.68.7 applies XPIA / homoglyph (NFKC) / heredoc / steganographic-markdown filtering to issue and PR bodies before the agent sees them. Active as of PR #1023.
3. **Option C (this PR)** — path-scoped auto-merge guard. Quality-gate can auto-approve freely, but CODEOWNERS blocks auto-merge of PRs touching sensitive paths.

## Pipeline impact

Zero. Quality-gate continues to auto-approve PRs touching `src/`, `tests/`, `docs/`, etc. Only PRs that shouldn't auto-merge anyway (touching workflows, lock files, build glue, release scripts) now require your explicit review.

## Refs
Refs #92 (meta — do NOT close)