### PR TITLE
fix: bound `_DISCOVERY_CACHE` and `_VSCODE_DISCOVERY_CACHE` with LRU eviction (#1082)

### DIFF
--- a/src/copilot_usage/parser.py
+++ b/src/copilot_usage/parser.py
@@ -78,7 +78,8 @@ class _DiscoveryCache:
 # Module-level discovery cache: root_path → _DiscoveryCache.
 # Avoids redundant inner os.scandir calls when the root directory
 # has not changed (no sessions added or removed).
-_DISCOVERY_CACHE: Final[dict[Path, _DiscoveryCache]] = {}
+_MAX_CACHED_DISCOVERY: Final[int] = 8
+_DISCOVERY_CACHE: Final[OrderedDict[Path, _DiscoveryCache]] = OrderedDict()
 
 # On cache hits, probe at most this many sessions without a cached
 # plan.md for a newly-created file.  The probe window rotates via
@@ -533,8 +534,13 @@ def _discover_with_identity(
         except OSError:
             return False, root, []
         no_plan_idx = [i for i, (_, pp) in enumerate(entries) if pp is None]
-        _DISCOVERY_CACHE[root] = _DiscoveryCache(
-            root_id=root_id, entries=entries, no_plan_indices=no_plan_idx
+        lru_insert(
+            _DISCOVERY_CACHE,
+            root,
+            _DiscoveryCache(
+                root_id=root_id, entries=entries, no_plan_indices=no_plan_idx
+            ),
+            _MAX_CACHED_DISCOVERY,
         )
         is_cache_hit = False
 

--- a/src/copilot_usage/vscode_parser.py
+++ b/src/copilot_usage/vscode_parser.py
@@ -150,7 +150,8 @@ class _VSCodeDiscoveryCache:
     log_paths: tuple[Path, ...]
 
 
-_VSCODE_DISCOVERY_CACHE: Final[dict[Path, _VSCodeDiscoveryCache]] = {}
+_MAX_VSCODE_DISCOVERY_CACHE: Final[int] = 8
+_VSCODE_DISCOVERY_CACHE: Final[OrderedDict[Path, _VSCodeDiscoveryCache]] = OrderedDict()
 
 
 def _scan_child_ids(root: Path) -> _ChildIds:
@@ -296,12 +297,17 @@ def _cached_discover_vscode_logs(base_path: Path | None) -> list[Path]:
         child_ids = _scan_child_ids(candidate)
         newest_path, newest_id = _newest_child_from_ids(candidate, child_ids)
         found = sorted(candidate.glob(_GLOB_PATTERN))
-        _VSCODE_DISCOVERY_CACHE[candidate] = _VSCodeDiscoveryCache(
-            root_id=root_id,
-            child_ids=child_ids,
-            newest_child_path=newest_path,
-            newest_child_id=newest_id,
-            log_paths=tuple(found),
+        lru_insert(
+            _VSCODE_DISCOVERY_CACHE,
+            candidate,
+            _VSCodeDiscoveryCache(
+                root_id=root_id,
+                child_ids=child_ids,
+                newest_child_path=newest_path,
+                newest_child_id=newest_id,
+                log_paths=tuple(found),
+            ),
+            _MAX_VSCODE_DISCOVERY_CACHE,
         )
         result.extend(found)
     result.sort()

--- a/tests/copilot_usage/test_parser.py
+++ b/tests/copilot_usage/test_parser.py
@@ -40,6 +40,7 @@ from copilot_usage.parser import (
     _DISCOVERY_CACHE,
     _EVENTS_CACHE,
     _FIRST_PASS_EVENT_TYPES,
+    _MAX_CACHED_DISCOVERY,
     _MAX_CACHED_EVENTS,
     _MAX_CACHED_SESSIONS,
     _MAX_PLAN_PROBES,
@@ -9600,3 +9601,34 @@ class TestGetAllSessionsPostParseStat:
             # stored file_id size should NOT be the inflated value
             assert entry.file_id is not None
             assert entry.file_id[1] == entry.end_offset
+
+
+# ---------------------------------------------------------------------------
+# _DISCOVERY_CACHE bounded by _MAX_CACHED_DISCOVERY
+# ---------------------------------------------------------------------------
+
+
+class TestDiscoveryCacheLRUEviction:
+    """_DISCOVERY_CACHE is bounded by _MAX_CACHED_DISCOVERY and uses LRU eviction."""
+
+    def setup_method(self) -> None:
+        _DISCOVERY_CACHE.clear()
+        _SESSION_CACHE.clear()
+        _EVENTS_CACHE.clear()
+
+    def test_discovery_cache_evicts_lru_entry(self, tmp_path: Path) -> None:
+        """Calling _discover_with_identity with more than _MAX_CACHED_DISCOVERY
+        distinct root paths evicts the least-recently-used entry."""
+        roots: list[Path] = []
+        for i in range(_MAX_CACHED_DISCOVERY + 2):
+            root = tmp_path / f"root{i}"
+            sess = root / "sess" / "events.jsonl"
+            _write_events(sess, _START_EVENT, _USER_MSG)
+            _discover_with_identity(root)
+            roots.append(root)
+
+        assert len(_DISCOVERY_CACHE) <= _MAX_CACHED_DISCOVERY
+        # The first root should have been evicted (LRU).
+        assert roots[0] not in _DISCOVERY_CACHE
+        # The last root should still be cached.
+        assert roots[-1] in _DISCOVERY_CACHE

--- a/tests/copilot_usage/test_vscode_parser.py
+++ b/tests/copilot_usage/test_vscode_parser.py
@@ -20,6 +20,7 @@ from copilot_usage.vscode_parser import (
     _CCREQ_RE,
     _MAX_CACHED_FILE_SUMMARIES,
     _MAX_CACHED_VSCODE_REQUESTS,
+    _MAX_VSCODE_DISCOVERY_CACHE,
     _PER_FILE_SUMMARY_CACHE,
     _VSCODE_DISCOVERY_CACHE,
     _VSCODE_LOG_CACHE,
@@ -3400,3 +3401,38 @@ class TestNewestChildFromIds:
         path, identity = _newest_child_from_ids(self._ROOT, child_ids)
         assert path == self._ROOT / "window2"
         assert identity == (100, 0)
+
+
+# ---------------------------------------------------------------------------
+# _VSCODE_DISCOVERY_CACHE bounded by _MAX_VSCODE_DISCOVERY_CACHE
+# ---------------------------------------------------------------------------
+
+
+class TestVscodeDiscoveryCacheLRUEviction:
+    """_VSCODE_DISCOVERY_CACHE is bounded by _MAX_VSCODE_DISCOVERY_CACHE."""
+
+    def test_vscode_discovery_cache_evicts_lru_entry(self, tmp_path: Path) -> None:
+        """Calling _cached_discover_vscode_logs with more than
+        _MAX_VSCODE_DISCOVERY_CACHE distinct roots evicts the LRU entry."""
+        roots: list[Path] = []
+        for i in range(_MAX_VSCODE_DISCOVERY_CACHE + 2):
+            root = tmp_path / f"root{i}"
+            log_dir = (
+                root
+                / "20260313T211400"
+                / "window1"
+                / "exthost"
+                / "GitHub.copilot-chat"
+            )
+            log_dir.mkdir(parents=True)
+            (log_dir / "GitHub Copilot Chat.log").write_text(
+                _make_log_line(req_idx=i)
+            )
+            _cached_discover_vscode_logs(root)
+            roots.append(root)
+
+        assert len(_VSCODE_DISCOVERY_CACHE) <= _MAX_VSCODE_DISCOVERY_CACHE
+        # The first root should have been evicted (LRU).
+        assert roots[0] not in _VSCODE_DISCOVERY_CACHE
+        # The last root should still be cached.
+        assert roots[-1] in _VSCODE_DISCOVERY_CACHE


### PR DESCRIPTION
Closes #1082

## Changes

Both `_DISCOVERY_CACHE` (in `parser.py`) and `_VSCODE_DISCOVERY_CACHE` (in `vscode_parser.py`) were plain `dict` instances without size bounds — inconsistent with every other module-level cache in the codebase which uses `OrderedDict` + `lru_insert`.

This PR converts both to bounded `OrderedDict` caches:

| Cache | Max Size Constant | Value |
|---|---|---|
| `_DISCOVERY_CACHE` | `_MAX_CACHED_DISCOVERY` | 8 |
| `_VSCODE_DISCOVERY_CACHE` | `_MAX_VSCODE_DISCOVERY_CACHE` | 8 |

### Source changes

- **`src/copilot_usage/parser.py`**: Changed `_DISCOVERY_CACHE` from `dict` to `OrderedDict`, added `_MAX_CACHED_DISCOVERY = 8`, replaced direct `dict.__setitem__` with `lru_insert()` in `_discover_with_identity`.
- **`src/copilot_usage/vscode_parser.py`**: Changed `_VSCODE_DISCOVERY_CACHE` from `dict` to `OrderedDict`, added `_MAX_VSCODE_DISCOVERY_CACHE = 8`, replaced direct `dict.__setitem__` with `lru_insert()` in `_cached_discover_vscode_logs`.

### Tests

- **`tests/copilot_usage/test_parser.py`**: Added `TestDiscoveryCacheLRUEviction` — calls `_discover_with_identity` with `_MAX_CACHED_DISCOVERY + 2` distinct roots and asserts the cache stays bounded and evicts LRU entries.
- **`tests/copilot_usage/test_vscode_parser.py`**: Added `TestVscodeDiscoveryCacheLRUEviction` — equivalent test for `_VSCODE_DISCOVERY_CACHE` via `_cached_discover_vscode_logs`.

All existing tests remain unchanged — the logical behaviour of both caches is preserved; only growth is now bounded.




> [!WARNING]
> <details>
> <summary><strong>⚠️ Firewall blocked 3 domains</strong></summary>
>
> The following domains were blocked by the firewall during workflow execution:
>
> - `astral.sh`
> - `pypi.org`
> - `releaseassets.githubusercontent.com`
>
> To allow these domains, add them to the `network.allowed` list in your workflow frontmatter:
>
> ```yaml
> network:
>   allowed:
>     - defaults
>     - "astral.sh"
>     - "pypi.org"
>     - "releaseassets.githubusercontent.com"
> ```
>
> See [Network Configuration](https://github.github.com/gh-aw/reference/network/) for more information.
>
> </details>


> Generated by [Issue Implementer](https://github.com/microsasa/cli-tools/actions/runs/24923936521/agentic_workflow) · ● 23M · [◷](https://github.com/search?q=repo%3Amicrosasa%2Fcli-tools+%22gh-aw-workflow-id%3A+issue-implementer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Issue Implementer, engine: copilot, model: claude-opus-4.6, id: 24923936521, workflow_id: issue-implementer, run: https://github.com/microsasa/cli-tools/actions/runs/24923936521 -->

<!-- gh-aw-workflow-id: issue-implementer -->