### PR TITLE
fix: import format_duration and format_tokens from canonical module (#1034)

### DIFF
--- a/tests/copilot_usage/test_report.py
+++ b/tests/copilot_usage/test_report.py
@@ -15,7 +15,9 @@ from pydantic import ValidationError
 from rich.console import Console
 
 from copilot_usage._formatting import (
+    format_duration,
     format_timedelta,
+    format_tokens,
     hms,
 )
 from copilot_usage.models import (
@@ -59,8 +61,6 @@ from copilot_usage.report import (
     _format_session_running_time,
     _render_model_table,
     _render_session_table,
-    format_duration,
-    format_tokens,
     render_cost_view,
     render_full_summary,
     render_live_sessions,


### PR DESCRIPTION
Closes #1034

## Problem

`tests/copilot_usage/test_report.py` imports `format_duration` and `format_tokens` from `copilot_usage.report`, but these helpers are not part of `report.__all__` — their canonical home is `copilot_usage._formatting`. This creates fragile coupling: if `report.py` ever stops importing them internally, 8+ tests would break at import time.

The same file already correctly imports `format_timedelta` and `hms` from `copilot_usage._formatting`, making the inconsistency visible at a glance.

## Fix

Moved `format_duration` and `format_tokens` from the `copilot_usage.report` import block to the existing `copilot_usage._formatting` import block in `test_report.py`.

No production code changes.

## Verification

- `make fix` — no lint/format issues
- `make check` — all checks pass (lint ✅, typecheck ✅, security ✅, unit tests 99% coverage ✅, e2e 91 passed ✅)




> Generated by [Issue Implementer](https://github.com/microsasa/cli-tools/actions/runs/24741093334/agentic_workflow) · ● 3.1M · [◷](https://github.com/search?q=repo%3Amicrosasa%2Fcli-tools+%22gh-aw-workflow-id%3A+issue-implementer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Issue Implementer, engine: copilot, model: claude-opus-4.6, id: 24741093334, workflow_id: issue-implementer, run: https://github.com/microsasa/cli-tools/actions/runs/24741093334 -->

<!-- gh-aw-workflow-id: issue-implementer -->