### PR TITLE
fix: use lambda factories for complex generic dict Pydantic fields (#1097)

### DIFF
--- a/src/copilot_usage/models.py
+++ b/src/copilot_usage/models.py
@@ -206,7 +206,7 @@ class ToolRequest(BaseModel):
 
     toolCallId: str = ""
     name: str = ""
-    arguments: dict[str, object] = Field(default_factory=dict)
+    arguments: dict[str, object] = Field(default_factory=lambda: {})
     type: str = ""
 
 
@@ -283,7 +283,7 @@ class SessionShutdownData(BaseModel):
     totalPremiumRequests: int = 0
     totalApiDurationMs: int = 0
     codeChanges: CodeChanges | None = None
-    modelMetrics: dict[str, ModelMetrics] = Field(default_factory=dict)
+    modelMetrics: dict[str, ModelMetrics] = Field(default_factory=lambda: {})
     currentModel: str | None = None
 
 
@@ -336,7 +336,7 @@ class SessionEvent(BaseModel):
     """
 
     type: str
-    data: dict[str, object] = Field(default_factory=dict)
+    data: dict[str, object] = Field(default_factory=lambda: {})
     id: str | None = None
     timestamp: datetime | None = None
     parentId: str | None = None

--- a/tests/copilot_usage/test_models.py
+++ b/tests/copilot_usage/test_models.py
@@ -185,6 +185,12 @@ def test_assistant_message_data_tool_requests_populated() -> None:
     assert d.toolRequests[0].toolCallId == "t1"
 
 
+def test_tool_request_arguments_default() -> None:
+    """arguments defaults to an empty dict when not supplied."""
+    d = ToolRequest()
+    assert d.arguments == {}
+
+
 class TestSanitizeNonNumericTokens:
     """Validator maps bool/str/non-positive outputTokens to 0."""
 
@@ -280,6 +286,12 @@ def test_session_shutdown_data_ignores_session_start_time() -> None:
     assert not hasattr(d, "sessionStartTime")
 
 
+def test_session_shutdown_data_model_metrics_default() -> None:
+    """modelMetrics defaults to an empty dict when not supplied."""
+    d = SessionShutdownData()
+    assert d.modelMetrics == {}
+
+
 def test_tool_execution_data() -> None:
     d = ToolExecutionData.model_validate(RAW_TOOL_EXEC["data"])
     assert d.success is True
@@ -337,6 +349,12 @@ def test_session_event_unknown_type() -> None:
     # Unknown types should not crash; as_*() methods raise ValueError on mismatch
     with pytest.raises(ValueError, match="Expected session.start"):
         ev.as_session_start()
+
+
+def test_session_event_data_default() -> None:
+    """data defaults to an empty dict when not supplied."""
+    ev = SessionEvent(type="session.start")
+    assert ev.data == {}
 
 
 def test_as_wrong_type_raises_value_error() -> None:


### PR DESCRIPTION
Closes #1097

## Changes

Replace `default_factory=dict` with `default_factory=lambda: {}` for three Pydantic fields whose value types are non-primitive:

| Class | Field | Type |
|---|---|---|
| `ToolRequest` | `arguments` | `dict[str, object]` |
| `SessionShutdownData` | `modelMetrics` | `dict[str, ModelMetrics]` |
| `SessionEvent` | `data` | `dict[str, object]` |

This aligns with the coding guideline requiring explicit lambda factories for complex generics so pyright strict mode can infer the correct element types, consistent with the existing `list` convention (e.g. `toolRequests: list[ToolRequest] = Field(default_factory=lambda: [])`).

## Tests

Added three unit tests verifying default construction produces empty dicts:

- `test_tool_request_arguments_default`
- `test_session_shutdown_data_model_metrics_default`
- `test_session_event_data_default`




> [!WARNING]
> <details>
> <summary><strong>⚠️ Firewall blocked 5 domains</strong></summary>
>
> The following domains were blocked by the firewall during workflow execution:
>
> - `astral.sh`
> - `files.pythonhosted.org`
> - `index.crates.io`
> - `pypi.org`
> - `releaseassets.githubusercontent.com`
>
> To allow these domains, add them to the `network.allowed` list in your workflow frontmatter:
>
> ```yaml
> network:
>   allowed:
>     - defaults
>     - "astral.sh"
>     - "files.pythonhosted.org"
>     - "index.crates.io"
>     - "pypi.org"
>     - "releaseassets.githubusercontent.com"
> ```
>
> See [Network Configuration](https://github.github.com/gh-aw/reference/network/) for more information.
>
> </details>


> Generated by [Issue Implementer](https://github.com/microsasa/cli-tools/actions/runs/24959119487/agentic_workflow) · ● 12.4M · [◷](https://github.com/search?q=repo%3Amicrosasa%2Fcli-tools+%22gh-aw-workflow-id%3A+issue-implementer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Issue Implementer, engine: copilot, model: claude-opus-4.6, id: 24959119487, workflow_id: issue-implementer, run: https://github.com/microsasa/cli-tools/actions/runs/24959119487 -->

<!-- gh-aw-workflow-id: issue-implementer -->