### PR TITLE
fix: harden responder dispatch loop (#1036)

### DIFF
--- a/.github/CODING_GUIDELINES.md
+++ b/.github/CODING_GUIDELINES.md
@@ -77,6 +77,53 @@ Standards for all contributors — human and AI — to the `copilot-usage` CLI.
   `KeyboardInterrupt` is handled separately.
 - Prefer early returns to reduce nesting.
 
+## Concurrency and I/O State
+
+### No Shared Mutable I/O State Across Calls
+
+- **Queues, daemon threads, file handles, sockets, and other I/O resources
+  must not outlive the function call that uses them.** Declare them as
+  locals (or instance attributes of a per-call object), and tear them down
+  in a `finally` block.
+- **No module-level lazy singletons for I/O readers** (e.g.
+  `_stdin_queue: Queue | None = None; if _stdin_queue is None: _stdin_queue = _start_thread()`).
+  Two consecutive calls to the same public entry point must not share any
+  queue, thread, or event — otherwise the second call sees stale state
+  from the first.
+- **No `ClassVar` queues/threads/events** on classes that are used as
+  singletons or reused across calls. Same failure mode as module-level
+  state.
+- The litmus test: *if two calls to the public entry point happen in the
+  same process, do they share any I/O handle, queue, or daemon thread?*
+  If yes, the design is wrong.
+
+### Why
+
+Python daemon threads blocked in `sys.stdin.readline()` or `input()`
+cannot be cleanly interrupted. If test 1 populates a shared queue with
+an EOF sentinel and its reader thread exits, test 2 sees the stale
+sentinel, and test 3 blocks on a dead reader forever — CI hits the 6 h
+runner timeout. This is not hypothetical: it is the canonical failure
+mode of PR #1015 / issue #1012.
+
+### Preferred Pattern
+
+```python
+def _interactive_loop() -> None:
+    reader: _Reader | None = None
+    try:
+        # ... loop body ...
+        if need_fallback:
+            reader = _start_reader()
+    finally:
+        if reader is not None:
+            reader.stop()
+```
+
+If cross-call reuse is genuinely required, pass the resource in as a
+parameter (explicit dependency injection) — never rely on a module-
+level default.
+
 ## Logging
 
 - Use **loguru**, not stdlib `logging`.

--- a/.github/workflows/pipeline-orchestrator.yml
+++ b/.github/workflows/pipeline-orchestrator.yml
@@ -247,7 +247,6 @@ jobs:
             [ -z "$CI_CONCLUSION" ] && CI_CONCLUSION="NO_CI_RESULT"
 
             HAS_CI_FIX_LABEL=$(echo "$LABELS" | jq -r 'if any(. == "aw-ci-fix-attempted") then "yes" else "" end')
-            HAS_RESPONSE_LABEL=$(echo "$LABELS" | jq -r 'if any(. == "aw-review-response-attempted") then "yes" else "" end')
 
             echo "  Branch: $BRANCH | CI: $CI_CONCLUSION"
 
@@ -360,11 +359,13 @@ jobs:
                 continue
               fi
 
-              # Belt-and-suspenders dispatch cap (issue #1036): count past
-              # rounds via orchestrator-applied numeric labels regardless of
-              # whether the responder itself successfully applied
-              # aw-review-response-attempted (the responder's add_labels call
-              # has been known to silently fail). Cap at 5 rounds.
+              # Dispatch cap (issue #1036): count past rounds via
+              # orchestrator-applied numeric labels. Trust model: these
+              # labels live in PR metadata, which only repo collaborators
+              # with triage/write can modify. On microsasa/cli-tools this
+              # is the sole owner. If outside collaborators are ever
+              # granted triage rights, revisit — the counter becomes
+              # forgeable and the cap can be bypassed or weaponized.
               ROUND=$(echo "$LABELS" | jq -r '[.[] | select(test("^aw-review-response-[0-9]+$"))] | length')
 
               if [[ "$ROUND" -ge 5 ]]; then
@@ -377,10 +378,33 @@ jobs:
 
               NEXT_ROUND=$((ROUND + 1))
               echo "  🔄 PR #${PR}: Recording round ${NEXT_ROUND}/5 and dispatching responder."
-              # Best-effort: remove stale per-round attempted label if present.
-              gh pr edit "$PR" --remove-label "aw-review-response-attempted" 2>/dev/null || true
-              gh pr edit "$PR" --add-label "aw-review-response-${NEXT_ROUND}"
-              gh workflow run review-responder.lock.yml -f pr_number="$PR"
+
+              # Clean up the responder's self-stop label from the prior round
+              # so the just-dispatched responder doesn't bail on its own
+              # step-1 check. Only attempt removal if the label is actually
+              # present — this distinguishes the benign case from real
+              # failures (auth, rate limit, 404) which we must not silently
+              # swallow (see issue #1036 lessons).
+              if echo "$LABELS" | jq -e 'any(. == "aw-review-response-attempted")' > /dev/null; then
+                if ! gh pr edit "$PR" --remove-label "aw-review-response-attempted"; then
+                  echo "  ⚠️  PR #${PR}: Failed to remove stale aw-review-response-attempted. Bailing this tick; cron will retry."
+                  echo "::endgroup::"
+                  continue
+                fi
+              fi
+
+              # Record the round BEFORE dispatching. If this fails, do not
+              # dispatch — otherwise the responder runs without the cap
+              # advancing, reproducing the original loop.
+              if ! gh pr edit "$PR" --add-label "aw-review-response-${NEXT_ROUND}"; then
+                echo "  ⚠️  PR #${PR}: Failed to add aw-review-response-${NEXT_ROUND}. Not dispatching; cron will retry."
+                echo "::endgroup::"
+                continue
+              fi
+
+              if ! gh workflow run review-responder.lock.yml -f pr_number="$PR"; then
+                echo "  ⚠️  PR #${PR}: Failed to dispatch review-responder. Round label was recorded; cron will retry."
+              fi
               echo "::endgroup::"
               continue
             fi

--- a/.github/workflows/pipeline-orchestrator.yml
+++ b/.github/workflows/pipeline-orchestrator.yml
@@ -360,26 +360,27 @@ jobs:
                 continue
               fi
 
-              if [[ -n "$HAS_RESPONSE_LABEL" ]]; then
-                # Count review-response-N labels for round tracking
-                ROUND=$(echo "$LABELS" | jq -r '[.[] | select(test("^aw-review-response-[0-9]+$"))] | length')
+              # Belt-and-suspenders dispatch cap (issue #1036): count past
+              # rounds via orchestrator-applied numeric labels regardless of
+              # whether the responder itself successfully applied
+              # aw-review-response-attempted (the responder's add_labels call
+              # has been known to silently fail). Cap at 5 rounds.
+              ROUND=$(echo "$LABELS" | jq -r '[.[] | select(test("^aw-review-response-[0-9]+$"))] | length')
 
-                if [[ "$ROUND" -ge 3 ]]; then
-                  echo "  ❌ PR #${PR}: Responder hit 3 rounds. Marking stuck."
-                  gh pr edit "$PR" --add-label "aw-pr-stuck:review"
-                  gh pr comment "$PR" --body "❌ Pipeline orchestrator: review-response loop reached 3 rounds. Marking as stuck for human review."
-                else
-                  NEXT_ROUND=$((ROUND + 1))
-                  echo "  🔄 PR #${PR}: Removing response label, enabling round ${NEXT_ROUND}."
-                  gh pr edit "$PR" --remove-label "aw-review-response-attempted"
-                  gh pr edit "$PR" --add-label "aw-review-response-${NEXT_ROUND}"
-                  echo "  📤 Dispatching responder for PR #${PR}."
-                  gh workflow run review-responder.lock.yml -f pr_number="$PR"
-                fi
-              else
-                echo "  📤 PR #${PR}: $UNADDRESSED_COUNT unaddressed threads. Dispatching responder."
-                gh workflow run review-responder.lock.yml -f pr_number="$PR"
+              if [[ "$ROUND" -ge 5 ]]; then
+                echo "  ❌ PR #${PR}: Responder hit 5 rounds. Marking stuck."
+                gh pr edit "$PR" --add-label "aw-pr-stuck:review"
+                gh pr comment "$PR" --body "❌ Pipeline orchestrator: review-response loop reached 5 rounds. Marking as stuck for human review."
+                echo "::endgroup::"
+                continue
               fi
+
+              NEXT_ROUND=$((ROUND + 1))
+              echo "  🔄 PR #${PR}: Recording round ${NEXT_ROUND}/5 and dispatching responder."
+              # Best-effort: remove stale per-round attempted label if present.
+              gh pr edit "$PR" --remove-label "aw-review-response-attempted" 2>/dev/null || true
+              gh pr edit "$PR" --add-label "aw-review-response-${NEXT_ROUND}"
+              gh workflow run review-responder.lock.yml -f pr_number="$PR"
               echo "::endgroup::"
               continue
             fi

--- a/.github/workflows/review-responder.lock.yml
+++ b/.github/workflows/review-responder.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"66aa5af030fe6385d40348b5ee30b6c7f1a44b0b8826d9ad6de1bd92b3cfbc9c","compiler_version":"v0.68.7","strict":true,"agent_id":"copilot","agent_model":"claude-opus-4.6"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"7de70f5953db8b88dede817669eb3d4a5e5551f3eda1007cc980444f1bc4ceec","compiler_version":"v0.68.7","strict":true,"agent_id":"copilot","agent_model":"claude-opus-4.6"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_CI_TRIGGER_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GH_AW_WRITE_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"f52802884d655622f0a2dfd6d6a2250983c95523","version":"v0.68.7"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.23"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.23"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.23"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.2.22"},{"image":"ghcr.io/github/github-mcp-server:v0.32.0"},{"image":"node:lts-alpine"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -181,19 +181,19 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_793a938b67e2b0b0_EOF'
+          cat << 'GH_AW_PROMPT_52f2db792afe9fa1_EOF'
           <system>
-          GH_AW_PROMPT_793a938b67e2b0b0_EOF
+          GH_AW_PROMPT_52f2db792afe9fa1_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_793a938b67e2b0b0_EOF'
+          cat << 'GH_AW_PROMPT_52f2db792afe9fa1_EOF'
           <safe-output-tools>
           Tools: reply_to_pull_request_review_comment(max:10), add_labels, push_to_pull_request_branch, missing_tool, missing_data, noop
-          GH_AW_PROMPT_793a938b67e2b0b0_EOF
+          GH_AW_PROMPT_52f2db792afe9fa1_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_push_to_pr_branch.md"
-          cat << 'GH_AW_PROMPT_793a938b67e2b0b0_EOF'
+          cat << 'GH_AW_PROMPT_52f2db792afe9fa1_EOF'
           </safe-output-tools>
           <github-context>
           The following GitHub context information is available for this workflow:
@@ -226,13 +226,13 @@ jobs:
             - **Note**: If a branch you need is not in the list above and is not listed as an additional fetched ref, it has NOT been checked out. For private repositories you cannot fetch it without proper authentication. If the branch is required and not available, exit with an error and ask the user to add it to the `fetch:` option of the `checkout:` configuration (e.g., `fetch: ["refs/pulls/open/*"]` for all open PR refs, or `fetch: ["main", "feature/my-branch"]` for specific branches).
           </github-context>
           
-          GH_AW_PROMPT_793a938b67e2b0b0_EOF
+          GH_AW_PROMPT_52f2db792afe9fa1_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_793a938b67e2b0b0_EOF'
+          cat << 'GH_AW_PROMPT_52f2db792afe9fa1_EOF'
           </system>
           {{#runtime-import .github/workflows/shared/fetch-review-comments.md}}
           {{#runtime-import .github/workflows/review-responder.md}}
-          GH_AW_PROMPT_793a938b67e2b0b0_EOF
+          GH_AW_PROMPT_52f2db792afe9fa1_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
@@ -421,14 +421,15 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << GH_AW_SAFE_OUTPUTS_CONFIG_c424ae3782670268_EOF
-          {"add_labels":{"github-token":"${GH_AW_WRITE_TOKEN}"},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"false"},"push_to_pull_request_branch":{"github-token":"${GH_AW_WRITE_TOKEN}","if_no_changes":"warn","labels":["aw"],"max_patch_size":1024,"protected_files":["package.json","bun.lockb","bunfig.toml","deno.json","deno.jsonc","deno.lock","global.json","NuGet.Config","Directory.Packages.props","mix.exs","mix.lock","go.mod","go.sum","stack.yaml","stack.yaml.lock","pom.xml","build.gradle","build.gradle.kts","settings.gradle","settings.gradle.kts","gradle.properties","package-lock.json","yarn.lock","pnpm-lock.yaml","npm-shrinkwrap.json","requirements.txt","Pipfile","Pipfile.lock","pyproject.toml","setup.py","setup.cfg","Gemfile","Gemfile.lock","uv.lock","CODEOWNERS","AGENTS.md","CLAUDE.md","GEMINI.md"],"protected_path_prefixes":[".github/",".agents/"],"target":"*"},"reply_to_pull_request_review_comment":{"github-token":"${GH_AW_WRITE_TOKEN}","max":10,"target":"*"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_c424ae3782670268_EOF
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << GH_AW_SAFE_OUTPUTS_CONFIG_21d9231e3e3aa0f1_EOF
+          {"add_labels":{"github-token":"${GH_AW_WRITE_TOKEN}","target":"*"},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"false"},"push_to_pull_request_branch":{"github-token":"${GH_AW_WRITE_TOKEN}","if_no_changes":"warn","labels":["aw"],"max_patch_size":1024,"protected_files":["package.json","bun.lockb","bunfig.toml","deno.json","deno.jsonc","deno.lock","global.json","NuGet.Config","Directory.Packages.props","mix.exs","mix.lock","go.mod","go.sum","stack.yaml","stack.yaml.lock","pom.xml","build.gradle","build.gradle.kts","settings.gradle","settings.gradle.kts","gradle.properties","package-lock.json","yarn.lock","pnpm-lock.yaml","npm-shrinkwrap.json","requirements.txt","Pipfile","Pipfile.lock","pyproject.toml","setup.py","setup.cfg","Gemfile","Gemfile.lock","uv.lock","CODEOWNERS","AGENTS.md","CLAUDE.md","GEMINI.md"],"protected_path_prefixes":[".github/",".agents/"],"target":"*"},"reply_to_pull_request_review_comment":{"github-token":"${GH_AW_WRITE_TOKEN}","max":10,"target":"*"},"report_incomplete":{}}
+          GH_AW_SAFE_OUTPUTS_CONFIG_21d9231e3e3aa0f1_EOF
       - name: Write Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
             {
               "description_suffixes": {
+                "add_labels": " CONSTRAINTS: Target: *.",
                 "reply_to_pull_request_review_comment": " CONSTRAINTS: Maximum 10 reply/replies can be created."
               },
               "repo_params": {},
@@ -648,7 +649,7 @@ jobs:
           
           mkdir -p /home/runner/.copilot
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_f5b5c9a2a2630bdf_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_9c10ef917928944e_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "github": {
@@ -689,7 +690,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_f5b5c9a2a2630bdf_EOF
+          GH_AW_MCP_CONFIG_9c10ef917928944e_EOF
       - name: Download activation artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -1282,7 +1283,7 @@ jobs:
           GH_AW_ALLOWED_DOMAINS: "*.pythonhosted.org,anaconda.org,api.business.githubcopilot.com,api.enterprise.githubcopilot.com,api.github.com,api.githubcopilot.com,api.individual.githubcopilot.com,api.snapcraft.io,archive.ubuntu.com,azure.archive.ubuntu.com,binstar.org,bootstrap.pypa.io,conda.anaconda.org,conda.binstar.org,crl.geotrust.com,crl.globalsign.com,crl.identrust.com,crl.sectigo.com,crl.thawte.com,crl.usertrust.com,crl.verisign.com,crl3.digicert.com,crl4.digicert.com,crls.ssl.com,files.pythonhosted.org,github.com,host.docker.internal,json-schema.org,json.schemastore.org,keyserver.ubuntu.com,ocsp.digicert.com,ocsp.geotrust.com,ocsp.globalsign.com,ocsp.identrust.com,ocsp.sectigo.com,ocsp.ssl.com,ocsp.thawte.com,ocsp.usertrust.com,ocsp.verisign.com,packagecloud.io,packages.cloud.google.com,packages.microsoft.com,pip.pypa.io,ppa.launchpad.net,pypi.org,pypi.python.org,raw.githubusercontent.com,registry.npmjs.org,repo.anaconda.com,repo.continuum.io,s.symcb.com,s.symcd.com,security.ubuntu.com,telemetry.enterprise.githubcopilot.com,ts-crl.ws.symantec.com,ts-ocsp.ws.symantec.com,www.googleapis.com"
           GITHUB_SERVER_URL: ${{ github.server_url }}
           GITHUB_API_URL: ${{ github.api_url }}
-          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"add_labels\":{\"github-token\":\"${{ secrets.GH_AW_WRITE_TOKEN }}\"},\"create_report_incomplete_issue\":{},\"missing_data\":{},\"missing_tool\":{},\"noop\":{\"max\":1,\"report-as-issue\":\"false\"},\"push_to_pull_request_branch\":{\"github-token\":\"${{ secrets.GH_AW_WRITE_TOKEN }}\",\"if_no_changes\":\"warn\",\"labels\":[\"aw\"],\"max_patch_size\":1024,\"protected_files\":[\"package.json\",\"bun.lockb\",\"bunfig.toml\",\"deno.json\",\"deno.jsonc\",\"deno.lock\",\"global.json\",\"NuGet.Config\",\"Directory.Packages.props\",\"mix.exs\",\"mix.lock\",\"go.mod\",\"go.sum\",\"stack.yaml\",\"stack.yaml.lock\",\"pom.xml\",\"build.gradle\",\"build.gradle.kts\",\"settings.gradle\",\"settings.gradle.kts\",\"gradle.properties\",\"package-lock.json\",\"yarn.lock\",\"pnpm-lock.yaml\",\"npm-shrinkwrap.json\",\"requirements.txt\",\"Pipfile\",\"Pipfile.lock\",\"pyproject.toml\",\"setup.py\",\"setup.cfg\",\"Gemfile\",\"Gemfile.lock\",\"uv.lock\",\"CODEOWNERS\",\"AGENTS.md\",\"CLAUDE.md\",\"GEMINI.md\"],\"protected_path_prefixes\":[\".github/\",\".agents/\"],\"target\":\"*\"},\"reply_to_pull_request_review_comment\":{\"github-token\":\"${{ secrets.GH_AW_WRITE_TOKEN }}\",\"max\":10,\"target\":\"*\"},\"report_incomplete\":{}}"
+          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"add_labels\":{\"github-token\":\"${{ secrets.GH_AW_WRITE_TOKEN }}\",\"target\":\"*\"},\"create_report_incomplete_issue\":{},\"missing_data\":{},\"missing_tool\":{},\"noop\":{\"max\":1,\"report-as-issue\":\"false\"},\"push_to_pull_request_branch\":{\"github-token\":\"${{ secrets.GH_AW_WRITE_TOKEN }}\",\"if_no_changes\":\"warn\",\"labels\":[\"aw\"],\"max_patch_size\":1024,\"protected_files\":[\"package.json\",\"bun.lockb\",\"bunfig.toml\",\"deno.json\",\"deno.jsonc\",\"deno.lock\",\"global.json\",\"NuGet.Config\",\"Directory.Packages.props\",\"mix.exs\",\"mix.lock\",\"go.mod\",\"go.sum\",\"stack.yaml\",\"stack.yaml.lock\",\"pom.xml\",\"build.gradle\",\"build.gradle.kts\",\"settings.gradle\",\"settings.gradle.kts\",\"gradle.properties\",\"package-lock.json\",\"yarn.lock\",\"pnpm-lock.yaml\",\"npm-shrinkwrap.json\",\"requirements.txt\",\"Pipfile\",\"Pipfile.lock\",\"pyproject.toml\",\"setup.py\",\"setup.cfg\",\"Gemfile\",\"Gemfile.lock\",\"uv.lock\",\"CODEOWNERS\",\"AGENTS.md\",\"CLAUDE.md\",\"GEMINI.md\"],\"protected_path_prefixes\":[\".github/\",\".agents/\"],\"target\":\"*\"},\"reply_to_pull_request_review_comment\":{\"github-token\":\"${{ secrets.GH_AW_WRITE_TOKEN }}\",\"max\":10,\"target\":\"*\"},\"report_incomplete\":{}}"
           GH_AW_CI_TRIGGER_TOKEN: ${{ secrets.GH_AW_CI_TRIGGER_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GH_AW_WRITE_TOKEN }}
         with:

--- a/.github/workflows/review-responder.lock.yml
+++ b/.github/workflows/review-responder.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"7de70f5953db8b88dede817669eb3d4a5e5551f3eda1007cc980444f1bc4ceec","compiler_version":"v0.68.7","strict":true,"agent_id":"copilot","agent_model":"claude-opus-4.6"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"8caaeb004e38f4a0f93cb5307cde86005ab70baac78969056ab76ce5bfe2c9f1","compiler_version":"v0.68.7","strict":true,"agent_id":"copilot","agent_model":"claude-opus-4.6"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_CI_TRIGGER_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GH_AW_WRITE_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"f52802884d655622f0a2dfd6d6a2250983c95523","version":"v0.68.7"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.23"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.23"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.23"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.2.22"},{"image":"ghcr.io/github/github-mcp-server:v0.32.0"},{"image":"node:lts-alpine"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -181,19 +181,19 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_52f2db792afe9fa1_EOF'
+          cat << 'GH_AW_PROMPT_f01f1fc2491d70d1_EOF'
           <system>
-          GH_AW_PROMPT_52f2db792afe9fa1_EOF
+          GH_AW_PROMPT_f01f1fc2491d70d1_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_52f2db792afe9fa1_EOF'
+          cat << 'GH_AW_PROMPT_f01f1fc2491d70d1_EOF'
           <safe-output-tools>
           Tools: reply_to_pull_request_review_comment(max:10), add_labels, push_to_pull_request_branch, missing_tool, missing_data, noop
-          GH_AW_PROMPT_52f2db792afe9fa1_EOF
+          GH_AW_PROMPT_f01f1fc2491d70d1_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_push_to_pr_branch.md"
-          cat << 'GH_AW_PROMPT_52f2db792afe9fa1_EOF'
+          cat << 'GH_AW_PROMPT_f01f1fc2491d70d1_EOF'
           </safe-output-tools>
           <github-context>
           The following GitHub context information is available for this workflow:
@@ -226,13 +226,13 @@ jobs:
             - **Note**: If a branch you need is not in the list above and is not listed as an additional fetched ref, it has NOT been checked out. For private repositories you cannot fetch it without proper authentication. If the branch is required and not available, exit with an error and ask the user to add it to the `fetch:` option of the `checkout:` configuration (e.g., `fetch: ["refs/pulls/open/*"]` for all open PR refs, or `fetch: ["main", "feature/my-branch"]` for specific branches).
           </github-context>
           
-          GH_AW_PROMPT_52f2db792afe9fa1_EOF
+          GH_AW_PROMPT_f01f1fc2491d70d1_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_52f2db792afe9fa1_EOF'
+          cat << 'GH_AW_PROMPT_f01f1fc2491d70d1_EOF'
           </system>
           {{#runtime-import .github/workflows/shared/fetch-review-comments.md}}
           {{#runtime-import .github/workflows/review-responder.md}}
-          GH_AW_PROMPT_52f2db792afe9fa1_EOF
+          GH_AW_PROMPT_f01f1fc2491d70d1_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
@@ -421,15 +421,15 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << GH_AW_SAFE_OUTPUTS_CONFIG_21d9231e3e3aa0f1_EOF
-          {"add_labels":{"github-token":"${GH_AW_WRITE_TOKEN}","target":"*"},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"false"},"push_to_pull_request_branch":{"github-token":"${GH_AW_WRITE_TOKEN}","if_no_changes":"warn","labels":["aw"],"max_patch_size":1024,"protected_files":["package.json","bun.lockb","bunfig.toml","deno.json","deno.jsonc","deno.lock","global.json","NuGet.Config","Directory.Packages.props","mix.exs","mix.lock","go.mod","go.sum","stack.yaml","stack.yaml.lock","pom.xml","build.gradle","build.gradle.kts","settings.gradle","settings.gradle.kts","gradle.properties","package-lock.json","yarn.lock","pnpm-lock.yaml","npm-shrinkwrap.json","requirements.txt","Pipfile","Pipfile.lock","pyproject.toml","setup.py","setup.cfg","Gemfile","Gemfile.lock","uv.lock","CODEOWNERS","AGENTS.md","CLAUDE.md","GEMINI.md"],"protected_path_prefixes":[".github/",".agents/"],"target":"*"},"reply_to_pull_request_review_comment":{"github-token":"${GH_AW_WRITE_TOKEN}","max":10,"target":"*"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_21d9231e3e3aa0f1_EOF
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << GH_AW_SAFE_OUTPUTS_CONFIG_98f552d7372d4c6f_EOF
+          {"add_labels":{"allowed":["aw-review-response-attempted"],"github-token":"${GH_AW_WRITE_TOKEN}","max":1,"target":"${{ inputs.pr_number }}"},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"false"},"push_to_pull_request_branch":{"github-token":"${GH_AW_WRITE_TOKEN}","if_no_changes":"warn","labels":["aw"],"max_patch_size":1024,"protected_files":["package.json","bun.lockb","bunfig.toml","deno.json","deno.jsonc","deno.lock","global.json","NuGet.Config","Directory.Packages.props","mix.exs","mix.lock","go.mod","go.sum","stack.yaml","stack.yaml.lock","pom.xml","build.gradle","build.gradle.kts","settings.gradle","settings.gradle.kts","gradle.properties","package-lock.json","yarn.lock","pnpm-lock.yaml","npm-shrinkwrap.json","requirements.txt","Pipfile","Pipfile.lock","pyproject.toml","setup.py","setup.cfg","Gemfile","Gemfile.lock","uv.lock","CODEOWNERS","AGENTS.md","CLAUDE.md","GEMINI.md"],"protected_path_prefixes":[".github/",".agents/"],"target":"*"},"reply_to_pull_request_review_comment":{"github-token":"${GH_AW_WRITE_TOKEN}","max":10,"target":"*"},"report_incomplete":{}}
+          GH_AW_SAFE_OUTPUTS_CONFIG_98f552d7372d4c6f_EOF
       - name: Write Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
             {
               "description_suffixes": {
-                "add_labels": " CONSTRAINTS: Target: *.",
+                "add_labels": " CONSTRAINTS: Maximum 1 label(s) can be added. Only these labels are allowed: [\"aw-review-response-attempted\"]. Target: ${{ inputs.pr_number }}.",
                 "reply_to_pull_request_review_comment": " CONSTRAINTS: Maximum 10 reply/replies can be created."
               },
               "repo_params": {},
@@ -649,7 +649,7 @@ jobs:
           
           mkdir -p /home/runner/.copilot
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_9c10ef917928944e_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_44d78ecc9500bfb1_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "github": {
@@ -690,7 +690,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_9c10ef917928944e_EOF
+          GH_AW_MCP_CONFIG_44d78ecc9500bfb1_EOF
       - name: Download activation artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -1283,7 +1283,7 @@ jobs:
           GH_AW_ALLOWED_DOMAINS: "*.pythonhosted.org,anaconda.org,api.business.githubcopilot.com,api.enterprise.githubcopilot.com,api.github.com,api.githubcopilot.com,api.individual.githubcopilot.com,api.snapcraft.io,archive.ubuntu.com,azure.archive.ubuntu.com,binstar.org,bootstrap.pypa.io,conda.anaconda.org,conda.binstar.org,crl.geotrust.com,crl.globalsign.com,crl.identrust.com,crl.sectigo.com,crl.thawte.com,crl.usertrust.com,crl.verisign.com,crl3.digicert.com,crl4.digicert.com,crls.ssl.com,files.pythonhosted.org,github.com,host.docker.internal,json-schema.org,json.schemastore.org,keyserver.ubuntu.com,ocsp.digicert.com,ocsp.geotrust.com,ocsp.globalsign.com,ocsp.identrust.com,ocsp.sectigo.com,ocsp.ssl.com,ocsp.thawte.com,ocsp.usertrust.com,ocsp.verisign.com,packagecloud.io,packages.cloud.google.com,packages.microsoft.com,pip.pypa.io,ppa.launchpad.net,pypi.org,pypi.python.org,raw.githubusercontent.com,registry.npmjs.org,repo.anaconda.com,repo.continuum.io,s.symcb.com,s.symcd.com,security.ubuntu.com,telemetry.enterprise.githubcopilot.com,ts-crl.ws.symantec.com,ts-ocsp.ws.symantec.com,www.googleapis.com"
           GITHUB_SERVER_URL: ${{ github.server_url }}
           GITHUB_API_URL: ${{ github.api_url }}
-          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"add_labels\":{\"github-token\":\"${{ secrets.GH_AW_WRITE_TOKEN }}\",\"target\":\"*\"},\"create_report_incomplete_issue\":{},\"missing_data\":{},\"missing_tool\":{},\"noop\":{\"max\":1,\"report-as-issue\":\"false\"},\"push_to_pull_request_branch\":{\"github-token\":\"${{ secrets.GH_AW_WRITE_TOKEN }}\",\"if_no_changes\":\"warn\",\"labels\":[\"aw\"],\"max_patch_size\":1024,\"protected_files\":[\"package.json\",\"bun.lockb\",\"bunfig.toml\",\"deno.json\",\"deno.jsonc\",\"deno.lock\",\"global.json\",\"NuGet.Config\",\"Directory.Packages.props\",\"mix.exs\",\"mix.lock\",\"go.mod\",\"go.sum\",\"stack.yaml\",\"stack.yaml.lock\",\"pom.xml\",\"build.gradle\",\"build.gradle.kts\",\"settings.gradle\",\"settings.gradle.kts\",\"gradle.properties\",\"package-lock.json\",\"yarn.lock\",\"pnpm-lock.yaml\",\"npm-shrinkwrap.json\",\"requirements.txt\",\"Pipfile\",\"Pipfile.lock\",\"pyproject.toml\",\"setup.py\",\"setup.cfg\",\"Gemfile\",\"Gemfile.lock\",\"uv.lock\",\"CODEOWNERS\",\"AGENTS.md\",\"CLAUDE.md\",\"GEMINI.md\"],\"protected_path_prefixes\":[\".github/\",\".agents/\"],\"target\":\"*\"},\"reply_to_pull_request_review_comment\":{\"github-token\":\"${{ secrets.GH_AW_WRITE_TOKEN }}\",\"max\":10,\"target\":\"*\"},\"report_incomplete\":{}}"
+          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"add_labels\":{\"allowed\":[\"aw-review-response-attempted\"],\"github-token\":\"${{ secrets.GH_AW_WRITE_TOKEN }}\",\"max\":1,\"target\":\"${{ inputs.pr_number }}\"},\"create_report_incomplete_issue\":{},\"missing_data\":{},\"missing_tool\":{},\"noop\":{\"max\":1,\"report-as-issue\":\"false\"},\"push_to_pull_request_branch\":{\"github-token\":\"${{ secrets.GH_AW_WRITE_TOKEN }}\",\"if_no_changes\":\"warn\",\"labels\":[\"aw\"],\"max_patch_size\":1024,\"protected_files\":[\"package.json\",\"bun.lockb\",\"bunfig.toml\",\"deno.json\",\"deno.jsonc\",\"deno.lock\",\"global.json\",\"NuGet.Config\",\"Directory.Packages.props\",\"mix.exs\",\"mix.lock\",\"go.mod\",\"go.sum\",\"stack.yaml\",\"stack.yaml.lock\",\"pom.xml\",\"build.gradle\",\"build.gradle.kts\",\"settings.gradle\",\"settings.gradle.kts\",\"gradle.properties\",\"package-lock.json\",\"yarn.lock\",\"pnpm-lock.yaml\",\"npm-shrinkwrap.json\",\"requirements.txt\",\"Pipfile\",\"Pipfile.lock\",\"pyproject.toml\",\"setup.py\",\"setup.cfg\",\"Gemfile\",\"Gemfile.lock\",\"uv.lock\",\"CODEOWNERS\",\"AGENTS.md\",\"CLAUDE.md\",\"GEMINI.md\"],\"protected_path_prefixes\":[\".github/\",\".agents/\"],\"target\":\"*\"},\"reply_to_pull_request_review_comment\":{\"github-token\":\"${{ secrets.GH_AW_WRITE_TOKEN }}\",\"max\":10,\"target\":\"*\"},\"report_incomplete\":{}}"
           GH_AW_CI_TRIGGER_TOKEN: ${{ secrets.GH_AW_CI_TRIGGER_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GH_AW_WRITE_TOKEN }}
         with:

--- a/.github/workflows/review-responder.md
+++ b/.github/workflows/review-responder.md
@@ -44,7 +44,9 @@ safe-outputs:
     max: 10
     github-token: ${{ secrets.GH_AW_WRITE_TOKEN }}
   add-labels:
-    target: "*"
+    allowed: [aw-review-response-attempted]
+    target: "${{ inputs.pr_number }}"
+    max: 1
     github-token: ${{ secrets.GH_AW_WRITE_TOKEN }}
 
 ---

--- a/.github/workflows/review-responder.md
+++ b/.github/workflows/review-responder.md
@@ -44,6 +44,7 @@ safe-outputs:
     max: 10
     github-token: ${{ secrets.GH_AW_WRITE_TOKEN }}
   add-labels:
+    target: "*"
     github-token: ${{ secrets.GH_AW_WRITE_TOKEN }}
 
 ---


### PR DESCRIPTION
Closes #1036.

## Problem

The responder workflow could enter an infinite dispatch loop: under `workflow_dispatch`, its `add_labels` safe-output call was failing with `No issue/PR number available`, so the `aw-review-response-attempted` loop-stopper label never landed. The orchestrator's round cap was gated on that label, so the cap never engaged. Result: 6h runner timeouts, 31h pipeline freeze observed on PR #1015.

## Fixes

### 1. Scope `add_labels` to least privilege (`.github/workflows/review-responder.md`)

```yaml
add-labels:
  allowed: [aw-review-response-attempted]
  target: "${{ inputs.pr_number }}"
  max: 1
```

- `allowed:` is server-enforced by gh-aw's safe-output handler. Any other label value is rejected before the GitHub API is called. This is the real security boundary and closes the prompt-injection vector: a malicious review comment can no longer drive the agent to apply arbitrary labels on arbitrary issues/PRs.
- `target: ${{ inputs.pr_number }}` is agent-guidance only (gh-aw's `add_labels` handler does not enforce `target` at runtime — verified in `actions/setup/js/add_labels.cjs`), but keeps the model pointed at the dispatched PR.
- `max: 1` is server-enforced.

Lock file recompiled via `gh aw compile review-responder`.

### 2. Orchestrator round counter (`.github/workflows/pipeline-orchestrator.yml`)

Cap counts orchestrator-applied `aw-review-response-N` labels directly (was previously gated on the responder-applied `aw-review-response-attempted` — the label that couldn't be applied). Max raised from 3 to 5 per request. On cap-hit: adds `aw-pr-stuck:review` + comment, skips dispatch.

**Trust model documented inline**: the counter lives in PR labels, which only repo collaborators with triage/write can modify. On `microsasa/cli-tools` that is the sole owner. If outside collaborators are ever granted triage, the counter becomes forgeable and this block needs revisiting.

### 3. Dispatch path hardening

Previous version used `gh pr edit --remove-label ... 2>/dev/null || true` and an unchecked `gh pr edit --add-label`, silently swallowing auth/rate-limit/timeout failures — the same class of failure that caused the original loop.

New flow: pre-check label presence, check exit codes on both `gh pr edit` calls, and bail this cron tick on any failure (cron retries). "Label not present" is the only legitimately-ignorable case.

### 4. Antipattern doc (`.github/CODING_GUIDELINES.md`)

"Concurrency and I/O State" section codifying the shared-I/O-state antipattern from PR #1015. Reachable to agents transitively: `.github/copilot-instructions.md` already points at `CODING_GUIDELINES.md`. Prose-only by design; mechanical enforcement (AST check) is out of scope and would be a follow-up only if the pattern recurs.

### 5. Dead code removal

Removed vestigial `HAS_RESPONSE_LABEL=...` assignment (no readers after the rework).

## What this PR does NOT do (council findings explicitly evaluated and declined)

- **No migration code for PRs in the old `aw-review-response-attempted` state.** Verified at the time of this commit: zero open PRs are in that state (`gh pr list --label aw-review-response-attempted` returns `[]`). Re-verify before merge if this PR sits.
- **No CAS/atomicity rework.** The existing workflow-level `concurrency:` block (lines 36–38) already serializes orchestrator runs across schedule + `workflow_dispatch`. The TOCTOU race the review flagged is not reachable under this setup.
- **No CI enforcement for the antipattern.** Grep-based checks are fragile; AST checks are out of scope.
- **No new automated tests.** The change is pure workflow yaml; the Python test harness cannot exercise it. Manual verification plan below.

## Verification

### Automated
- `make check` passes (Python-only: ruff, pyright, bandit, pytest). **Does not validate workflow yaml** — do not treat this as coverage of the changed files.
- `python -c "import yaml; yaml.safe_load(...)"` parses both `pipeline-orchestrator.yml` and `review-responder.lock.yml` without error.
- `gh aw compile review-responder` regenerates the lock file deterministically; lock reflects the new `allowed`/`target`/`max` config.

### Manual test plan (to run post-merge on a test PR)

1. **Cap boundary**: on a scratch `aw`-labeled PR, pre-add `aw-review-response-1..4`; trigger orchestrator; confirm it dispatches round 5. Add `aw-review-response-5`; trigger again; confirm it applies `aw-pr-stuck:review` and does **not** dispatch.
2. **Add-label failure bail-out**: temporarily revoke `GH_AW_WRITE_TOKEN`; trigger orchestrator; confirm it logs the failure and does not call `gh workflow run`.
3. **Concurrency group**: trigger two manual dispatches back-to-back; confirm second run queues (Actions UI shows "waiting") rather than executing in parallel.
4. **add_labels allowlist**: from the responder, emit a safe-output requesting a label other than `aw-review-response-attempted`; confirm handler rejects it (logs show `"Only allowed: ..."`).

## Review council

This PR was reviewed by a 10-reviewer adversarial council (5 personas × 2 distinct models each from {opus-4.6, opus-4.7, gpt-5.3-codex, gpt-5.4, sonnet-4.6}). The prior revision received 5 REJECT / 5 APPROVE_WITH_REQUIRED_CHANGES verdicts. Current revision directly addresses the cross-persona BLOCKERs (prompt-injection vector, silent failure) and documents the findings declined and why.
