### PR TITLE
fix: correct `active_*` field docs for pure-active sessions (#1077)

### DIFF
--- a/src/copilot_usage/docs/implementation.md
+++ b/src/copilot_usage/docs/implementation.md
@@ -78,9 +78,9 @@ Typed dispatch uses the `as_*()` accessors on `SessionEvent` (e.g. `as_session_s
 | `last_resume_time`       | `datetime \| None`           | Timestamp of `session.resume` event (if any, after last shutdown)                   |
 | `events_path`            | `Path \| None`               | Set by `get_all_sessions()` after building — not from events                        |
 | `shutdown_cycles`        | `list[tuple[datetime \| None, SessionShutdownData]]` | Pre-computed list of `(timestamp, shutdown_payload)` pairs for every `session.shutdown` event. Populated by `build_session_summary()` so renderers never need to re-scan the event list. |
-| `active_model_calls`     | `int`                       | `assistant.turn_start` count after last shutdown (resumed sessions only)            |
-| `active_user_messages`   | `int`                       | `user.message` count after last shutdown (resumed sessions only)                    |
-| `active_output_tokens`   | `int`                       | Sum of `outputTokens` from `assistant.message` events after last shutdown           |
+| `active_model_calls`     | `int`                       | Turn-starts since last shutdown (resumed sessions); equals `model_calls` for pure-active sessions |
+| `active_user_messages`   | `int`                       | User messages since last shutdown (resumed sessions); equals `user_messages` for pure-active sessions |
+| `active_output_tokens`   | `int`                       | Output tokens since last shutdown (resumed sessions); equals full-session output tokens for pure-active sessions |
 
 ---
 
@@ -192,7 +192,7 @@ Populated from the `timestamp` of the `session.resume` event after the last shut
 For resumed sessions (in `parser.py`):
 - `end_time` is set to `None` (not the last shutdown timestamp)
 - `model_metrics` contain the **merged shutdown data** (historical baseline)
-- `active_model_calls`, `active_user_messages`, `active_output_tokens` contain **only** post-shutdown counts
+- `active_model_calls`, `active_user_messages`, `active_output_tokens` contain **only** post-shutdown counts (for pure-active sessions these equal the full-session totals since there is no shutdown baseline)
 - `model_calls` and `user_messages` are the **total** counts across the entire session
 
 ---

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -276,3 +276,34 @@ def test_implementation_md_symbols_exist_in_expected_modules() -> None:
                 f"implementation.md references '{symbol}' as a public "
                 f"export of {module_path}, but it is not in __all__"
             )
+
+
+def test_active_fields_document_pure_active_semantics() -> None:
+    """The active_model_calls / active_user_messages / active_output_tokens
+    field descriptions must mention pure-active session semantics — not just
+    resumed sessions."""
+    for field in (
+        "active_model_calls",
+        "active_user_messages",
+        "active_output_tokens",
+    ):
+        # Find the table row for this field
+        match = re.search(
+            rf"^\|[^|]*`{field}`[^|]*\|[^|]*\|([^|]+)\|",
+            _IMPL_MD,
+            re.MULTILINE,
+        )
+        assert match, (
+            f"Could not find '{field}' table row in implementation.md"
+        )
+        description = match.group(1)
+        assert "pure-active" in description, (
+            f"'{field}' description in implementation.md must mention "
+            f"pure-active session semantics — for sessions that never "
+            f"shut down, active_* equals the full-session total"
+        )
+        assert "resumed sessions only" not in description, (
+            f"'{field}' description in implementation.md must not say "
+            f"'resumed sessions only' — the field is also populated "
+            f"for pure-active sessions"
+        )

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -293,9 +293,7 @@ def test_active_fields_document_pure_active_semantics() -> None:
             _IMPL_MD,
             re.MULTILINE,
         )
-        assert match, (
-            f"Could not find '{field}' table row in implementation.md"
-        )
+        assert match, f"Could not find '{field}' table row in implementation.md"
         description = match.group(1)
         assert "pure-active" in description, (
             f"'{field}' description in implementation.md must mention "


### PR DESCRIPTION
Closes #1077

## Changes

The `implementation.md` descriptions of `active_model_calls`, `active_user_messages`, and `active_output_tokens` incorrectly implied these fields are only populated for resumed sessions ("after last shutdown", "resumed sessions only"). In reality, `_build_active_summary` sets them to full-session totals for pure-active sessions (sessions that have never seen a `SESSION_SHUTDOWN`).

### Documentation updates

1. **Field table** (lines 81–83): Each field now describes both cases:
   - Resumed sessions: counts since last shutdown
   - Pure-active sessions: equals the full-session total

2. **Prose section** ("Resumed session summary construction"): Added parenthetical clarifying that the "post-shutdown only" characterisation applies to the resumed code path, and that pure-active sessions use full-session totals since there is no shutdown baseline.

### Test

Added `test_active_fields_document_pure_active_semantics` in `tests/test_docs.py` that verifies:
- Each `active_*` field description mentions "pure-active"
- None of the descriptions say "resumed sessions only"




> [!WARNING]
> <details>
> <summary><strong>⚠️ Firewall blocked 8 domains</strong></summary>
>
> The following domains were blocked by the firewall during workflow execution:
>
> - `astral.sh`
> - `conda.anaconda.org`
> - `index.crates.io`
> - `objects.githubusercontent.com`
> - `pypi.org`
> - `releaseassets.githubusercontent.com`
> - `repo.anaconda.com`
> - `static.rustlang.org`
>
> To allow these domains, add them to the `network.allowed` list in your workflow frontmatter:
>
> ```yaml
> network:
>   allowed:
>     - defaults
>     - "astral.sh"
>     - "conda.anaconda.org"
>     - "index.crates.io"
>     - "objects.githubusercontent.com"
>     - "pypi.org"
>     - "releaseassets.githubusercontent.com"
>     - "repo.anaconda.com"
>     - "static.rustlang.org"
> ```
>
> See [Network Configuration](https://github.github.com/gh-aw/reference/network/) for more information.
>
> </details>


> Generated by [Issue Implementer](https://github.com/microsasa/cli-tools/actions/runs/24912117656/agentic_workflow) · ● 26.2M · [◷](https://github.com/search?q=repo%3Amicrosasa%2Fcli-tools+%22gh-aw-workflow-id%3A+issue-implementer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Issue Implementer, engine: copilot, model: claude-opus-4.6, id: 24912117656, workflow_id: issue-implementer, run: https://github.com/microsasa/cli-tools/actions/runs/24912117656 -->

<!-- gh-aw-workflow-id: issue-implementer -->