### PR TITLE
test: verify render_live_sessions Est. Cost uses active_model_calls (#1096)

### DIFF
--- a/tests/copilot_usage/test_report.py
+++ b/tests/copilot_usage/test_report.py
@@ -494,6 +494,70 @@ class TestRenderLiveSessions:
         output = _capture_output([session])
         assert "~0" in output
 
+    def test_resumed_session_est_cost_uses_active_model_calls(self) -> None:
+        """render_live_sessions Est. Cost must be based on active_model_calls, not model_calls total."""
+        now = datetime.now(tz=UTC)
+        session = SessionSummary(
+            session_id="aabbccdd-eeee-ffff-aaaa-dddddddddddd",
+            name="Resumed Cost Test",
+            model="claude-opus-4.6",
+            is_active=True,
+            start_time=now - timedelta(hours=3),
+            last_resume_time=now - timedelta(minutes=10),
+            # Historical totals — must NOT appear in cost column
+            user_messages=263,
+            model_calls=275,
+            model_metrics={
+                "claude-opus-4.6": ModelMetrics(
+                    usage=TokenUsage(outputTokens=200_000),
+                )
+            },
+            # Post-resume activity (claude-opus-4.6 multiplier = 3.0)
+            active_user_messages=2,
+            active_output_tokens=800,
+            active_model_calls=4,  # → Est. Cost ~12 (4 × 3.0)
+        )
+        output = _capture_output([session])
+        # Must show ~12, not ~825 (275 × 3.0)
+        assert "~12" in output, (
+            "Est. Cost should use active_model_calls (4), not total model_calls (275)"
+        )
+        assert "~825" not in output, (
+            "Est. Cost must not use historical model_calls total"
+        )
+
+    def test_resumed_session_zero_activity_no_est_cost(self) -> None:
+        """Resumed session with zero post-resume model calls should show no estimated cost."""
+        now = datetime.now(tz=UTC)
+        session = SessionSummary(
+            session_id="aabbccdd-eeee-ffff-aaaa-eeeeeeeeeeee",
+            name="Zero Activity Resumed",
+            model="claude-opus-4.6",
+            is_active=True,
+            start_time=now - timedelta(hours=2),
+            last_resume_time=now - timedelta(minutes=1),
+            # Historical totals
+            user_messages=150,
+            model_calls=100,
+            model_metrics={
+                "claude-opus-4.6": ModelMetrics(
+                    usage=TokenUsage(outputTokens=80_000),
+                )
+            },
+            # Zero post-resume activity
+            active_user_messages=0,
+            active_output_tokens=0,
+            active_model_calls=0,  # → Est. Cost ~0 (0 × 3.0)
+        )
+        output = _capture_output([session])
+        # active_model_calls=0 → cost should be ~0, not ~300 (100 × 3.0)
+        assert "~0" in output, (
+            "Est. Cost should be ~0 for zero active_model_calls"
+        )
+        assert "~300" not in output, (
+            "Est. Cost must not use historical model_calls total"
+        )
+
 
 # ---------------------------------------------------------------------------
 # Helpers for session detail tests


### PR DESCRIPTION
Closes #1096

## Problem

`test_resumed_session_shows_active_fields` verifies `active_user_messages` and `active_output_tokens` in the `render_live_sessions` output, but **never asserts the `Est. Cost` column**. If a future change bypasses `_effective_stats` and passes `session.model_calls` directly, the cost estimate would show `~825` (275 × 3.0) instead of `~12` (4 × 3.0) — a 20× overestimate with no test failure.

## Changes

Added two tests to `TestRenderLiveSessions` in `tests/copilot_usage/test_report.py`:

1. **`test_resumed_session_est_cost_uses_active_model_calls`** — Creates a resumed session with `active_model_calls=4` and `model_calls=275` on `claude-opus-4.6` (3.0× multiplier). Asserts `~12` appears and `~825` does not.

2. **`test_resumed_session_zero_activity_no_est_cost`** — Creates a resumed session with `active_model_calls=0` and `model_calls=100`. Asserts `~0` appears and `~300` does not.

Both tests validate that the `_effective_stats` indirection is the sole path to the call count used for cost estimation in `render_live_sessions`.




> [!WARNING]
> <details>
> <summary><strong>⚠️ Firewall blocked 3 domains</strong></summary>
>
> The following domains were blocked by the firewall during workflow execution:
>
> - `astral.sh`
> - `pypi.org`
> - `releaseassets.githubusercontent.com`
>
> To allow these domains, add them to the `network.allowed` list in your workflow frontmatter:
>
> ```yaml
> network:
>   allowed:
>     - defaults
>     - "astral.sh"
>     - "pypi.org"
>     - "releaseassets.githubusercontent.com"
> ```
>
> See [Network Configuration](https://github.github.com/gh-aw/reference/network/) for more information.
>
> </details>


> Generated by [Issue Implementer](https://github.com/microsasa/cli-tools/actions/runs/24958888972/agentic_workflow) · ● 17M · [◷](https://github.com/search?q=repo%3Amicrosasa%2Fcli-tools+%22gh-aw-workflow-id%3A+issue-implementer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Issue Implementer, engine: copilot, model: claude-opus-4.6, id: 24958888972, workflow_id: issue-implementer, run: https://github.com/microsasa/cli-tools/actions/runs/24958888972 -->

<!-- gh-aw-workflow-id: issue-implementer -->