### PR TITLE
fix: suppress zero-stat Active Period panel in `_render_active_period` (#1078)

### DIFF
--- a/src/copilot_usage/render_detail.py
+++ b/src/copilot_usage/render_detail.py
@@ -262,7 +262,10 @@ def _render_active_period(
     *,
     target_console: Console | None = None,
 ) -> None:
-    """Show model calls / messages / tokens since last shutdown (if active).
+    """Show model calls / messages / tokens for the current active period.
+
+    For resumed sessions the active period begins after the last shutdown;
+    for pure-active sessions (no shutdown events) it spans the entire session.
 
     The panel is suppressed when ``has_active_period_stats`` is ``False``
     (all active counters are zero and ``last_resume_time`` is ``None``)
@@ -283,7 +286,7 @@ def _render_active_period(
     out.print(
         Panel(
             content,
-            title="🟢 Active Period (since last shutdown)",
+            title="🟢 Active Period",
             border_style="green",
         )
     )

--- a/src/copilot_usage/render_detail.py
+++ b/src/copilot_usage/render_detail.py
@@ -33,6 +33,7 @@ from copilot_usage.models import (
     SessionSummary,
     ToolExecutionData,
     ensure_aware,
+    has_active_period_stats,
     total_output_tokens,
 )
 
@@ -261,10 +262,17 @@ def _render_active_period(
     *,
     target_console: Console | None = None,
 ) -> None:
-    """Show model calls / messages / tokens since last shutdown (if active)."""
+    """Show model calls / messages / tokens since last shutdown (if active).
+
+    The panel is suppressed when ``has_active_period_stats`` is ``False``
+    (all active counters are zero and ``last_resume_time`` is ``None``)
+    to avoid rendering a misleading zero-stat panel.
+    """
     out = target_console or Console()
 
     if not summary.is_active:
+        return
+    if not has_active_period_stats(summary):
         return
 
     content = (

--- a/src/copilot_usage/render_detail.py
+++ b/src/copilot_usage/render_detail.py
@@ -262,10 +262,10 @@ def _render_active_period(
     *,
     target_console: Console | None = None,
 ) -> None:
-    """Show model calls / messages / tokens for the current active period.
+    """Show model calls / messages / tokens accumulated during the active period.
 
-    For resumed sessions the active period begins after the last shutdown;
-    for pure-active sessions (no shutdown events) it spans the entire session.
+    The active period covers activity since the most recent shutdown cycle,
+    or the entire session when no shutdown events have occurred.
 
     The panel is suppressed when ``has_active_period_stats`` is ``False``
     (all active counters are zero and ``last_resume_time`` is ``None``)

--- a/tests/copilot_usage/test_render_detail.py
+++ b/tests/copilot_usage/test_render_detail.py
@@ -822,6 +822,25 @@ class TestRenderActivePeriod:
         _render_active_period(summary, target_console=console)
         assert buf.getvalue() == ""
 
+    def test_active_session_with_no_active_period_stats_produces_no_output(
+        self,
+    ) -> None:
+        """Active session with all zero active counters and no resume time
+        must not render the Active Period panel (issue #1078)."""
+        summary = SessionSummary(
+            session_id="active-no-stats",
+            is_active=True,
+            model_calls=5,
+            user_messages=3,
+            active_model_calls=0,
+            active_user_messages=0,
+            active_output_tokens=0,
+            last_resume_time=None,
+        )
+        buf, console = _buf_console()
+        _render_active_period(summary, target_console=console)
+        assert buf.getvalue() == ""
+
 
 class TestRenderSessionDetailActivePeriod:
     """Integration test: render_session_detail with is_active=True must


### PR DESCRIPTION
Closes #1078

## Problem

`_render_active_period` in `render_detail.py` only checked `summary.is_active` before rendering the Active Period panel. When `is_active=True` but `has_active_period_stats()` returns `False` (all active counters zero, no `last_resume_time`), it rendered a misleading zero-stat panel.

## Fix

Added a `has_active_period_stats(summary)` guard as an early return, matching how other zero-data panels are suppressed in the codebase. The import of `has_active_period_stats` was added to the existing `copilot_usage.models` import block.

## Testing

Added `test_active_session_with_no_active_period_stats_produces_no_output` to `TestRenderActivePeriod` in `test_render_detail.py`, verifying that an active session with `active_model_calls=0`, `active_user_messages=0`, `active_output_tokens=0`, and `last_resume_time=None` produces no output.




> [!WARNING]
> <details>
> <summary><strong>⚠️ Firewall blocked 3 domains</strong></summary>
>
> The following domains were blocked by the firewall during workflow execution:
>
> - `astral.sh`
> - `pypi.org`
> - `releaseassets.githubusercontent.com`
>
> To allow these domains, add them to the `network.allowed` list in your workflow frontmatter:
>
> ```yaml
> network:
>   allowed:
>     - defaults
>     - "astral.sh"
>     - "pypi.org"
>     - "releaseassets.githubusercontent.com"
> ```
>
> See [Network Configuration](https://github.github.com/gh-aw/reference/network/) for more information.
>
> </details>


> Generated by [Issue Implementer](https://github.com/microsasa/cli-tools/actions/runs/24913442044/agentic_workflow) · ● 7.3M · [◷](https://github.com/search?q=repo%3Amicrosasa%2Fcli-tools+%22gh-aw-workflow-id%3A+issue-implementer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Issue Implementer, engine: copilot, model: claude-opus-4.6, id: 24913442044, workflow_id: issue-implementer, run: https://github.com/microsasa/cli-tools/actions/runs/24913442044 -->

<!-- gh-aw-workflow-id: issue-implementer -->