### PR TITLE
fix: add `Final` annotation to `__version__` and document `shutdown_cycles` (#1059)

### DIFF
--- a/src/copilot_usage/__init__.py
+++ b/src/copilot_usage/__init__.py
@@ -3,4 +3,4 @@ from typing import Final
 
 __all__: Final[list[str]] = ["__version__"]
 
-__version__: str = version("cli-tools")
+__version__: Final[str] = version("cli-tools")

--- a/src/copilot_usage/docs/implementation.md
+++ b/src/copilot_usage/docs/implementation.md
@@ -77,6 +77,7 @@ Typed dispatch uses the `as_*()` accessors on `SessionEvent` (e.g. `as_session_s
 | `has_shutdown_metrics`   | `bool`                      | `True` when at least one shutdown event produced non-empty `modelMetrics`; set to `bool(merged_metrics)` after merging all shutdowns |
 | `last_resume_time`       | `datetime \| None`           | Timestamp of `session.resume` event (if any, after last shutdown)                   |
 | `events_path`            | `Path \| None`               | Set by `get_all_sessions()` after building — not from events                        |
+| `shutdown_cycles`        | `list[tuple[datetime \| None, SessionShutdownData]]` | Pre-computed list of `(timestamp, shutdown_payload)` pairs for every `session.shutdown` event. Populated by `build_session_summary()` so renderers never need to re-scan the event list. |
 | `active_model_calls`     | `int`                       | `assistant.turn_start` count after last shutdown (resumed sessions only)            |
 | `active_user_messages`   | `int`                       | `user.message` count after last shutdown (resumed sessions only)                    |
 | `active_output_tokens`   | `int`                       | Sum of `outputTokens` from `assistant.message` events after last shutdown           |

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -5,6 +5,7 @@ import shutil
 import subprocess
 import zipfile
 from pathlib import Path
+from typing import Final, get_args, get_origin
 
 import pytest
 
@@ -37,6 +38,20 @@ def test_all_names_importable(module_name: str) -> None:
         assert name in mod_vars, (
             f"{module_name}.__all__ lists {name!r}, but it is not defined in the module"
         )
+
+
+def test_version_is_final_str() -> None:
+    """``__version__`` must be annotated as ``Final[str]`` per coding guidelines."""
+    import copilot_usage
+
+    ann = copilot_usage.__annotations__["__version__"]
+    assert get_origin(ann) is Final, (
+        f"__version__ annotation should be Final[str], got {ann!r}"
+    )
+    args = get_args(ann)
+    assert args == (str,), (
+        f"__version__ annotation should be Final[str], got Final[{args!r}]"
+    )
 
 
 def test_wheel_excludes_docs(tmp_path: Path) -> None:


### PR DESCRIPTION
Closes #1059

## Changes

### 1. `__version__` missing `Final` annotation
**File:** `src/copilot_usage/__init__.py`

Changed `__version__: str` → `__version__: Final[str]` per coding guidelines requiring `Final` for module-level constants that should never be reassigned. `Final` was already imported in the file.

### 2. `SessionSummary.shutdown_cycles` absent from `implementation.md` field table
**File:** `src/copilot_usage/docs/implementation.md`

Added the `shutdown_cycles` row to the `SessionSummary` fields table, documenting its type (`list[tuple[datetime | None, SessionShutdownData]]`) and how it's populated by `build_session_summary()`.

### 3. Regression test for `Final` annotation
**File:** `tests/test_packaging.py`

Added `test_version_is_final_str()` which asserts that `__version__` is annotated as `Final[str]` using `typing.get_origin` and `typing.get_args`, guarding against regression.




> [!WARNING]
> <details>
> <summary><strong>⚠️ Firewall blocked 2 domains</strong></summary>
>
> The following domains were blocked by the firewall during workflow execution:
>
> - `astral.sh`
> - `pypi.org`
>
> To allow these domains, add them to the `network.allowed` list in your workflow frontmatter:
>
> ```yaml
> network:
>   allowed:
>     - defaults
>     - "astral.sh"
>     - "pypi.org"
> ```
>
> See [Network Configuration](https://github.github.com/gh-aw/reference/network/) for more information.
>
> </details>


> Generated by [Issue Implementer](https://github.com/microsasa/cli-tools/actions/runs/24826134756/agentic_workflow) · ● 8.6M · [◷](https://github.com/search?q=repo%3Amicrosasa%2Fcli-tools+%22gh-aw-workflow-id%3A+issue-implementer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Issue Implementer, engine: copilot, model: claude-opus-4.6, id: 24826134756, workflow_id: issue-implementer, run: https://github.com/microsasa/cli-tools/actions/runs/24826134756 -->

<!-- gh-aw-workflow-id: issue-implementer -->