### PR TITLE
test: add coverage for `_render_active_period` with zero post-shutdown stats (#1088)

### DIFF
--- a/tests/copilot_usage/test_render_detail.py
+++ b/tests/copilot_usage/test_render_detail.py
@@ -822,6 +822,35 @@ class TestRenderActivePeriod:
         _render_active_period(summary, target_console=console)
         assert buf.getvalue() == ""
 
+    def test_active_session_with_zero_stats_renders_zero_panel(self) -> None:
+        """Active session with zero post-shutdown stats still renders the panel.
+
+        Documents current behaviour: ``_render_active_period`` checks only
+        ``is_active``, not ``has_active_period_stats()``, so the panel appears
+        even when all counters are zero and ``last_resume_time`` is ``None``.
+
+        When issue #1078 is resolved this test should be updated to assert
+        that the panel is **not** rendered.
+        """
+        # is_active=True but all active_* counters are 0 and last_resume_time
+        # is None → has_active_period_stats() returns False.
+        summary = SessionSummary(
+            session_id="zero-active-test",
+            is_active=True,
+            active_model_calls=0,
+            active_user_messages=0,
+            active_output_tokens=0,
+            last_resume_time=None,
+        )
+        buf, console = _buf_console()
+        _render_active_period(summary, target_console=console)
+        output = _strip_ansi(buf.getvalue())
+        # Panel is rendered with zero stats (current behaviour — see #1078).
+        assert "Active Period" in output
+        assert "0 model calls" in output
+        assert "0 user messages" in output
+        assert "0 output tokens" in output
+
 
 class TestRenderSessionDetailActivePeriod:
     """Integration test: render_session_detail with is_active=True must
@@ -849,6 +878,38 @@ class TestRenderSessionDetailActivePeriod:
         render_session_detail([ev], summary, target_console=console)
         output = _strip_ansi(buf.getvalue())
         assert "Active Period" in output
+
+    def test_render_session_detail_idle_active_no_zero_panel_after_fix(self) -> None:
+        """Integration: render_session_detail with an idle active session.
+
+        The session is active (``is_active=True``) but has zero post-shutdown
+        stats (``has_active_period_stats()`` returns ``False``).  Under current
+        behaviour the "Active Period" panel is rendered with all-zero
+        counters.
+
+        When issue #1078 is resolved this test should be updated to assert
+        that "Active Period" is **not** present in the output.
+        """
+        summary = SessionSummary(
+            session_id="idle-active-e2e",
+            start_time=datetime(2026, 4, 1, 10, 0, 0, tzinfo=UTC),
+            is_active=True,
+            active_model_calls=0,
+            active_user_messages=0,
+            active_output_tokens=0,
+            last_resume_time=None,
+        )
+        ev = SessionEvent(
+            type=EventType.USER_MESSAGE,
+            timestamp=datetime(2026, 4, 1, 10, 1, 0, tzinfo=UTC),
+            data={"content": "ping"},
+        )
+        buf, console = _buf_console()
+        render_session_detail([ev], summary, target_console=console)
+        output = _strip_ansi(buf.getvalue())
+        # Current behaviour: zero-stat panel is rendered (see #1078).
+        assert "Active Period" in output
+        assert "0 model calls" in output
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #1088

## Summary

Adds explicit test coverage for the uncovered `_render_active_period` code path where `is_active=True` but `has_active_period_stats()` returns `False` (all `active_*` counters are zero and `last_resume_time` is `None`).

## Tests added

### `TestRenderActivePeriod.test_active_session_with_zero_stats_renders_zero_panel`
- **Unit test**: calls `_render_active_period` directly with a `SessionSummary` where `is_active=True`, all active counters are `0`, and `last_resume_time=None`.
- Asserts the "Active Period" panel **is** rendered with `0 model calls`, `0 user messages`, `0 output tokens` (documents current behaviour).
- Includes comment linking to issue #1078 — when that code-health issue is resolved, this test should be updated to assert the panel is **not** rendered.

### `TestRenderSessionDetailActivePeriod.test_render_session_detail_idle_active_no_zero_panel_after_fix`
- **Integration test**: calls `render_session_detail` end-to-end with the same idle-active session configuration.
- Asserts the same zero-stat panel rendering via the public API.
- Also linked to issue #1078 for future update.

## No production code changes
This is a test-only change — no modifications to `src/`.




> [!WARNING]
> <details>
> <summary><strong>⚠️ Firewall blocked 4 domains</strong></summary>
>
> The following domains were blocked by the firewall during workflow execution:
>
> - `astral.sh`
> - `index.crates.io`
> - `pypi.org`
> - `releaseassets.githubusercontent.com`
>
> To allow these domains, add them to the `network.allowed` list in your workflow frontmatter:
>
> ```yaml
> network:
>   allowed:
>     - defaults
>     - "astral.sh"
>     - "index.crates.io"
>     - "pypi.org"
>     - "releaseassets.githubusercontent.com"
> ```
>
> See [Network Configuration](https://github.github.com/gh-aw/reference/network/) for more information.
>
> </details>


> Generated by [Issue Implementer](https://github.com/microsasa/cli-tools/actions/runs/24932989805/agentic_workflow) · ● 20.4M · [◷](https://github.com/search?q=repo%3Amicrosasa%2Fcli-tools+%22gh-aw-workflow-id%3A+issue-implementer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Issue Implementer, engine: copilot, model: claude-opus-4.6, id: 24932989805, workflow_id: issue-implementer, run: https://github.com/microsasa/cli-tools/actions/runs/24932989805 -->

<!-- gh-aw-workflow-id: issue-implementer -->