### PR TITLE
fix: remove redundant time guard in `_normalize_until` (#1026)

### DIFF
--- a/src/copilot_usage/cli.py
+++ b/src/copilot_usage/cli.py
@@ -9,7 +9,7 @@ import select
 import sys
 import threading
 from dataclasses import dataclass
-from datetime import datetime, time as dt_time
+from datetime import datetime
 from pathlib import Path
 from typing import Final, Literal
 
@@ -126,7 +126,7 @@ def _normalize_until(arg: _ParsedDateArg | None) -> datetime | None:
     if arg is None:
         return None
     aware = ensure_aware(arg.value)
-    if not arg.has_explicit_time and aware.time() == dt_time(0, 0, 0):
+    if not arg.has_explicit_time:
         return aware.replace(hour=23, minute=59, second=59, microsecond=999999)
     return aware
 

--- a/tests/copilot_usage/test_cli.py
+++ b/tests/copilot_usage/test_cli.py
@@ -3019,6 +3019,24 @@ class TestNormalizeUntil:
         assert result.tzinfo is not None
         assert result.hour == 23
 
+    def test_non_midnight_with_no_explicit_time_expanded(self) -> None:
+        """Regression for issue #1026: expansion depends solely on has_explicit_time.
+
+        Constructs a _ParsedDateArg with has_explicit_time=False but a
+        non-midnight time component.  Before the fix, the redundant
+        ``aware.time() == dt_time(0, 0, 0)`` guard prevented expansion.
+        """
+        arg = _ParsedDateArg(
+            value=datetime(2025, 1, 15, 12, 30, 0, tzinfo=UTC),
+            has_explicit_time=False,
+        )
+        result = _normalize_until(arg)
+        assert result is not None
+        assert result.hour == 23
+        assert result.minute == 59
+        assert result.second == 59
+        assert result.microsecond == 999999
+
 
 class TestNormalizeUntilNonUtcTimezone:
     """_normalize_until preserves non-UTC timezone offsets when expanding date-only."""


### PR DESCRIPTION
Closes #1026

## Problem

`_normalize_until` contained a redundant condition:

```python
if not arg.has_explicit_time and aware.time() == dt_time(0, 0, 0):
```

The second check (`aware.time() == dt_time(0, 0, 0)`) is permanently `True` whenever `has_explicit_time` is `False`, because the only format that sets `has_explicit_time=False` is `"%Y-%m-%d"` which always produces midnight. This dead condition misleads readers and creates a latent correctness risk.

## Changes

- **`src/copilot_usage/cli.py`**: Simplified the condition to `if not arg.has_explicit_time:` and removed the unused `dt_time` import.
- **`tests/copilot_usage/test_cli.py`**: Added a regression test (`test_non_midnight_with_no_explicit_time_expanded`) that directly constructs a `_ParsedDateArg` with `has_explicit_time=False` and a non-midnight time, verifying expansion still occurs. This test would have failed on the old code.

## Verification

- All existing tests pass (1427 passed)
- Lint, typecheck, and security scans clean




> Generated by [Issue Implementer](https://github.com/microsasa/cli-tools/actions/runs/24736510782/agentic_workflow) · ● 5M · [◷](https://github.com/search?q=repo%3Amicrosasa%2Fcli-tools+%22gh-aw-workflow-id%3A+issue-implementer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Issue Implementer, engine: copilot, model: claude-opus-4.6, id: 24736510782, workflow_id: issue-implementer, run: https://github.com/microsasa/cli-tools/actions/runs/24736510782 -->

<!-- gh-aw-workflow-id: issue-implementer -->