### PR TITLE
fix: update architecture.md test listing and add regression guard (#1085)

### DIFF
--- a/src/copilot_usage/docs/architecture.md
+++ b/src/copilot_usage/docs/architecture.md
@@ -78,8 +78,10 @@ tests/
 │   ├── test_models.py          Pydantic model creation and validation
 │   ├── test_parser.py          Event parsing, session summary building, edge cases
 │   ├── test_pricing.py         Pricing lookups, cost estimation
-│   ├── test_report.py          Rich output & session-detail rendering
+│   ├── test_report.py          Rich output — summary, cost, live, and full-summary views
+│   ├── test_render_detail.py   Session-detail rendering (render_detail.py)
 │   ├── test_formatting.py      Formatting helpers and string utilities
+│   ├── test_fs_utils.py        Filesystem helpers and LRU cache utilities
 │   ├── test_logging_config.py  Loguru configuration
 │   ├── test_cli.py             Click command invocation via CliRunner
 │   ├── test_vscode_parser.py   VS Code log parsing, discovery, aggregation

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -278,6 +278,29 @@ def test_implementation_md_symbols_exist_in_expected_modules() -> None:
             )
 
 
+def test_test_tree_lists_all_test_modules() -> None:
+    """Every test_*.py file in tests/copilot_usage/ must appear in the
+    test directory tree in architecture.md."""
+    test_dir = Path(__file__).parents[1] / "tests" / "copilot_usage"
+    on_disk = {p.name for p in test_dir.glob("test_*.py")}
+    # Extract the tests/copilot_usage/ subtree section from architecture.md.
+    tree_match = re.search(
+        r"^tests/\s*\n├── copilot_usage/.*?(?=^├──|\Z)",
+        _ARCH_MD,
+        re.MULTILINE | re.DOTALL,
+    )
+    assert tree_match, (
+        "Could not find the 'tests/ ... copilot_usage/' subtree "
+        "in architecture.md"
+    )
+    tree_text = tree_match.group(0)
+    missing = {f for f in on_disk if f not in tree_text}
+    assert not missing, (
+        f"Test files missing from the test directory tree in "
+        f"architecture.md: {sorted(missing)}"
+    )
+
+
 def test_active_fields_document_pure_active_semantics() -> None:
     """The active_model_calls / active_user_messages / active_output_tokens
     field descriptions must mention pure-active session semantics — not just


### PR DESCRIPTION
Closes #1085

## Changes

### 1. Fix `architecture.md` test directory listing

- Added `test_render_detail.py` — "Session-detail rendering (render_detail.py)"
- Added `test_fs_utils.py` — "Filesystem helpers and LRU cache utilities"
- Updated `test_report.py` description from "Rich output & session-detail rendering" to "Rich output — summary, cost, live, and full-summary views" (session-detail rendering moved to `render_detail.py`)

### 2. Add regression guard in `test_docs.py`

Added `test_test_tree_lists_all_test_modules` that:
1. Globs all `test_*.py` files in `tests/copilot_usage/`
2. Extracts the test tree block from `architecture.md`
3. Asserts every file on disk appears in the tree text
4. Fails loudly when a new test file is added without a corresponding entry

This mirrors the existing `test_components_table_lists_all_modules` guard for source modules.

### Validation

- Verified the new test **would fail** on the old `architecture.md` (correctly detects `test_render_detail.py` and `test_fs_utils.py` as missing)
- Verified the new test **passes** after the `architecture.md` fix




> [!WARNING]
> <details>
> <summary><strong>⚠️ Firewall blocked 4 domains</strong></summary>
>
> The following domains were blocked by the firewall during workflow execution:
>
> - `astral.sh`
> - `index.crates.io`
> - `pypi.org`
> - `releaseassets.githubusercontent.com`
>
> To allow these domains, add them to the `network.allowed` list in your workflow frontmatter:
>
> ```yaml
> network:
>   allowed:
>     - defaults
>     - "astral.sh"
>     - "index.crates.io"
>     - "pypi.org"
>     - "releaseassets.githubusercontent.com"
> ```
>
> See [Network Configuration](https://github.github.com/gh-aw/reference/network/) for more information.
>
> </details>


> Generated by [Issue Implementer](https://github.com/microsasa/cli-tools/actions/runs/24928187640/agentic_workflow) · ● 12.4M · [◷](https://github.com/search?q=repo%3Amicrosasa%2Fcli-tools+%22gh-aw-workflow-id%3A+issue-implementer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Issue Implementer, engine: copilot, model: claude-opus-4.6, id: 24928187640, workflow_id: issue-implementer, run: https://github.com/microsasa/cli-tools/actions/runs/24928187640 -->

<!-- gh-aw-workflow-id: issue-implementer -->