### PR TITLE
test: verify `stop_observer` non-None contract (#1076)

### DIFF
--- a/tests/copilot_usage/test_cli.py
+++ b/tests/copilot_usage/test_cli.py
@@ -881,11 +881,10 @@ def test_stop_observer_calls_stop_then_join_with_timeout() -> None:
     """stop_observer(observer) calls observer.stop() then observer.join(timeout=2)."""
     from unittest.mock import MagicMock, call
 
-    from copilot_usage.interactive import Stoppable
-    from copilot_usage.interactive import stop_observer as _stop_obs
+    from copilot_usage.interactive import Stoppable, stop_observer as _stop_obs
 
     mock_obs = MagicMock(spec=Stoppable)
-    _stop_obs(mock_obs)
+    _stop_obs(mock_obs)  # type: ignore[arg-type]  # pyright: ignore[reportArgumentType]
 
     mock_obs.stop.assert_called_once_with()
     mock_obs.join.assert_called_once_with(timeout=2)

--- a/tests/copilot_usage/test_cli.py
+++ b/tests/copilot_usage/test_cli.py
@@ -879,12 +879,13 @@ def test_stop_observer_none_is_noop() -> None:
 
 def test_stop_observer_calls_stop_then_join_with_timeout() -> None:
     """stop_observer(observer) calls observer.stop() then observer.join(timeout=2)."""
+    from typing import cast
     from unittest.mock import MagicMock, call
 
     from copilot_usage.interactive import Stoppable, stop_observer as _stop_obs
 
     mock_obs = MagicMock(spec=Stoppable)
-    _stop_obs(mock_obs)  # type: ignore[arg-type]  # pyright: ignore[reportArgumentType]
+    _stop_obs(cast(Stoppable, mock_obs))
 
     mock_obs.stop.assert_called_once_with()
     mock_obs.join.assert_called_once_with(timeout=2)
@@ -2416,11 +2417,13 @@ def test_interactive_loop_nonexistent_session_path(
     monkeypatch.setattr(cli_mod, "_start_observer", _tracking_start)
 
     # Track _stop_observer calls to verify it's called with None in finally.
-    stop_observer_args: list[object] = []
+    from copilot_usage.interactive import Stoppable
 
-    def _tracking_stop(observer: object) -> None:
+    stop_observer_args: list[Stoppable | None] = []
+
+    def _tracking_stop(observer: Stoppable | None) -> None:
         stop_observer_args.append(observer)
-        _stop_observer(observer)  # type: ignore[arg-type]  # pyright: ignore[reportArgumentType]
+        _stop_observer(observer)
 
     monkeypatch.setattr(cli_mod, "_stop_observer", _tracking_stop)
 

--- a/tests/copilot_usage/test_cli.py
+++ b/tests/copilot_usage/test_cli.py
@@ -877,6 +877,22 @@ def test_stop_observer_none_is_noop() -> None:
     _stop_observer(None)  # should not raise
 
 
+def test_stop_observer_calls_stop_then_join_with_timeout() -> None:
+    """stop_observer(observer) calls observer.stop() then observer.join(timeout=2)."""
+    from unittest.mock import MagicMock, call
+
+    from copilot_usage.interactive import Stoppable
+    from copilot_usage.interactive import stop_observer as _stop_obs
+
+    mock_obs = MagicMock(spec=Stoppable)
+    _stop_obs(mock_obs)
+
+    mock_obs.stop.assert_called_once_with()
+    mock_obs.join.assert_called_once_with(timeout=2)
+    # Verify order: stop() must precede join()
+    assert mock_obs.mock_calls == [call.stop(), call.join(timeout=2)]
+
+
 # ---------------------------------------------------------------------------
 # _FileChangeHandler tests
 # ---------------------------------------------------------------------------

--- a/tests/copilot_usage/test_cli.py
+++ b/tests/copilot_usage/test_cli.py
@@ -11,8 +11,8 @@ import threading
 import time
 from datetime import UTC, datetime, timedelta, timezone
 from pathlib import Path
-from typing import Any
-from unittest.mock import patch
+from typing import Any, cast
+from unittest.mock import MagicMock, call, patch
 
 import click
 import pytest
@@ -34,7 +34,10 @@ from copilot_usage.cli import (
     _validate_since_until,
     main,
 )
-from copilot_usage.interactive import render_session_list as _render_session_list
+from copilot_usage.interactive import (
+    Stoppable,
+    render_session_list as _render_session_list,
+)
 from copilot_usage.models import ensure_aware_opt
 
 # ---------------------------------------------------------------------------
@@ -879,11 +882,6 @@ def test_stop_observer_none_is_noop() -> None:
 
 def test_stop_observer_calls_stop_then_join_with_timeout() -> None:
     """_stop_observer(observer) calls observer.stop() then observer.join(timeout=2)."""
-    from typing import cast
-    from unittest.mock import MagicMock, call
-
-    from copilot_usage.interactive import Stoppable
-
     mock_obs = MagicMock(spec=Stoppable)
     _stop_observer(cast(Stoppable, mock_obs))
 
@@ -2417,8 +2415,6 @@ def test_interactive_loop_nonexistent_session_path(
     monkeypatch.setattr(cli_mod, "_start_observer", _tracking_start)
 
     # Track _stop_observer calls to verify it's called with None in finally.
-    from copilot_usage.interactive import Stoppable
-
     stop_observer_args: list[Stoppable | None] = []
 
     def _tracking_stop(observer: Stoppable | None) -> None:

--- a/tests/copilot_usage/test_cli.py
+++ b/tests/copilot_usage/test_cli.py
@@ -878,14 +878,14 @@ def test_stop_observer_none_is_noop() -> None:
 
 
 def test_stop_observer_calls_stop_then_join_with_timeout() -> None:
-    """stop_observer(observer) calls observer.stop() then observer.join(timeout=2)."""
+    """_stop_observer(observer) calls observer.stop() then observer.join(timeout=2)."""
     from typing import cast
     from unittest.mock import MagicMock, call
 
-    from copilot_usage.interactive import Stoppable, stop_observer as _stop_obs
+    from copilot_usage.interactive import Stoppable
 
     mock_obs = MagicMock(spec=Stoppable)
-    _stop_obs(cast(Stoppable, mock_obs))
+    _stop_observer(cast(Stoppable, mock_obs))
 
     mock_obs.stop.assert_called_once_with()
     mock_obs.join.assert_called_once_with(timeout=2)


### PR DESCRIPTION
Closes #1076

## What

Adds `test_stop_observer_calls_stop_then_join_with_timeout` to directly verify the non-None branch of `stop_observer()`:

- `observer.stop()` is called exactly once
- `observer.join(timeout=2)` is called exactly once
- `stop()` precedes `join()` (order matters: stop signals exit, join waits)

## Why

The existing test suite only covered the `None` guard path. The non-None path was exercised incidentally in teardown but with **no assertions** on the contract. The following regressions would pass the old suite:

| Change | Impact |
|---|---|
| `join(timeout=2)` → `join()` | Infinite hang |
| `join(timeout=2)` → `join(timeout=0)` | Returns before thread stops |
| Swap `stop()` / `join()` | join times out immediately |
| Remove `join()` entirely | Thread leak |

## Test

Uses `MagicMock(spec=Stoppable)` to assert exact call sequence and timeout value.




> [!WARNING]
> <details>
> <summary><strong>⚠️ Firewall blocked 2 domains</strong></summary>
>
> The following domains were blocked by the firewall during workflow execution:
>
> - `astral.sh`
> - `pypi.org`
>
> To allow these domains, add them to the `network.allowed` list in your workflow frontmatter:
>
> ```yaml
> network:
>   allowed:
>     - defaults
>     - "astral.sh"
>     - "pypi.org"
> ```
>
> See [Network Configuration](https://github.github.com/gh-aw/reference/network/) for more information.
>
> </details>


> Generated by [Issue Implementer](https://github.com/microsasa/cli-tools/actions/runs/24909571014/agentic_workflow) · ● 9M · [◷](https://github.com/search?q=repo%3Amicrosasa%2Fcli-tools+%22gh-aw-workflow-id%3A+issue-implementer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Issue Implementer, engine: copilot, model: claude-opus-4.6, id: 24909571014, workflow_id: issue-implementer, run: https://github.com/microsasa/cli-tools/actions/runs/24909571014 -->

<!-- gh-aw-workflow-id: issue-implementer -->