### PR TITLE
fix: use single per-call Console in non-interactive CLI commands (#1045)

### DIFF
--- a/src/copilot_usage/cli.py
+++ b/src/copilot_usage/cli.py
@@ -439,13 +439,14 @@ def summary(
     """Show usage summary across all sessions."""
     path = path or ctx.obj.get("path")
     aware_since, aware_until = _validate_since_until(since, until)
-    _print_version_header()
+    c = Console()
+    _print_version_header(target=c)
     try:
         sessions = get_all_sessions(path)
     except OSError as exc:
         click.echo(f"Error reading sessions: {exc}", err=True)
         sys.exit(1)
-    render_summary(sessions, since=aware_since, until=aware_until)
+    render_summary(sessions, since=aware_since, until=aware_until, target_console=c)
 
 
 # ---------------------------------------------------------------------------
@@ -468,7 +469,8 @@ def session(ctx: click.Context, session_id: str, path: Path | None) -> None:
         click.echo("Error: session ID cannot be empty.", err=True)
         sys.exit(1)
 
-    _print_version_header()
+    c = Console()
+    _print_version_header(target=c)
     path = path or ctx.obj.get("path")
     try:
         all_sessions = get_all_sessions(path)
@@ -502,7 +504,7 @@ def session(ctx: click.Context, session_id: str, path: Path | None) -> None:
         click.echo(f"Error reading session: {exc}", err=True)
         sys.exit(1)
 
-    render_session_detail(events, matched)
+    render_session_detail(events, matched, target_console=c)
 
 
 # ---------------------------------------------------------------------------
@@ -539,14 +541,15 @@ def cost(
     """Show premium request costs from shutdown data."""
     path = path or ctx.obj.get("path")
     aware_since, aware_until = _validate_since_until(since, until)
-    _print_version_header()
+    c = Console()
+    _print_version_header(target=c)
     try:
         sessions = get_all_sessions(path)
     except OSError as exc:
         click.echo(f"Error reading sessions: {exc}", err=True)
         sys.exit(1)
 
-    render_cost_view(sessions, since=aware_since, until=aware_until)
+    render_cost_view(sessions, since=aware_since, until=aware_until, target_console=c)
 
 
 # ---------------------------------------------------------------------------
@@ -564,14 +567,15 @@ def cost(
 @click.pass_context
 def live(ctx: click.Context, path: Path | None) -> None:
     """Show usage for active sessions."""
-    _print_version_header()
+    c = Console()
+    _print_version_header(target=c)
     path = path or ctx.obj.get("path")
     try:
         sessions = get_all_sessions(path)
     except OSError as exc:
         click.echo(f"Error reading sessions: {exc}", err=True)
         sys.exit(1)
-    render_live_sessions(sessions)
+    render_live_sessions(sessions, target_console=c)
 
 
 # ---------------------------------------------------------------------------
@@ -591,7 +595,8 @@ def vscode(vscode_logs: Path | None) -> None:
     from copilot_usage.vscode_parser import get_vscode_summary
     from copilot_usage.vscode_report import render_vscode_summary
 
-    _print_version_header()
+    c = Console()
+    _print_version_header(target=c)
     summary = get_vscode_summary(vscode_logs)
     if summary.total_requests == 0:
         if summary.log_files_found > 0 and summary.log_files_parsed == 0:
@@ -599,4 +604,4 @@ def vscode(vscode_logs: Path | None) -> None:
         else:
             click.echo("No VS Code Copilot Chat requests found.", err=True)
         sys.exit(1)
-    render_vscode_summary(summary)
+    render_vscode_summary(summary, target_console=c)

--- a/src/copilot_usage/interactive.py
+++ b/src/copilot_usage/interactive.py
@@ -41,16 +41,16 @@ WATCHDOG_DEBOUNCE_SECS: Final[float] = (
 )
 
 
-def print_version_header(target: Console) -> None:
+def print_version_header(target: Console | None = None) -> None:
     """Print 'Copilot Usage' left-aligned with version right-aligned."""
-    c = target
+    console = target or Console()
     title = "Copilot Usage"
     version_text = f"v{__version__}"
     header = Text()
     header.append(title, style="bold")
-    header.append(" " * max(1, c.width - len(title) - len(version_text)))
+    header.append(" " * max(1, console.width - len(title) - len(version_text)))
     header.append(version_text, style="dim")
-    c.print(header)
+    console.print(header)
 
 
 def render_session_list(console: Console, sessions: list[SessionSummary]) -> None:

--- a/src/copilot_usage/interactive.py
+++ b/src/copilot_usage/interactive.py
@@ -40,12 +40,10 @@ WATCHDOG_DEBOUNCE_SECS: Final[float] = (
     2.0  # Prevents rapid redraws during tool-use bursts
 )
 
-console: Final[Console] = Console()
 
-
-def print_version_header(target: Console | None = None) -> None:
+def print_version_header(target: Console) -> None:
     """Print 'Copilot Usage' left-aligned with version right-aligned."""
-    c = target or console
+    c = target
     title = "Copilot Usage"
     version_text = f"v{__version__}"
     header = Text()

--- a/tests/copilot_usage/test_cli.py
+++ b/tests/copilot_usage/test_cli.py
@@ -3919,9 +3919,12 @@ def test_build_session_index_duplicate_ids() -> None:
 class TestSingleConsolePerCommand:
     """Each non-interactive command should construct exactly one Console.
 
-    Verifies the fix for issue #1045 by spying on ``copilot_usage.cli.Console``
-    construction during a command invocation and asserting the command reuses
-    that single Console for both the version header and the report body.
+    Verifies the fix for issue #1045 by patching ``Console`` in the CLI
+    module **and** every renderer module (``report``, ``render_detail``,
+    ``interactive``, ``vscode_report``).  If any renderer falls back to
+    creating its own ``Console()`` (because ``target_console`` was not
+    forwarded), the spy will record a second construction and the
+    ``len(created_consoles) == 1`` assertion will fail.
     """
 
     def _invoke_and_capture_consoles(
@@ -3929,8 +3932,17 @@ class TestSingleConsolePerCommand:
         monkeypatch: pytest.MonkeyPatch,
         args: list[str],
     ) -> tuple[Any, list[Console]]:
-        """Invoke a CLI command and record every Console created by the CLI module."""
+        """Invoke a CLI command and record every ``Console`` created.
+
+        Patches ``Console`` in the CLI module and all renderer modules so
+        that a fallback ``target_console or Console()`` in any renderer is
+        caught as a second construction.
+        """
         import copilot_usage.cli as cli_module
+        import copilot_usage.interactive as interactive_module
+        import copilot_usage.render_detail as render_detail_module
+        import copilot_usage.report as report_module
+        import copilot_usage.vscode_report as vscode_report_module
 
         created_consoles: list[Console] = []
         original_console = cli_module.Console
@@ -3941,6 +3953,10 @@ class TestSingleConsolePerCommand:
             return console
 
         monkeypatch.setattr(cli_module, "Console", recording_console)
+        monkeypatch.setattr(interactive_module, "Console", recording_console)
+        monkeypatch.setattr(report_module, "Console", recording_console)
+        monkeypatch.setattr(render_detail_module, "Console", recording_console)
+        monkeypatch.setattr(vscode_report_module, "Console", recording_console)
         runner = CliRunner()
         result = runner.invoke(main, args)
         assert result.exit_code == 0

--- a/tests/copilot_usage/test_cli.py
+++ b/tests/copilot_usage/test_cli.py
@@ -3917,69 +3917,121 @@ def test_build_session_index_duplicate_ids() -> None:
 
 
 class TestSingleConsolePerCommand:
-    """Each non-interactive command writes version header and report body to one Console.
+    """Each non-interactive command should construct exactly one Console.
 
-    Verifies the fix for issue #1045: both the version header text (e.g.
-    "Copilot Usage") and the command-specific report body appear in the
-    same captured output, proving a single Console instance is used.
+    Verifies the fix for issue #1045 by spying on ``copilot_usage.cli.Console``
+    construction during a command invocation and asserting the command reuses
+    that single Console for both the version header and the report body.
     """
 
-    def test_summary_header_and_body_same_console(self, tmp_path: Path) -> None:
-        """summary command: header and body appear in the same output."""
-        _write_session(tmp_path, "aaaa1111-0000-0000-0000-000000000000", name="First")
+    def _invoke_and_capture_consoles(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        args: list[str],
+    ) -> tuple[Any, list[Console]]:
+        """Invoke a CLI command and record every Console created by the CLI module."""
+        import copilot_usage.cli as cli_module
+
+        created_consoles: list[Console] = []
+        original_console = cli_module.Console
+
+        def recording_console(*a: Any, **kw: Any) -> Console:
+            console = original_console(*a, **kw)
+            created_consoles.append(console)
+            return console
+
+        monkeypatch.setattr(cli_module, "Console", recording_console)
         runner = CliRunner()
-        result = runner.invoke(main, ["summary", "--path", str(tmp_path)])
+        result = runner.invoke(main, args)
         assert result.exit_code == 0
+        assert len(created_consoles) == 1
+        return result, created_consoles
+
+    def test_summary_header_and_body_same_console(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """summary command: one Console renders both header and body."""
+        _write_session(tmp_path, "aaaa1111-0000-0000-0000-000000000000", name="First")
+        result, created_consoles = self._invoke_and_capture_consoles(
+            monkeypatch,
+            ["summary", "--path", str(tmp_path)],
+        )
+        assert len(created_consoles) == 1
         output = _strip_ansi(result.output)
         assert "Copilot Usage" in output
         assert f"v{__version__}" in output
         # Report body content from render_summary
         assert "First" in output or "Summary" in output
 
-    def test_session_header_and_body_same_console(self, tmp_path: Path) -> None:
-        """session command: header and body appear in the same output."""
+    def test_session_header_and_body_same_console(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """session command: one Console renders both header and body."""
         _write_session(tmp_path, "bbbb2222-0000-0000-0000-000000000000", name="Detail")
-        runner = CliRunner()
-        result = runner.invoke(main, ["session", "bbbb2222", "--path", str(tmp_path)])
-        assert result.exit_code == 0
+        result, created_consoles = self._invoke_and_capture_consoles(
+            monkeypatch,
+            ["session", "bbbb2222", "--path", str(tmp_path)],
+        )
+        assert len(created_consoles) == 1
         output = _strip_ansi(result.output)
         assert "Copilot Usage" in output
         assert f"v{__version__}" in output
         assert "Session Detail" in output
 
-    def test_cost_header_and_body_same_console(self, tmp_path: Path) -> None:
-        """cost command: header and body appear in the same output."""
+    def test_cost_header_and_body_same_console(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """cost command: one Console renders both header and body."""
         _write_session(
             tmp_path,
             "cccc3333-0000-0000-0000-000000000000",
             name="Cost Test",
             premium=5,
         )
-        runner = CliRunner()
-        result = runner.invoke(main, ["cost", "--path", str(tmp_path)])
-        assert result.exit_code == 0
+        result, created_consoles = self._invoke_and_capture_consoles(
+            monkeypatch,
+            ["cost", "--path", str(tmp_path)],
+        )
+        assert len(created_consoles) == 1
         output = _strip_ansi(result.output)
         assert "Copilot Usage" in output
         assert f"v{__version__}" in output
         assert "Cost" in output or "Total" in output
 
-    def test_live_header_and_body_same_console(self, tmp_path: Path) -> None:
-        """live command: header and body appear in the same output."""
+    def test_live_header_and_body_same_console(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """live command: one Console renders both header and body."""
         _write_session(
             tmp_path,
             "dddd4444-0000-0000-0000-000000000000",
             name="Active",
             active=True,
         )
-        runner = CliRunner()
-        result = runner.invoke(main, ["live", "--path", str(tmp_path)])
-        assert result.exit_code == 0
+        result, created_consoles = self._invoke_and_capture_consoles(
+            monkeypatch,
+            ["live", "--path", str(tmp_path)],
+        )
+        assert len(created_consoles) == 1
         output = _strip_ansi(result.output)
         assert "Copilot Usage" in output
         assert f"v{__version__}" in output
+        assert "Active Copilot Sessions" in output or "Active" in output
 
-    def test_vscode_header_and_body_same_console(self, tmp_path: Path) -> None:
-        """vscode command: header and body appear in the same output."""
+    def test_vscode_header_and_body_same_console(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """vscode command: one Console renders both header and body."""
         log_dir = tmp_path / "session_1" / "window1" / "exthost" / "GitHub.copilot-chat"
         log_dir.mkdir(parents=True)
         log_file = log_dir / "GitHub Copilot Chat.log"
@@ -3987,9 +4039,11 @@ class TestSingleConsolePerCommand:
             "2026-03-15 10:00:00.123 [info] ccreq:abc.copilotmd | success | "
             "claude-sonnet-4 | 500ms | [chat]\n",
         )
-        runner = CliRunner()
-        result = runner.invoke(main, ["vscode", "--vscode-logs", str(tmp_path)])
-        assert result.exit_code == 0
+        result, created_consoles = self._invoke_and_capture_consoles(
+            monkeypatch,
+            ["vscode", "--vscode-logs", str(tmp_path)],
+        )
+        assert len(created_consoles) == 1
         output = _strip_ansi(result.output)
         assert "Copilot Usage" in output
         assert f"v{__version__}" in output

--- a/tests/copilot_usage/test_cli.py
+++ b/tests/copilot_usage/test_cli.py
@@ -2619,7 +2619,7 @@ def test_interactive_cost_view_prints_version_header(
     header_calls: list[str] = []
     orig_header = cli_mod._print_version_header
 
-    def _patched_header(target: Console | None = None) -> None:
+    def _patched_header(target: Console) -> None:
         header_calls.append("called")
         orig_header(target)
 
@@ -2669,7 +2669,7 @@ def test_interactive_detail_view_prints_version_header(
     header_calls: list[str] = []
     orig_header = cli_mod._print_version_header
 
-    def _patched_header(target: Console | None = None) -> None:
+    def _patched_header(target: Console) -> None:
         header_calls.append("called")
         orig_header(target)
 
@@ -2720,7 +2720,7 @@ def test_interactive_version_header_count_matches_auto_refresh(
     header_calls: list[str] = []
     orig_header = cli_mod._print_version_header
 
-    def _patched_header(target: Console | None = None) -> None:
+    def _patched_header(target: Console) -> None:
         header_calls.append("called")
         orig_header(target)
 
@@ -3909,3 +3909,88 @@ def test_build_session_index_duplicate_ids() -> None:
     index = _build_session_index(sessions)
     assert index["dup-id"] == 2
     assert index["unique-id"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Issue #1045 — non-interactive commands use a single per-call Console
+# ---------------------------------------------------------------------------
+
+
+class TestSingleConsolePerCommand:
+    """Each non-interactive command writes version header and report body to one Console.
+
+    Verifies the fix for issue #1045: both the version header text (e.g.
+    "Copilot Usage") and the command-specific report body appear in the
+    same captured output, proving a single Console instance is used.
+    """
+
+    def test_summary_header_and_body_same_console(self, tmp_path: Path) -> None:
+        """summary command: header and body appear in the same output."""
+        _write_session(tmp_path, "aaaa1111-0000-0000-0000-000000000000", name="First")
+        runner = CliRunner()
+        result = runner.invoke(main, ["summary", "--path", str(tmp_path)])
+        assert result.exit_code == 0
+        output = _strip_ansi(result.output)
+        assert "Copilot Usage" in output
+        assert f"v{__version__}" in output
+        # Report body content from render_summary
+        assert "First" in output or "Summary" in output
+
+    def test_session_header_and_body_same_console(self, tmp_path: Path) -> None:
+        """session command: header and body appear in the same output."""
+        _write_session(tmp_path, "bbbb2222-0000-0000-0000-000000000000", name="Detail")
+        runner = CliRunner()
+        result = runner.invoke(main, ["session", "bbbb2222", "--path", str(tmp_path)])
+        assert result.exit_code == 0
+        output = _strip_ansi(result.output)
+        assert "Copilot Usage" in output
+        assert f"v{__version__}" in output
+        assert "Session Detail" in output
+
+    def test_cost_header_and_body_same_console(self, tmp_path: Path) -> None:
+        """cost command: header and body appear in the same output."""
+        _write_session(
+            tmp_path,
+            "cccc3333-0000-0000-0000-000000000000",
+            name="Cost Test",
+            premium=5,
+        )
+        runner = CliRunner()
+        result = runner.invoke(main, ["cost", "--path", str(tmp_path)])
+        assert result.exit_code == 0
+        output = _strip_ansi(result.output)
+        assert "Copilot Usage" in output
+        assert f"v{__version__}" in output
+        assert "Cost" in output or "Total" in output
+
+    def test_live_header_and_body_same_console(self, tmp_path: Path) -> None:
+        """live command: header and body appear in the same output."""
+        _write_session(
+            tmp_path,
+            "dddd4444-0000-0000-0000-000000000000",
+            name="Active",
+            active=True,
+        )
+        runner = CliRunner()
+        result = runner.invoke(main, ["live", "--path", str(tmp_path)])
+        assert result.exit_code == 0
+        output = _strip_ansi(result.output)
+        assert "Copilot Usage" in output
+        assert f"v{__version__}" in output
+
+    def test_vscode_header_and_body_same_console(self, tmp_path: Path) -> None:
+        """vscode command: header and body appear in the same output."""
+        log_dir = tmp_path / "session_1" / "window1" / "exthost" / "GitHub.copilot-chat"
+        log_dir.mkdir(parents=True)
+        log_file = log_dir / "GitHub Copilot Chat.log"
+        log_file.write_text(
+            "2026-03-15 10:00:00.123 [info] ccreq:abc.copilotmd | success | "
+            "claude-sonnet-4 | 500ms | [chat]\n",
+        )
+        runner = CliRunner()
+        result = runner.invoke(main, ["vscode", "--vscode-logs", str(tmp_path)])
+        assert result.exit_code == 0
+        output = _strip_ansi(result.output)
+        assert "Copilot Usage" in output
+        assert f"v{__version__}" in output
+        assert "VS Code Copilot Chat" in output


### PR DESCRIPTION
Closes #1045

## Problem

Non-interactive CLI commands (`summary`, `session`, `cost`, `live`, `vscode`) wrote the version header to a module-level `Console` instance in `interactive.py` while each render function created its own separate `Console`. This violated the coding guideline against shared mutable I/O state that outlives a call, and could cause terminal-width skew between the header and report body.

## Changes

### `src/copilot_usage/interactive.py`
- Removed the module-level `console: Final[Console] = Console()` 
- Made `print_version_header`'s `target` parameter required (`Console` instead of `Console | None`)

### `src/copilot_usage/cli.py`
- Each non-interactive command now creates a single per-call `Console()` and passes it to both `_print_version_header(target=c)` and the corresponding render function (e.g. `render_summary(..., target_console=c)`)

### `tests/copilot_usage/test_cli.py`
- Added `TestSingleConsolePerCommand` class with tests for all five non-interactive commands, verifying that both the version header text and report body text appear in the same captured output
- Updated existing test helper signatures to match the new required `target: Console` parameter




> Generated by [Issue Implementer](https://github.com/microsasa/cli-tools/actions/runs/24745743861/agentic_workflow) · ● 17.7M · [◷](https://github.com/search?q=repo%3Amicrosasa%2Fcli-tools+%22gh-aw-workflow-id%3A+issue-implementer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Issue Implementer, engine: copilot, model: claude-opus-4.6, id: 24745743861, workflow_id: issue-implementer, run: https://github.com/microsasa/cli-tools/actions/runs/24745743861 -->

<!-- gh-aw-workflow-id: issue-implementer -->