### PR TITLE
test: add exact-boundary tests for `_validate_since_until` and `FileChangeHandler.dispatch` (#1091)

### DIFF
--- a/tests/copilot_usage/test_cli.py
+++ b/tests/copilot_usage/test_cli.py
@@ -934,6 +934,29 @@ class TestFileChangeHandler:
         handler.dispatch(object())
         assert event.is_set()
 
+    def test_dispatch_suppressed_at_exact_debounce_boundary(self) -> None:
+        """A call arriving at exactly WATCHDOG_DEBOUNCE_SECS after the previous
+        trigger is still suppressed — the guard uses <=, not <."""
+        import time as _time
+
+        from copilot_usage.interactive import (
+            WATCHDOG_DEBOUNCE_SECS,
+            FileChangeHandler as _FileChangeHandler,
+        )
+
+        event = threading.Event()
+        handler = _FileChangeHandler(event)
+        handler.dispatch(object())  # prime: sets _last_trigger = now
+        assert event.is_set()
+        event.clear()
+
+        # Simulate _last_trigger exactly WATCHDOG_DEBOUNCE_SECS ago.
+        handler._last_trigger = _time.monotonic() - WATCHDOG_DEBOUNCE_SECS
+        handler.dispatch(object())
+        assert not event.is_set(), (
+            "At exactly the boundary (<=) the event should still be suppressed"
+        )
+
     def test_dispatch_interface(self) -> None:
         """_FileChangeHandler provides a dispatch(event) interface compatible with watchdog handlers."""
         from copilot_usage.interactive import (
@@ -3429,6 +3452,14 @@ class TestValidateSinceUntil:
         expected_until = dt_before.isoformat(sep=" ", timespec="seconds")
         assert expected_since in msg
         assert expected_until in msg
+
+    def test_equal_since_until_does_not_raise(self) -> None:
+        """since == until is not an error — the strict > guard does not fire."""
+        t = datetime(2026, 3, 7, 12, 0, 0, tzinfo=UTC)
+        arg = _ParsedDateArg(value=t, has_explicit_time=True)
+        aware_since, aware_until = _validate_since_until(t, arg)
+        assert aware_since == t
+        assert aware_until == t
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #1091

## Changes

Adds two missing boundary tests that document the intended inclusive/exclusive semantics of comparison operators in core logic:

### Gap 1 — `_validate_since_until` with `since == until`

**New test:** `TestValidateSinceUntil.test_equal_since_until_does_not_raise`

Asserts that passing `--since` and `--until` with the same timestamp does **not** raise a `UsageError`. The guard uses strict `>`, so equal timestamps are valid. A regression changing `>` to `>=` would now be caught.

### Gap 2 — `FileChangeHandler.dispatch()` at exactly `WATCHDOG_DEBOUNCE_SECS`

**New test:** `TestFileChangeHandler.test_dispatch_suppressed_at_exact_debounce_boundary`

Asserts that a dispatch call arriving at **exactly** `WATCHDOG_DEBOUNCE_SECS` after the previous trigger is still suppressed. The guard uses `<=`, so the boundary is inclusive. A regression changing `<=` to `<` would now be caught.

No source changes — purely test coverage improvements.




> [!WARNING]
> <details>
> <summary><strong>⚠️ Firewall blocked 5 domains</strong></summary>
>
> The following domains were blocked by the firewall during workflow execution:
>
> - `astral.sh`
> - `files.pythonhosted.org`
> - `index.crates.io`
> - `pypi.org`
> - `releaseassets.githubusercontent.com`
>
> To allow these domains, add them to the `network.allowed` list in your workflow frontmatter:
>
> ```yaml
> network:
>   allowed:
>     - defaults
>     - "astral.sh"
>     - "files.pythonhosted.org"
>     - "index.crates.io"
>     - "pypi.org"
>     - "releaseassets.githubusercontent.com"
> ```
>
> See [Network Configuration](https://github.github.com/gh-aw/reference/network/) for more information.
>
> </details>


> Generated by [Issue Implementer](https://github.com/microsasa/cli-tools/actions/runs/24952508091/agentic_workflow) · ● 14.2M · [◷](https://github.com/search?q=repo%3Amicrosasa%2Fcli-tools+%22gh-aw-workflow-id%3A+issue-implementer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Issue Implementer, engine: copilot, model: claude-opus-4.6, id: 24952508091, workflow_id: issue-implementer, run: https://github.com/microsasa/cli-tools/actions/runs/24952508091 -->

<!-- gh-aw-workflow-id: issue-implementer -->