### PR TITLE
fix: dead code cleanup — unused imports and untyped `__version__` (#1029)

### DIFF
--- a/src/copilot_usage/__init__.py
+++ b/src/copilot_usage/__init__.py
@@ -1,3 +1,6 @@
 from importlib.metadata import version
+from typing import Final
 
-__version__ = version("cli-tools")
+__all__: Final[list[str]] = ["__version__"]
+
+__version__: str = version("cli-tools")

--- a/src/copilot_usage/cli.py
+++ b/src/copilot_usage/cli.py
@@ -19,13 +19,9 @@ from rich.console import Console
 
 from copilot_usage import __version__
 from copilot_usage.interactive import (
-    FileChangeEventHandler as _FileChangeEventHandler,  # noqa: F401  # pyright: ignore[reportUnusedImport]
-    FileChangeHandler as _FileChangeHandler,  # noqa: F401  # pyright: ignore[reportUnusedImport]
-    Stoppable as _Stoppable,  # noqa: F401  # pyright: ignore[reportUnusedImport]
     build_session_index as _build_session_index,
     draw_home as _draw_home,
     print_version_header as _print_version_header,
-    render_session_list as _render_session_list,  # noqa: F401  # pyright: ignore[reportUnusedImport]
     start_observer as _start_observer,
     stop_observer as _stop_observer,
     write_prompt as _write_prompt,
@@ -110,9 +106,6 @@ class _DateTimeOrDate(click.ParamType):
             except ValueError:
                 continue
         return None
-
-
-console: Final[Console] = Console()
 
 
 def _normalize_until(arg: _ParsedDateArg | None) -> datetime | None:

--- a/tests/copilot_usage/test_cli.py
+++ b/tests/copilot_usage/test_cli.py
@@ -28,13 +28,13 @@ from copilot_usage.cli import (
     _ParsedDateArg,
     _print_version_header,
     _read_line_nonblocking,
-    _render_session_list,
     _show_session_by_index,
     _start_observer,
     _stop_observer,
     _validate_since_until,
     main,
 )
+from copilot_usage.interactive import render_session_list as _render_session_list
 from copilot_usage.models import ensure_aware_opt
 
 # ---------------------------------------------------------------------------
@@ -887,8 +887,8 @@ class TestFileChangeHandler:
 
     def test_dispatch_sets_event_on_first_call(self) -> None:
         """First dispatch call within a cold window sets the change_event."""
-        from copilot_usage.cli import (
-            _FileChangeHandler,
+        from copilot_usage.interactive import (
+            FileChangeHandler as _FileChangeHandler,
         )
 
         event = threading.Event()
@@ -900,8 +900,8 @@ class TestFileChangeHandler:
         """Second dispatch call within 2 s is suppressed (debounce)."""
         import time as _time
 
-        from copilot_usage.cli import (
-            _FileChangeHandler,
+        from copilot_usage.interactive import (
+            FileChangeHandler as _FileChangeHandler,
         )
 
         event = threading.Event()
@@ -919,8 +919,8 @@ class TestFileChangeHandler:
         """Dispatch fires again after > 2 s gap."""
         import time as _time
 
-        from copilot_usage.cli import (
-            _FileChangeHandler,
+        from copilot_usage.interactive import (
+            FileChangeHandler as _FileChangeHandler,
         )
 
         event = threading.Event()
@@ -936,8 +936,8 @@ class TestFileChangeHandler:
 
     def test_dispatch_interface(self) -> None:
         """_FileChangeHandler provides a dispatch(event) interface compatible with watchdog handlers."""
-        from copilot_usage.cli import (
-            _FileChangeHandler,
+        from copilot_usage.interactive import (
+            FileChangeHandler as _FileChangeHandler,
         )
 
         event = threading.Event()
@@ -957,8 +957,8 @@ class TestFileChangeHandler:
         """
         import time as _time
 
-        from copilot_usage.cli import (
-            _FileChangeHandler,
+        from copilot_usage.interactive import (
+            FileChangeHandler as _FileChangeHandler,
         )
 
         event = threading.Event()

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -10,6 +10,7 @@ import pytest
 
 # Modules that declare __all__ and the expected public names.
 _PUBLIC_MODULES: list[str] = [
+    "copilot_usage",
     "copilot_usage._formatting",
     "copilot_usage._fs_utils",
     "copilot_usage.cli",


### PR DESCRIPTION
Closes #1029

## Changes

**Finding 1 — Remove dead re-import aliases in `cli.py`**
Removed four unused alias imports from `copilot_usage.interactive` that were kept solely to satisfy tests importing through `cli.py`. Each had `noqa: F401` and `pyright: ignore[reportUnusedImport]` suppressors:
- `FileChangeEventHandler as _FileChangeEventHandler`
- `FileChangeHandler as _FileChangeHandler`
- `Stoppable as _Stoppable`
- `render_session_list as _render_session_list`

Updated `tests/copilot_usage/test_cli.py` to import `FileChangeHandler` and `render_session_list` directly from `copilot_usage.interactive`.

**Finding 2 — Remove unused `Console` instance in `cli.py`**
Deleted the module-level `console: Final[Console] = Console()` (previously line 115) which was never referenced. The `Console` import is retained for use in the `_show_session_by_index` type annotation.

**Finding 3 — Add `__all__` and type annotation to `__init__.py`**
Added `__all__: Final[list[str]] = ["__version__"]` and an explicit `str` annotation to `__version__`, matching the project convention used by every other module.

Added `"copilot_usage"` to `_PUBLIC_MODULES` in `tests/test_packaging.py` so the packaging test validates the new `__all__`.

## Verification
- `ruff check` / `ruff format --check` — clean
- `pyright` — 0 errors (3 pre-existing warnings in test fixtures)
- All 1428 unit tests pass; all 91 e2e tests pass




> Generated by [Issue Implementer](https://github.com/microsasa/cli-tools/actions/runs/24737014360/agentic_workflow) · ● 9.4M · [◷](https://github.com/search?q=repo%3Amicrosasa%2Fcli-tools+%22gh-aw-workflow-id%3A+issue-implementer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Issue Implementer, engine: copilot, model: claude-opus-4.6, id: 24737014360, workflow_id: issue-implementer, run: https://github.com/microsasa/cli-tools/actions/runs/24737014360 -->

<!-- gh-aw-workflow-id: issue-implementer -->