### PR TITLE
fix: remove misleading 'Since Last Shutdown' from active sessions title (#1072)

### DIFF
--- a/src/copilot_usage/report.py
+++ b/src/copilot_usage/report.py
@@ -554,9 +554,7 @@ def _render_active_section_from(
         )
         return
 
-    table = Table(
-        title="🟢 Active Sessions", border_style="green"
-    )
+    table = Table(title="🟢 Active Sessions", border_style="green")
     table.add_column("Name", style="bold", max_width=40)
     table.add_column("Model")
     table.add_column("Model Calls", justify="right")

--- a/src/copilot_usage/report.py
+++ b/src/copilot_usage/report.py
@@ -555,7 +555,7 @@ def _render_active_section_from(
         return
 
     table = Table(
-        title="🟢 Active Sessions (Since Last Shutdown)", border_style="green"
+        title="🟢 Active Sessions", border_style="green"
     )
     table.add_column("Name", style="bold", max_width=40)
     table.add_column("Model")

--- a/src/copilot_usage/report.py
+++ b/src/copilot_usage/report.py
@@ -592,7 +592,7 @@ def render_full_summary(
     """Render the two-section summary for interactive mode.
 
     Section 1: Historical shutdown data (totals, per-model, per-session).
-    Section 2: Active sessions since last shutdown.
+    Section 2: Currently active sessions.
 
     *sessions* must be in descending ``start_time`` order — the contract
     guaranteed by :func:`~copilot_usage.parser.get_all_sessions`.  No

--- a/tests/copilot_usage/test_report.py
+++ b/tests/copilot_usage/test_report.py
@@ -3656,9 +3656,9 @@ class TestHistoricalSectionResumedFreeSessions:
             },
         )
         output = _capture_full_summary([session])
-        # Active section table title should indicate it is scoped to the period
-        # since the last shutdown, which distinguishes it from the historical table.
-        assert "Since Last Shutdown" in output
+        # Active section table title should NOT contain the misleading
+        # "Since Last Shutdown" qualifier (issue #1072).
+        assert "Since Last Shutdown" not in output
         # The same resumed session should appear in both the historical and active sections.
         assert output.count("ResumedFreeSession") == 2
         # And the generic empty-active message should not be shown.
@@ -3682,6 +3682,27 @@ class TestHistoricalSectionResumedFreeSessions:
         )
         output = _capture_full_summary([session])
         assert "No historical shutdown data" in output
+
+    def test_pure_active_section_title_no_since_last_shutdown(self) -> None:
+        """Issue #1072 — pure-active session (has_shutdown_metrics=False)
+        must NOT show 'Since Last Shutdown' in the active-section title."""
+        session = SessionSummary(
+            session_id="pure-active-title-1234",
+            name="PureActiveTitle",
+            model="gpt-5-mini",
+            start_time=datetime(2025, 1, 15, 10, 0, tzinfo=UTC),
+            is_active=True,
+            has_shutdown_metrics=False,
+            total_premium_requests=0,
+            user_messages=2,
+            model_calls=1,
+            active_model_calls=1,
+            active_output_tokens=100,
+        )
+        output = _capture_full_summary([session])
+        assert "Since Last Shutdown" not in output
+        # The generic title should still be present.
+        assert "Active Sessions" in output
 
 
 class TestBuildEventDetailsCatchAll:

--- a/tests/e2e/test_e2e.py
+++ b/tests/e2e/test_e2e.py
@@ -809,7 +809,7 @@ class TestSessionNotFoundAvailableE2E:
 # ---------------------------------------------------------------------------
 
 # Marker that separates the historical section from the active section
-_ACTIVE_MARKER = "Active Sessions (Since Last Shutdown)"
+_ACTIVE_MARKER = "Active Sessions"
 
 # Minimal completed session with zero premium requests (free-tier model only).
 # Used to verify that the historical filter's ``not s.is_active`` branch


### PR DESCRIPTION
## Summary

`_render_active_section_from` in `report.py` hardcoded the table title **"🟢 Active Sessions (Since Last Shutdown)"** for all active sessions — including pure-active sessions that have never had a shutdown event (`has_shutdown_metrics=False`).

This changes the title to **"🟢 Active Sessions"** unconditionally (Option A from the issue). The columns already indicate what data is being shown; the parenthetical qualifier only added confusion for pure-active sessions.

## Changes

- **`src/copilot_usage/report.py`**: Change table title from `"🟢 Active Sessions (Since Last Shutdown)"` to `"🟢 Active Sessions"`
- **`tests/copilot_usage/test_report.py`**: Update existing resumed-session test to assert absence of qualifier; add new `test_pure_active_section_title_no_since_last_shutdown` test
- **`tests/e2e/test_e2e.py`**: Update `_ACTIVE_MARKER` constant to match new title

Closes #1072




> [!WARNING]
> <details>
> <summary><strong>⚠️ Firewall blocked 3 domains</strong></summary>
>
> The following domains were blocked by the firewall during workflow execution:
>
> - `astral.sh`
> - `index.crates.io`
> - `pypi.org`
>
> To allow these domains, add them to the `network.allowed` list in your workflow frontmatter:
>
> ```yaml
> network:
>   allowed:
>     - defaults
>     - "astral.sh"
>     - "index.crates.io"
>     - "pypi.org"
> ```
>
> See [Network Configuration](https://github.github.com/gh-aw/reference/network/) for more information.
>
> </details>


> Generated by [Issue Implementer](https://github.com/microsasa/cli-tools/actions/runs/24895913640/agentic_workflow) · ● 10M · [◷](https://github.com/search?q=repo%3Amicrosasa%2Fcli-tools+%22gh-aw-workflow-id%3A+issue-implementer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Issue Implementer, engine: copilot, model: claude-opus-4.6, id: 24895913640, workflow_id: issue-implementer, run: https://github.com/microsasa/cli-tools/actions/runs/24895913640 -->

<!-- gh-aw-workflow-id: issue-implementer -->