### PR TITLE
test: add direct unit tests for `_start_input_reader_thread` (#1056)

### DIFF
--- a/tests/copilot_usage/test_cli.py
+++ b/tests/copilot_usage/test_cli.py
@@ -22,9 +22,9 @@ from rich.console import Console
 
 from copilot_usage import __version__
 from copilot_usage.cli import (
+    _FALLBACK_EOF,
     _build_session_index,
     _DateTimeOrDate,
-    _FALLBACK_EOF,
     _normalize_until,
     _ParsedDateArg,
     _print_version_header,

--- a/tests/copilot_usage/test_cli.py
+++ b/tests/copilot_usage/test_cli.py
@@ -24,11 +24,13 @@ from copilot_usage import __version__
 from copilot_usage.cli import (
     _build_session_index,
     _DateTimeOrDate,
+    _FALLBACK_EOF,
     _normalize_until,
     _ParsedDateArg,
     _print_version_header,
     _read_line_nonblocking,
     _show_session_by_index,
+    _start_input_reader_thread,
     _start_observer,
     _stop_observer,
     _validate_since_until,
@@ -2167,6 +2169,93 @@ class TestReadLineNonblocking:
         finally:
             r_file.close()
             os.close(w_fd)
+
+
+# ---------------------------------------------------------------------------
+# _start_input_reader_thread unit tests (issue #1056)
+# ---------------------------------------------------------------------------
+
+
+class TestStartInputReaderThread:
+    """Direct unit tests for _start_input_reader_thread."""
+
+    def test_thread_is_daemon(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Spawned thread must be daemon so it cannot block process exit."""
+        captured_daemon: list[bool] = []
+        _real_thread_init = threading.Thread.__init__
+
+        def _spy_init(self_thread: threading.Thread, *args: Any, **kwargs: Any) -> None:
+            _real_thread_init(self_thread, *args, **kwargs)
+            if self_thread.name == "input-fallback":
+                captured_daemon.append(self_thread.daemon)
+
+        monkeypatch.setattr(threading.Thread, "__init__", _spy_init)
+        monkeypatch.setattr(
+            "builtins.input", lambda: (_ for _ in ()).throw(EOFError())
+        )
+
+        q = _start_input_reader_thread()
+        q.get(timeout=2.0)  # drain sentinel so thread exits
+
+        assert captured_daemon == [True], "input-fallback thread must be daemon=True"
+
+    def test_normal_input_is_stripped_and_queued(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """User input is stripped before being placed on the queue."""
+        inputs = iter(["  hello  ", EOFError()])
+
+        def _fake_input() -> str:
+            val = next(inputs)
+            if isinstance(val, BaseException):
+                raise val
+            return val  # type: ignore[return-value]
+
+        monkeypatch.setattr("builtins.input", _fake_input)
+
+        q = _start_input_reader_thread()
+        assert q.get(timeout=2.0) == "hello"
+        assert q.get(timeout=2.0) == _FALLBACK_EOF
+
+    def test_eoferror_puts_fallback_sentinel(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """EOFError from input() places _FALLBACK_EOF on the queue."""
+        monkeypatch.setattr(
+            "builtins.input", lambda: (_ for _ in ()).throw(EOFError())
+        )
+
+        q = _start_input_reader_thread()
+        assert q.get(timeout=2.0) == _FALLBACK_EOF
+
+    def test_keyboard_interrupt_puts_fallback_sentinel(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """KeyboardInterrupt from input() places _FALLBACK_EOF on the queue."""
+        monkeypatch.setattr(
+            "builtins.input", lambda: (_ for _ in ()).throw(KeyboardInterrupt())
+        )
+
+        q = _start_input_reader_thread()
+        assert q.get(timeout=2.0) == _FALLBACK_EOF
+
+    def test_unexpected_exception_puts_fallback_and_logs_warning(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Unexpected exception places _FALLBACK_EOF and logs a warning."""
+        monkeypatch.setattr(
+            "builtins.input", lambda: (_ for _ in ()).throw(RuntimeError("boom"))
+        )
+
+        import copilot_usage.cli as cli_mod
+
+        with patch.object(cli_mod.logger, "warning") as warn_spy:
+            q = _start_input_reader_thread()
+            sentinel = q.get(timeout=2.0)
+
+        assert sentinel == _FALLBACK_EOF
+        warn_spy.assert_called_once()
+        assert "Unexpected stdin error" in warn_spy.call_args.args[0]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/copilot_usage/test_cli.py
+++ b/tests/copilot_usage/test_cli.py
@@ -2202,9 +2202,7 @@ class TestStartInputReaderThread:
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """User input is stripped before being placed on the queue."""
-        inputs: Iterator[str | BaseException] = iter(
-            ["  hello  ", EOFError()]
-        )
+        inputs: Iterator[str | BaseException] = iter(["  hello  ", EOFError()])
 
         def _fake_input() -> str:
             val = next(inputs)

--- a/tests/copilot_usage/test_cli.py
+++ b/tests/copilot_usage/test_cli.py
@@ -9,6 +9,7 @@ import os
 import re
 import threading
 import time
+from collections.abc import Iterator
 from datetime import UTC, datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
@@ -2201,7 +2202,9 @@ class TestStartInputReaderThread:
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """User input is stripped before being placed on the queue."""
-        inputs = iter(["  hello  ", EOFError()])
+        inputs: Iterator[str | BaseException] = iter(
+            ["  hello  ", EOFError()]
+        )
 
         def _fake_input() -> str:
             val = next(inputs)

--- a/tests/copilot_usage/test_cli.py
+++ b/tests/copilot_usage/test_cli.py
@@ -2182,15 +2182,14 @@ class TestStartInputReaderThread:
 
     def test_thread_is_daemon(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Spawned thread must be daemon so it cannot block process exit."""
-        captured_daemon: list[bool] = []
-        _real_thread_init = threading.Thread.__init__
+        captured_daemon: list[bool | None] = []
+        _real_thread = threading.Thread
 
-        def _spy_init(self_thread: threading.Thread, *args: Any, **kwargs: Any) -> None:
-            _real_thread_init(self_thread, *args, **kwargs)
-            if self_thread.name == "input-fallback":
-                captured_daemon.append(self_thread.daemon)
+        def _spy_thread(*args: Any, **kwargs: Any) -> threading.Thread:
+            captured_daemon.append(kwargs.get("daemon"))
+            return _real_thread(*args, **kwargs)
 
-        monkeypatch.setattr(threading.Thread, "__init__", _spy_init)
+        monkeypatch.setattr("copilot_usage.cli.threading.Thread", _spy_thread)
         monkeypatch.setattr("builtins.input", lambda: (_ for _ in ()).throw(EOFError()))
 
         q = _start_input_reader_thread()

--- a/tests/copilot_usage/test_cli.py
+++ b/tests/copilot_usage/test_cli.py
@@ -2190,9 +2190,7 @@ class TestStartInputReaderThread:
                 captured_daemon.append(self_thread.daemon)
 
         monkeypatch.setattr(threading.Thread, "__init__", _spy_init)
-        monkeypatch.setattr(
-            "builtins.input", lambda: (_ for _ in ()).throw(EOFError())
-        )
+        monkeypatch.setattr("builtins.input", lambda: (_ for _ in ()).throw(EOFError()))
 
         q = _start_input_reader_thread()
         q.get(timeout=2.0)  # drain sentinel so thread exits
@@ -2209,7 +2207,7 @@ class TestStartInputReaderThread:
             val = next(inputs)
             if isinstance(val, BaseException):
                 raise val
-            return val  # type: ignore[return-value]
+            return val
 
         monkeypatch.setattr("builtins.input", _fake_input)
 
@@ -2221,9 +2219,7 @@ class TestStartInputReaderThread:
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """EOFError from input() places _FALLBACK_EOF on the queue."""
-        monkeypatch.setattr(
-            "builtins.input", lambda: (_ for _ in ()).throw(EOFError())
-        )
+        monkeypatch.setattr("builtins.input", lambda: (_ for _ in ()).throw(EOFError()))
 
         q = _start_input_reader_thread()
         assert q.get(timeout=2.0) == _FALLBACK_EOF
@@ -2255,6 +2251,7 @@ class TestStartInputReaderThread:
 
         assert sentinel == _FALLBACK_EOF
         warn_spy.assert_called_once()
+        assert warn_spy.call_args is not None
         assert "Unexpected stdin error" in warn_spy.call_args.args[0]
 
 


### PR DESCRIPTION
Closes #1056

## Summary

Adds `TestStartInputReaderThread` class in `tests/copilot_usage/test_cli.py` with five isolated unit tests for `_start_input_reader_thread`:

| Test | What it asserts |
|---|---|
| `test_thread_is_daemon` | Thread is created with `daemon=True` — regression guard for the CI hang from issue #1012 |
| `test_normal_input_is_stripped_and_queued` | Happy path: stripped user input lands on the queue, then EOF sentinel |
| `test_eoferror_puts_fallback_sentinel` | `EOFError` → `_FALLBACK_EOF` on queue |
| `test_keyboard_interrupt_puts_fallback_sentinel` | `KeyboardInterrupt` → `_FALLBACK_EOF` on queue (**previously untested at any level**) |
| `test_unexpected_exception_puts_fallback_and_logs_warning` | Unexpected `RuntimeError` → `_FALLBACK_EOF` + `logger.warning` called |

## Approach

- Tests monkeypatch `builtins.input` to inject specific behaviors
- Daemon-flag test spies on `threading.Thread.__init__` to capture `daemon` before the thread starts
- All tests drain the queue with a 2s timeout to avoid hanging if the contract is broken




> [!WARNING]
> <details>
> <summary><strong>⚠️ Firewall blocked 2 domains</strong></summary>
>
> The following domains were blocked by the firewall during workflow execution:
>
> - `astral.sh`
> - `pypi.org`
>
> To allow these domains, add them to the `network.allowed` list in your workflow frontmatter:
>
> ```yaml
> network:
>   allowed:
>     - defaults
>     - "astral.sh"
>     - "pypi.org"
> ```
>
> See [Network Configuration](https://github.github.com/gh-aw/reference/network/) for more information.
>
> </details>


> Generated by [Issue Implementer](https://github.com/microsasa/cli-tools/actions/runs/24801062844/agentic_workflow) · ● 11M · [◷](https://github.com/search?q=repo%3Amicrosasa%2Fcli-tools+%22gh-aw-workflow-id%3A+issue-implementer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Issue Implementer, engine: copilot, model: claude-opus-4.6, id: 24801062844, workflow_id: issue-implementer, run: https://github.com/microsasa/cli-tools/actions/runs/24801062844 -->

<!-- gh-aw-workflow-id: issue-implementer -->