### PR TITLE
fix(docs): update stale code snippets in implementation.md (#1048)

### DIFF
--- a/src/copilot_usage/docs/implementation.md
+++ b/src/copilot_usage/docs/implementation.md
@@ -97,13 +97,18 @@ Each `session.shutdown` event represents the metrics for **one lifecycle** (star
 
 **`_first_pass(events)` → `_FirstPassResult`** — single pass collecting all shutdowns:
 ```python
-all_shutdowns: tuple[tuple[int, SessionShutdownData], ...] = ()
+_shutdowns: list[tuple[int, SessionShutdownData]] = []
 # ...
 elif ev.type == EventType.SESSION_SHUTDOWN:
     # ... validate, extract data ...
-    all_shutdowns.append((idx, data))
+    _shutdowns.append((idx, data))
+# ...
+return _FirstPassResult(
+    # ... other fields ...
+    all_shutdowns=tuple(_shutdowns),
+)
 ```
-Each tuple stores `(event_index, shutdown_data)`. The model is resolved inline and stored on `_FirstPassResult.model`.
+Accumulation uses a local list; the frozen `_FirstPassResult` dataclass stores the result as `all_shutdowns: tuple[tuple[int, SessionShutdownData], ...]` — immutable once built. Each tuple stores `(event_index, shutdown_data)`. The model is resolved inline and stored on `_FirstPassResult.model`.
 
 **`_build_completed_summary(fp, name, resume, events)` → `SessionSummary`** — sums across all shutdowns:
 ```python

--- a/src/copilot_usage/docs/implementation.md
+++ b/src/copilot_usage/docs/implementation.md
@@ -97,7 +97,7 @@ Each `session.shutdown` event represents the metrics for **one lifecycle** (star
 
 **`_first_pass(events)` → `_FirstPassResult`** — single pass collecting all shutdowns:
 ```python
-all_shutdowns: list[tuple[int, SessionShutdownData]] = []
+all_shutdowns: tuple[tuple[int, SessionShutdownData], ...] = ()
 # ...
 elif ev.type == EventType.SESSION_SHUTDOWN:
     # ... validate, extract data ...
@@ -105,12 +105,13 @@ elif ev.type == EventType.SESSION_SHUTDOWN:
 ```
 Each tuple stores `(event_index, shutdown_data)`. The model is resolved inline and stored on `_FirstPassResult.model`.
 
-**`_build_completed_summary(fp, name, resume)` → `SessionSummary`** — sums across all shutdowns:
+**`_build_completed_summary(fp, name, resume, events)` → `SessionSummary`** — sums across all shutdowns:
 ```python
-for _idx, sd in fp.all_shutdowns:
+for idx, sd in fp.all_shutdowns:
     total_premium += sd.totalPremiumRequests
     total_api_duration += sd.totalApiDurationMs
     # ... merge model_metrics ...
+    shutdown_cycles.append((events[idx].timestamp, sd))  # idx used for timestamp lookup
 ```
 
 ### Model metrics merging

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -171,6 +171,47 @@ def test_components_table_lists_all_modules() -> None:
     )
 
 
+def test_build_completed_summary_signature_mentions_events() -> None:
+    """The _build_completed_summary signature snippet must include the
+    'events' parameter that was added for shutdown_cycles."""
+    match = re.search(
+        r"`_build_completed_summary\(([^)]*)\)`",
+        _IMPL_MD,
+    )
+    assert match, (
+        "Could not find '_build_completed_summary(...)' signature in implementation.md"
+    )
+    sig = match.group(1)
+    assert "events" in sig, (
+        "_build_completed_summary signature in implementation.md must "
+        "include 'events' — the parameter is used to look up timestamps "
+        "for shutdown_cycles"
+    )
+
+
+def test_all_shutdowns_type_is_tuple_not_list() -> None:
+    """all_shutdowns must be documented as a tuple (matching the frozen
+    _FirstPassResult dataclass), not a list."""
+    assert "all_shutdowns: tuple" in _IMPL_MD, (
+        "implementation.md must show 'all_shutdowns: tuple[...]' — "
+        "_FirstPassResult is frozen so the field is an immutable tuple"
+    )
+    assert "all_shutdowns: list" not in _IMPL_MD, (
+        "implementation.md still shows 'all_shutdowns: list[...]' — "
+        "_FirstPassResult uses tuple, not list"
+    )
+
+
+def test_shutdown_loop_uses_idx_not_underscore_idx() -> None:
+    """The shutdown loop snippet must use 'idx' (consumed for timestamp
+    lookup), not '_idx' (which implies the variable is unused)."""
+    assert "_idx" not in _IMPL_MD, (
+        "implementation.md contains '_idx' — the index variable is used "
+        "to look up event timestamps via events[idx].timestamp, so it "
+        "must be spelled 'idx' (not '_idx')"
+    )
+
+
 def test_architecture_first_pass_mentions_resume_detection() -> None:
     """The _first_pass() description in architecture.md must mention
     post-shutdown resume data tracking."""


### PR DESCRIPTION
## Summary

Fixes three stale code snippets in `src/copilot_usage/docs/implementation.md` that had drifted from the actual implementation in `parser.py`.

### Changes

**Documentation fixes (`implementation.md`):**
1. **`_build_completed_summary` signature** — added the missing `events` parameter (4 positional args, not 3)
2. **`all_shutdowns` type** — changed from `list[tuple[...]]` to `tuple[tuple[...], ...]` to match the frozen `_FirstPassResult` dataclass
3. **Loop variable `_idx` → `idx`** — renamed to reflect that the index is actually used for `events[idx].timestamp` lookup, and added the `shutdown_cycles.append(...)` call

**Regression tests (`tests/test_docs.py`):**
- `test_build_completed_summary_signature_mentions_events` — asserts the signature snippet includes `events`
- `test_all_shutdowns_type_is_tuple_not_list` — asserts `all_shutdowns: tuple` appears (and `all_shutdowns: list` does not)
- `test_shutdown_loop_uses_idx_not_underscore_idx` — asserts `_idx` does not appear anywhere in the doc

All existing tests continue to pass. `make check` passes cleanly (lint, typecheck, security, tests at 99% coverage).

Closes #1048




> Generated by [Issue Implementer](https://github.com/microsasa/cli-tools/actions/runs/24761389236/agentic_workflow) · ● 4.3M · [◷](https://github.com/search?q=repo%3Amicrosasa%2Fcli-tools+%22gh-aw-workflow-id%3A+issue-implementer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Issue Implementer, engine: copilot, model: claude-opus-4.6, id: 24761389236, workflow_id: issue-implementer, run: https://github.com/microsasa/cli-tools/actions/runs/24761389236 -->

<!-- gh-aw-workflow-id: issue-implementer -->