### PR TITLE
fix: freeze `ModelPricing` to prevent shared-reference mutation (#1022)

### DIFF
--- a/src/copilot_usage/pricing.py
+++ b/src/copilot_usage/pricing.py
@@ -14,7 +14,7 @@ from functools import lru_cache
 from typing import Final
 
 from loguru import logger
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 
 __all__: Final[list[str]] = [
     "ModelPricing",
@@ -45,6 +45,8 @@ class PricingTier(StrEnum):
 
 class ModelPricing(BaseModel):
     """Pricing metadata for a single AI model."""
+
+    model_config = ConfigDict(frozen=True)
 
     model_name: str
     multiplier: float = 1.0

--- a/tests/copilot_usage/test_pricing.py
+++ b/tests/copilot_usage/test_pricing.py
@@ -6,6 +6,7 @@ from functools import lru_cache
 
 import pytest
 from loguru import logger
+from pydantic import ValidationError
 
 from copilot_usage import pricing
 from copilot_usage.pricing import (
@@ -40,6 +41,24 @@ class TestModelPricing:
         assert p.model_name == "opus"
         assert p.multiplier == 50.0
         assert p.tier == PricingTier.PREMIUM
+
+    def test_model_pricing_is_immutable(self) -> None:
+        """Assigning to a field on a frozen ModelPricing must raise ValidationError."""
+        p = ModelPricing(model_name="test", multiplier=1.0)
+        with pytest.raises(ValidationError):
+            p.multiplier = 2.0
+
+    def test_cache_isolation_via_frozen_model(self) -> None:
+        """Exact-match lookup returns a frozen object — mutation is impossible,
+        so the cache and KNOWN_PRICING registry cannot be corrupted."""
+        first = lookup_model_pricing("claude-sonnet-4.6")
+        assert first.multiplier == 1.0
+
+        with pytest.raises(ValidationError):
+            first.multiplier = 99.0
+
+        second = lookup_model_pricing("claude-sonnet-4.6")
+        assert second.multiplier == 1.0
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #1022

## Problem

`ModelPricing` was a plain (non-frozen) Pydantic `BaseModel`, so callers could mutate fields on objects returned by `lookup_model_pricing`. Since exact-match lookups return direct references to objects in `KNOWN_PRICING` (cached via `lru_cache`), any mutation silently corrupted both the registry and the cache.

## Solution

Add `model_config = ConfigDict(frozen=True)` to `ModelPricing`. Frozen Pydantic models raise `ValidationError` on field assignment, making accidental corruption impossible.

## Changes

- **`src/copilot_usage/pricing.py`**: Import `ConfigDict`, add `model_config = ConfigDict(frozen=True)` to `ModelPricing`.
- **`tests/copilot_usage/test_pricing.py`**: Add two regression tests:
  - `test_model_pricing_is_immutable` — asserts field assignment raises `ValidationError`.
  - `test_cache_isolation_via_frozen_model` — asserts that attempting mutation on a looked-up object cannot corrupt subsequent lookups.

## Verification

`make check` passes (lint, typecheck, security, all tests at 99% coverage).




> Generated by [Issue Implementer](https://github.com/microsasa/cli-tools/actions/runs/24732552576/agentic_workflow) · ● 5M · [◷](https://github.com/search?q=repo%3Amicrosasa%2Fcli-tools+%22gh-aw-workflow-id%3A+issue-implementer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Issue Implementer, engine: copilot, model: claude-opus-4.6, id: 24732552576, workflow_id: issue-implementer, run: https://github.com/microsasa/cli-tools/actions/runs/24732552576 -->

<!-- gh-aw-workflow-id: issue-implementer -->