### PR TITLE
test: cover untested branches in render_detail.py (#1058)

### DIFF
--- a/tests/copilot_usage/test_render_detail.py
+++ b/tests/copilot_usage/test_render_detail.py
@@ -33,6 +33,7 @@ from copilot_usage.render_detail import (
     _render_recent_events,
     _render_shutdown_cycles,
     _safe_event_data,
+    _truncate,
     render_session_detail,
 )
 
@@ -957,3 +958,84 @@ def test_build_event_details_returns_empty_for_unrecognized_type() -> None:
     """Wildcard case must return '' for event types without explicit handling."""
     ev = SessionEvent(type=EventType.SESSION_RESUME, data={})
     assert _build_event_details(ev) == ""
+
+
+# ---------------------------------------------------------------------------
+# _build_event_details — SESSION_SHUTDOWN arm (issue #1058)
+# ---------------------------------------------------------------------------
+
+
+class TestBuildEventDetailsSessionShutdown:
+    """Tests for the SESSION_SHUTDOWN branch of _build_event_details."""
+
+    def test_non_empty_shutdown_type(self) -> None:
+        """Non-empty shutdownType must render as 'type=<value>'."""
+        ev = SessionEvent(
+            type=EventType.SESSION_SHUTDOWN,
+            data={
+                "shutdownType": "routine",
+                "totalPremiumRequests": 0,
+                "totalApiDurationMs": 0,
+                "modelMetrics": {},
+            },
+        )
+        assert _build_event_details(ev) == "type=routine"
+
+    def test_empty_shutdown_type(self) -> None:
+        """Empty shutdownType must render as ''."""
+        ev = SessionEvent(
+            type=EventType.SESSION_SHUTDOWN,
+            data={
+                "shutdownType": "",
+                "totalPremiumRequests": 0,
+                "totalApiDurationMs": 0,
+                "modelMetrics": {},
+            },
+        )
+        assert _build_event_details(ev) == ""
+
+    def test_malformed_data_returns_empty(self) -> None:
+        """Malformed data (int shutdownType) triggers ValidationError → ''."""
+        ev = SessionEvent(
+            type=EventType.SESSION_SHUTDOWN,
+            data={"shutdownType": 99},  # int triggers ValidationError
+        )
+        assert _build_event_details(ev) == ""
+
+
+# ---------------------------------------------------------------------------
+# _render_shutdown_cycles — None timestamp path (issue #1058)
+# ---------------------------------------------------------------------------
+
+
+class TestRenderShutdownCyclesNoneTimestamp:
+    """A shutdown cycle with ts=None must display '—' in the Date column."""
+
+    def test_none_timestamp_renders_dash(self) -> None:
+        """A shutdown cycle with ts=None must display '—' in the Date column."""
+        sd = SessionShutdownData(
+            shutdownType="routine",
+            totalPremiumRequests=1,
+            totalApiDurationMs=500,
+            modelMetrics={},
+        )
+        summary = SessionSummary(
+            session_id="no-ts",
+            shutdown_cycles=[(None, sd)],
+        )
+        buf = io.StringIO()
+        console = Console(file=buf, force_terminal=True, width=120)
+        _render_shutdown_cycles(summary, target_console=console)
+        output = _strip_ansi(buf.getvalue())
+        assert "—" in output
+
+
+# ---------------------------------------------------------------------------
+# _truncate — max_len ≤ 0 guard (issue #1058)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("max_len", [0, -1, -100])
+def test_truncate_non_positive_max_len_returns_empty(max_len: int) -> None:
+    """_truncate must return '' for any max_len ≤ 0."""
+    assert _truncate("hello", max_len) == ""

--- a/tests/copilot_usage/test_render_detail.py
+++ b/tests/copilot_usage/test_render_detail.py
@@ -87,23 +87,20 @@ class TestRenderCodeChanges:
 
     def test_none_produces_no_output(self) -> None:
         """code_changes=None → returns immediately without printing."""
-        buf = io.StringIO()
-        console = Console(file=buf, force_terminal=True)
+        buf, console = _buf_console()
         _render_code_changes(None, target_console=console)
         assert buf.getvalue() == ""
 
     def test_all_zero_produces_no_output(self) -> None:
         """All fields zero/empty → returns without printing."""
-        buf = io.StringIO()
-        console = Console(file=buf, force_terminal=True)
+        buf, console = _buf_console()
         changes = CodeChanges(linesAdded=0, linesRemoved=0, filesModified=[])
         _render_code_changes(changes, target_console=console)
         assert buf.getvalue() == ""
 
     def test_with_data_shows_table(self) -> None:
         """Non-zero code changes → renders a table with stats."""
-        buf = io.StringIO()
-        console = Console(file=buf, force_terminal=True)
+        buf, console = _buf_console()
         changes = CodeChanges(linesAdded=10, linesRemoved=2, filesModified=["a.py"])
         _render_code_changes(changes, target_console=console)
         output = buf.getvalue()
@@ -113,8 +110,7 @@ class TestRenderCodeChanges:
 
     def test_files_present_zero_line_counts_renders_table(self) -> None:
         """filesModified non-empty with zero line deltas → table IS rendered."""
-        buf = io.StringIO()
-        console = Console(file=buf, force_terminal=True)
+        buf, console = _buf_console()
         changes = CodeChanges(linesAdded=0, linesRemoved=0, filesModified=["a.py"])
         _render_code_changes(changes, target_console=console)
         output = _strip_ansi(buf.getvalue())
@@ -126,8 +122,7 @@ class TestRenderCodeChanges:
 
     def test_zero_files_positive_line_counts_renders_table(self) -> None:
         """Empty filesModified with positive line counts → table IS rendered."""
-        buf = io.StringIO()
-        console = Console(file=buf, force_terminal=True)
+        buf, console = _buf_console()
         changes = CodeChanges(linesAdded=5, linesRemoved=2, filesModified=[])
         _render_code_changes(changes, target_console=console)
         output = buf.getvalue()

--- a/tests/copilot_usage/test_render_detail.py
+++ b/tests/copilot_usage/test_render_detail.py
@@ -1023,8 +1023,7 @@ class TestRenderShutdownCyclesNoneTimestamp:
             session_id="no-ts",
             shutdown_cycles=[(None, sd)],
         )
-        buf = io.StringIO()
-        console = Console(file=buf, force_terminal=True, width=120)
+        buf, console = _buf_console()
         _render_shutdown_cycles(summary, target_console=console)
         output = _strip_ansi(buf.getvalue())
         assert "—" in output


### PR DESCRIPTION
Closes #1058

Adds direct test coverage for three untested branches in `src/copilot_usage/render_detail.py`:

### Gap 1 — `_build_event_details`: SESSION_SHUTDOWN arm
New `TestBuildEventDetailsSessionShutdown` class with three tests:
- **`test_non_empty_shutdown_type`** — verifies `"type=routine"` output
- **`test_empty_shutdown_type`** — verifies empty string output
- **`test_malformed_data_returns_empty`** — int `shutdownType` triggers `ValidationError` → `""`

### Gap 2 — `_render_shutdown_cycles`: `ts=None` path
New `TestRenderShutdownCyclesNoneTimestamp` class:
- **`test_none_timestamp_renders_dash`** — `(None, sd)` tuple renders `"—"` in Date column

### Gap 3 — `_truncate`: `max_len ≤ 0` guard
Parametrized test covering `max_len ∈ {0, -1, -100}`:
- **`test_truncate_non_positive_max_len_returns_empty`** — all return `""`

### Notes
- No source changes — test-only additions
- All tests follow existing patterns in the file (same imports, helpers, style)
- Environment could not run `make check` locally (network-blocked sandbox; `uv` not available), but CI will validate




> [!WARNING]
> <details>
> <summary><strong>⚠️ Firewall blocked 2 domains</strong></summary>
>
> The following domains were blocked by the firewall during workflow execution:
>
> - `astral.sh`
> - `pypi.org`
>
> To allow these domains, add them to the `network.allowed` list in your workflow frontmatter:
>
> ```yaml
> network:
>   allowed:
>     - defaults
>     - "astral.sh"
>     - "pypi.org"
> ```
>
> See [Network Configuration](https://github.github.com/gh-aw/reference/network/) for more information.
>
> </details>


> Generated by [Issue Implementer](https://github.com/microsasa/cli-tools/actions/runs/24824695584/agentic_workflow) · ● 14.9M · [◷](https://github.com/search?q=repo%3Amicrosasa%2Fcli-tools+%22gh-aw-workflow-id%3A+issue-implementer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Issue Implementer, engine: copilot, model: claude-opus-4.6, id: 24824695584, workflow_id: issue-implementer, run: https://github.com/microsasa/cli-tools/actions/runs/24824695584 -->

<!-- gh-aw-workflow-id: issue-implementer -->