### PR TITLE
fix: add unattributed active tokens row to model breakdown table (#1092)

### DIFF
--- a/src/copilot_usage/report.py
+++ b/src/copilot_usage/report.py
@@ -345,15 +345,43 @@ def _render_totals(console: Console, sessions: list[SessionSummary]) -> None:
     console.print(Panel("\n".join(lines), title="Totals", border_style="cyan"))
 
 
+def _unattributed_active_tokens(sessions: list[SessionSummary]) -> int:
+    """Return total unattributed active output tokens across *sessions*.
+
+    Only sessions that have been resumed (``has_shutdown_metrics`` is True
+    and ``active_output_tokens > 0``) contribute — their active tokens are
+    not captured inside ``model_metrics`` and would otherwise be missing
+    from per-model breakdowns.
+    """
+    return sum(
+        s.active_output_tokens
+        for s in sessions
+        if s.has_shutdown_metrics and s.active_output_tokens > 0
+    )
+
+
 def _render_model_table(
     console: Console,
     sessions: list[SessionSummary],
     *,
     title: str = "Per-Model Breakdown",
+    shutdown_only: bool = False,
 ) -> None:
-    """Render the per-model breakdown table."""
+    """Render the per-model breakdown table.
+
+    When *shutdown_only* is ``False`` (the default) and any session has
+    unattributed active output tokens (resumed sessions whose post-shutdown
+    tokens are not captured in ``model_metrics``), an
+    ``(active, unattributed)`` row is appended so that the table total
+    reconciles with the totals panel.
+
+    Pass ``shutdown_only=True`` to suppress the active row — used by the
+    historical section of :func:`render_full_summary` where only shutdown
+    metrics are shown.
+    """
     merged = _aggregate_model_metrics(sessions)
-    if not merged:
+    unattributed = 0 if shutdown_only else _unattributed_active_tokens(sessions)
+    if not merged and unattributed == 0:
         return
 
     table = Table(title=title, border_style="cyan")
@@ -375,6 +403,17 @@ def _render_model_table(
             format_tokens(mm.usage.outputTokens),
             format_tokens(mm.usage.cacheReadTokens),
             format_tokens(mm.usage.cacheWriteTokens),
+        )
+
+    if unattributed > 0:
+        table.add_row(
+            "(active, unattributed)",
+            "—",
+            "—",
+            "—",
+            format_tokens(unattributed),
+            "—",
+            "—",
         )
 
     console.print(table)
@@ -525,7 +564,7 @@ def _render_historical_section_from(
     )
 
     # Per-model table
-    _render_model_table(console, historical)
+    _render_model_table(console, historical, shutdown_only=True)
 
     # Per-session table — shutdown-only tokens and counts
     _render_session_table(

--- a/tests/copilot_usage/test_report.py
+++ b/tests/copilot_usage/test_report.py
@@ -61,6 +61,7 @@ from copilot_usage.report import (
     _format_session_running_time,
     _render_model_table,
     _render_session_table,
+    _unattributed_active_tokens,
     render_cost_view,
     render_full_summary,
     render_live_sessions,
@@ -6405,3 +6406,180 @@ class TestRenderCostViewNoRedundantTotalOutputTokens:
             "total_output_tokens should not be called for resumed sessions "
             "with model_metrics"
         )
+
+
+# ---------------------------------------------------------------------------
+# render_summary token consistency (issue #1092)
+# ---------------------------------------------------------------------------
+
+
+class TestRenderSummaryTokenConsistency:
+    """Issue #1092 — model table must reconcile with totals panel for resumed sessions."""
+
+    def test_resumed_session_model_table_includes_active_row(self) -> None:
+        """An '(active, unattributed)' row appears for resumed sessions."""
+        session = SessionSummary(
+            session_id="resumed-xyz1234",
+            start_time=datetime(2026, 4, 1, tzinfo=UTC),
+            is_active=True,
+            has_shutdown_metrics=True,
+            last_resume_time=datetime.now(tz=UTC),
+            active_output_tokens=250,
+            active_model_calls=2,
+            active_user_messages=1,
+            model_calls=7,
+            user_messages=4,
+            model_metrics={
+                "gpt-4": ModelMetrics(
+                    requests=RequestMetrics(count=5, cost=10),
+                    usage=TokenUsage(outputTokens=350),
+                ),
+            },
+        )
+        output = _capture_summary([session])
+        assert "(active, unattributed)" in output
+
+    def test_resumed_session_totals_equal_model_table_sum(self) -> None:
+        """Totals panel output tokens equal model-table row sum + active row."""
+        session = SessionSummary(
+            session_id="resumed-consist",
+            start_time=datetime(2026, 4, 1, tzinfo=UTC),
+            is_active=True,
+            has_shutdown_metrics=True,
+            last_resume_time=datetime.now(tz=UTC),
+            active_output_tokens=250,
+            active_model_calls=2,
+            active_user_messages=1,
+            model_calls=7,
+            user_messages=4,
+            model_metrics={
+                "gpt-4": ModelMetrics(
+                    requests=RequestMetrics(count=5, cost=10),
+                    usage=TokenUsage(outputTokens=350),
+                ),
+            },
+        )
+        buf = StringIO()
+        console = Console(file=buf, force_terminal=True, width=200)
+        render_summary([session], target_console=console)
+        output = buf.getvalue()
+        clean = re.sub(r"\x1b\[[0-9;]*m", "", output)
+
+        # Totals panel shows 600 tokens (350 shutdown + 250 active)
+        totals = _compute_session_totals([session])
+        assert totals.output_tokens == 600
+
+        # Model table must include a 350-token gpt-4 row and a 250-token
+        # active row so the breakdown sums to 600.
+        assert "350" in clean
+        assert "250" in clean
+        assert "(active, unattributed)" in clean
+
+    def test_no_active_row_when_not_resumed(self) -> None:
+        """Non-resumed sessions do not produce an active-unattributed row."""
+        session = SessionSummary(
+            session_id="normal-xyz1234",
+            start_time=datetime(2026, 4, 1, tzinfo=UTC),
+            model_metrics={
+                "gpt-4": ModelMetrics(
+                    requests=RequestMetrics(count=5, cost=10),
+                    usage=TokenUsage(outputTokens=350),
+                ),
+            },
+        )
+        output = _capture_summary([session])
+        assert "(active, unattributed)" not in output
+
+    def test_no_active_row_when_active_tokens_zero(self) -> None:
+        """Resumed session with zero active_output_tokens has no active row."""
+        session = SessionSummary(
+            session_id="resumed-zero",
+            start_time=datetime(2026, 4, 1, tzinfo=UTC),
+            is_active=True,
+            has_shutdown_metrics=True,
+            last_resume_time=datetime.now(tz=UTC),
+            active_output_tokens=0,
+            model_metrics={
+                "gpt-4": ModelMetrics(
+                    requests=RequestMetrics(count=5, cost=10),
+                    usage=TokenUsage(outputTokens=350),
+                ),
+            },
+        )
+        output = _capture_summary([session])
+        assert "(active, unattributed)" not in output
+
+    def test_multiple_sessions_aggregate_active_tokens(self) -> None:
+        """Active tokens from multiple resumed sessions are summed."""
+        s1 = SessionSummary(
+            session_id="resumed-a",
+            start_time=datetime(2026, 4, 2, tzinfo=UTC),
+            is_active=True,
+            has_shutdown_metrics=True,
+            last_resume_time=datetime.now(tz=UTC),
+            active_output_tokens=100,
+            active_model_calls=1,
+            active_user_messages=1,
+            model_calls=3,
+            user_messages=2,
+            model_metrics={
+                "gpt-4": ModelMetrics(
+                    requests=RequestMetrics(count=2, cost=4),
+                    usage=TokenUsage(outputTokens=200),
+                ),
+            },
+        )
+        s2 = SessionSummary(
+            session_id="resumed-b",
+            start_time=datetime(2026, 4, 1, tzinfo=UTC),
+            is_active=True,
+            has_shutdown_metrics=True,
+            last_resume_time=datetime.now(tz=UTC),
+            active_output_tokens=150,
+            active_model_calls=1,
+            active_user_messages=1,
+            model_calls=4,
+            user_messages=3,
+            model_metrics={
+                "gpt-4": ModelMetrics(
+                    requests=RequestMetrics(count=3, cost=6),
+                    usage=TokenUsage(outputTokens=300),
+                ),
+            },
+        )
+        output = _capture_summary([s1, s2])
+        assert "(active, unattributed)" in output
+
+        # The unattributed row should show 250 (100 + 150)
+        assert _unattributed_active_tokens([s1, s2]) == 250
+
+    def test_historical_section_no_active_row(self) -> None:
+        """Historical section in render_full_summary uses shutdown-only tokens — no active row."""
+        session = SessionSummary(
+            session_id="resumed-hist",
+            start_time=datetime(2026, 4, 1, tzinfo=UTC),
+            is_active=True,
+            has_shutdown_metrics=True,
+            last_resume_time=datetime.now(tz=UTC),
+            active_output_tokens=250,
+            active_model_calls=2,
+            active_user_messages=1,
+            model_calls=7,
+            user_messages=4,
+            total_premium_requests=5,
+            model_metrics={
+                "gpt-4": ModelMetrics(
+                    requests=RequestMetrics(count=5, cost=10),
+                    usage=TokenUsage(outputTokens=350),
+                ),
+            },
+        )
+        buf = StringIO()
+        console = Console(file=buf, force_terminal=True, width=200)
+        render_full_summary([session], target_console=console)
+        output = buf.getvalue()
+        clean = re.sub(r"\x1b\[[0-9;]*m", "", output)
+        # The historical section should NOT have the active row —
+        # it deliberately uses shutdown-only tokens.
+        # Find lines from the "Historical Totals" section
+        assert "(active, unattributed)" not in clean


### PR DESCRIPTION
Closes #1092

## Problem

`render_summary`'s model breakdown table only displayed tokens from `model_metrics` (shutdown-period data), while the totals panel included `active_output_tokens` for resumed sessions. This caused a visible discrepancy — e.g., totals showing **600** tokens but the model table only showing **350**.

## Solution (Option A from the issue)

Added an `(active, unattributed)` row to the model breakdown table when any session has unattributed active output tokens (`has_shutdown_metrics=True` and `active_output_tokens > 0`). This makes the model table reconcile with the totals panel:

- **Totals panel**: 600 tokens (350 shutdown + 250 active) ✅
- **Model table**: gpt-4 → 350 tokens + (active, unattributed) → 250 tokens = 600 ✅
- **Session table row**: 600 tokens ✅

The historical section in `render_full_summary` passes `shutdown_only=True` to suppress the active row, preserving its existing shutdown-only semantics.

## Changes

- **`src/copilot_usage/report.py`**:
  - Added `_unattributed_active_tokens()` helper to compute aggregate unattributed active tokens
  - Added `shutdown_only` parameter to `_render_model_table()` (default `False`)
  - Appends `(active, unattributed)` row when unattributed tokens exist and `shutdown_only=False`
  - Updated `_render_historical_section_from()` to pass `shutdown_only=True`

- **`tests/copilot_usage/test_report.py`**:
  - Added `TestRenderSummaryTokenConsistency` class with 6 tests covering:
    - Active row appears for resumed sessions
    - Totals reconcile with model table sum
    - No active row for non-resumed sessions
    - No active row when `active_output_tokens=0`
    - Multiple sessions aggregate active tokens correctly
    - Historical section suppresses the active row




> [!WARNING]
> <details>
> <summary><strong>⚠️ Firewall blocked 5 domains</strong></summary>
>
> The following domains were blocked by the firewall during workflow execution:
>
> - `astral.sh`
> - `conda.anaconda.org`
> - `pypi.org`
> - `releaseassets.githubusercontent.com`
> - `repo.anaconda.com`
>
> To allow these domains, add them to the `network.allowed` list in your workflow frontmatter:
>
> ```yaml
> network:
>   allowed:
>     - defaults
>     - "astral.sh"
>     - "conda.anaconda.org"
>     - "pypi.org"
>     - "releaseassets.githubusercontent.com"
>     - "repo.anaconda.com"
> ```
>
> See [Network Configuration](https://github.github.com/gh-aw/reference/network/) for more information.
>
> </details>


> Generated by [Issue Implementer](https://github.com/microsasa/cli-tools/actions/runs/24952728879/agentic_workflow) · ● 33.2M · [◷](https://github.com/search?q=repo%3Amicrosasa%2Fcli-tools+%22gh-aw-workflow-id%3A+issue-implementer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Issue Implementer, engine: copilot, model: claude-opus-4.6, id: 24952728879, workflow_id: issue-implementer, run: https://github.com/microsasa/cli-tools/actions/runs/24952728879 -->

<!-- gh-aw-workflow-id: issue-implementer -->