### PR TITLE
refactor: replace ModelPricing Pydantic model with frozen dataclass (#1073)

### DIFF
--- a/src/copilot_usage/pricing.py
+++ b/src/copilot_usage/pricing.py
@@ -1,4 +1,4 @@
-"""Model pricing data and premium-request cost estimation.
+"""Model pricing data and premium-request multiplier lookup.
 
 GitHub Copilot charges different premium-request multipliers depending on the
 AI model used.  This module provides:
@@ -6,7 +6,6 @@ AI model used.  This module provides:
 * A ``ModelPricing`` frozen dataclass for per-model pricing metadata.
 * A registry of known multipliers (easy to update in one place).
 * Lookup helpers that handle exact matches, partial matches, and unknown models.
-* A cost-estimation function that works with ``SessionSummary.model_metrics``.
 """
 
 import dataclasses

--- a/src/copilot_usage/pricing.py
+++ b/src/copilot_usage/pricing.py
@@ -3,18 +3,18 @@
 GitHub Copilot charges different premium-request multipliers depending on the
 AI model used.  This module provides:
 
-* A ``ModelPricing`` Pydantic model for per-model pricing metadata.
+* A ``ModelPricing`` frozen dataclass for per-model pricing metadata.
 * A registry of known multipliers (easy to update in one place).
 * Lookup helpers that handle exact matches, partial matches, and unknown models.
 * A cost-estimation function that works with ``SessionSummary.model_metrics``.
 """
 
+import dataclasses
 from enum import StrEnum
 from functools import lru_cache
 from typing import Final
 
 from loguru import logger
-from pydantic import BaseModel, ConfigDict
 
 __all__: Final[list[str]] = [
     "ModelPricing",
@@ -39,14 +39,13 @@ class PricingTier(StrEnum):
 
 
 # ---------------------------------------------------------------------------
-# Pydantic model
+# Pricing dataclass
 # ---------------------------------------------------------------------------
 
 
-class ModelPricing(BaseModel):
+@dataclasses.dataclass(frozen=True, slots=True)
+class ModelPricing:
     """Pricing metadata for a single AI model."""
-
-    model_config = ConfigDict(frozen=True)
 
     model_name: str
     multiplier: float = 1.0

--- a/tests/copilot_usage/test_pricing.py
+++ b/tests/copilot_usage/test_pricing.py
@@ -2,11 +2,11 @@
 
 # pyright: reportPrivateUsage=false
 
+import dataclasses
 from functools import lru_cache
 
 import pytest
 from loguru import logger
-from pydantic import ValidationError
 
 from copilot_usage import pricing
 from copilot_usage.pricing import (
@@ -43,10 +43,10 @@ class TestModelPricing:
         assert p.tier == PricingTier.PREMIUM
 
     def test_model_pricing_is_immutable(self) -> None:
-        """Assigning to a field on a frozen ModelPricing must raise ValidationError."""
+        """Assigning to a field on a frozen ModelPricing must raise FrozenInstanceError."""
         p = ModelPricing(model_name="test", multiplier=1.0)
-        with pytest.raises(ValidationError):
-            p.multiplier = 2.0
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            p.multiplier = 2.0  # type: ignore[misc]
 
     def test_cache_isolation_via_frozen_model(self) -> None:
         """Exact-match lookup returns a frozen object — mutation is impossible,
@@ -54,11 +54,27 @@ class TestModelPricing:
         first = lookup_model_pricing("claude-sonnet-4.6")
         assert first.multiplier == 1.0
 
-        with pytest.raises(ValidationError):
-            first.multiplier = 99.0
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            first.multiplier = 99.0  # type: ignore[misc]
 
         second = lookup_model_pricing("claude-sonnet-4.6")
         assert second.multiplier == 1.0
+
+    def test_is_frozen_dataclass(self) -> None:
+        """ModelPricing must be a stdlib frozen dataclass with slots."""
+        assert dataclasses.is_dataclass(ModelPricing)
+        assert dataclasses.is_dataclass(ModelPricing(model_name="x"))
+        # Verify frozen=True via FrozenInstanceError on assignment
+        p = ModelPricing(model_name="x")
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            p.model_name = "y"  # type: ignore[misc]
+
+    def test_model_pricing_in_all(self) -> None:
+        """ModelPricing is exported in __all__ and importable from the public API."""
+        assert "ModelPricing" in pricing.__all__
+        from copilot_usage.pricing import ModelPricing as MP
+
+        assert MP is ModelPricing
 
 
 # ---------------------------------------------------------------------------

--- a/tests/copilot_usage/test_pricing.py
+++ b/tests/copilot_usage/test_pricing.py
@@ -48,8 +48,8 @@ class TestModelPricing:
         with pytest.raises(dataclasses.FrozenInstanceError):
             p.multiplier = 2.0  # type: ignore[misc]
 
-    def test_cache_isolation_via_frozen_model(self) -> None:
-        """Exact-match lookup returns a frozen object — mutation is impossible,
+    def test_cache_isolation_via_frozen_dataclass(self) -> None:
+        """Exact-match lookup returns a frozen dataclass — mutation is impossible,
         so the cache and KNOWN_PRICING registry cannot be corrupted."""
         first = lookup_model_pricing("claude-sonnet-4.6")
         assert first.multiplier == 1.0
@@ -62,10 +62,12 @@ class TestModelPricing:
 
     def test_is_frozen_dataclass(self) -> None:
         """ModelPricing must be a stdlib frozen dataclass with slots."""
-        assert dataclasses.is_dataclass(ModelPricing)
-        assert dataclasses.is_dataclass(ModelPricing(model_name="x"))
-        # Verify frozen=True via FrozenInstanceError on assignment
         p = ModelPricing(model_name="x")
+        assert dataclasses.is_dataclass(ModelPricing)
+        assert dataclasses.is_dataclass(p)
+        assert hasattr(ModelPricing, "__slots__")
+        assert not hasattr(p, "__dict__")
+        # Verify frozen=True via FrozenInstanceError on assignment
         with pytest.raises(dataclasses.FrozenInstanceError):
             p.model_name = "y"  # type: ignore[misc]
 


### PR DESCRIPTION
Closes #1073

## Summary

Convert `ModelPricing` in `src/copilot_usage/pricing.py` from a frozen Pydantic `BaseModel` to a stdlib frozen slotted dataclass, per the coding guideline: *"Pydantic at the boundary, plain Python internally."*

`ModelPricing` never processes external JSON — all instances are constructed from the internal `_RAW_MULTIPLIERS` dict, the `_cached_lookup` `lru_cache`, or synthesised for unknown/ambiguous models. It is a pure value object that never touches an I/O boundary.

## Changes

### `src/copilot_usage/pricing.py`
- Replace `class ModelPricing(BaseModel)` with `@dataclasses.dataclass(frozen=True, slots=True)`
- Remove `from pydantic import BaseModel, ConfigDict` and `model_config = ConfigDict(frozen=True)`
- Add `import dataclasses`
- Update module docstring ("frozen dataclass" instead of "Pydantic model")

### `tests/copilot_usage/test_pricing.py`
- Replace `from pydantic import ValidationError` with `import dataclasses`
- Update `pytest.raises(ValidationError)` → `pytest.raises(dataclasses.FrozenInstanceError)` in existing immutability tests
- Add `test_is_frozen_dataclass` — asserts `dataclasses.is_dataclass(ModelPricing)` and that mutation raises `FrozenInstanceError`
- Add `test_model_pricing_in_all` — asserts `ModelPricing` is in `__all__` and importable from the public API




> [!WARNING]
> <details>
> <summary><strong>⚠️ Firewall blocked 2 domains</strong></summary>
>
> The following domains were blocked by the firewall during workflow execution:
>
> - `astral.sh`
> - `pypi.org`
>
> To allow these domains, add them to the `network.allowed` list in your workflow frontmatter:
>
> ```yaml
> network:
>   allowed:
>     - defaults
>     - "astral.sh"
>     - "pypi.org"
> ```
>
> See [Network Configuration](https://github.github.com/gh-aw/reference/network/) for more information.
>
> </details>


> Generated by [Issue Implementer](https://github.com/microsasa/cli-tools/actions/runs/24899200771/agentic_workflow) · ● 9.3M · [◷](https://github.com/search?q=repo%3Amicrosasa%2Fcli-tools+%22gh-aw-workflow-id%3A+issue-implementer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Issue Implementer, engine: copilot, model: claude-opus-4.6, id: 24899200771, workflow_id: issue-implementer, run: https://github.com/microsasa/cli-tools/actions/runs/24899200771 -->

<!-- gh-aw-workflow-id: issue-implementer -->