### PR TITLE
fix: return zeros from `_effective_stats` for resumed sessions without active-period stats (#1101)

### DIFF
--- a/src/copilot_usage/report.py
+++ b/src/copilot_usage/report.py
@@ -71,12 +71,24 @@ class _EffectiveStats:
 
 
 def _effective_stats(session: SessionSummary) -> _EffectiveStats:
-    """Return active-period stats if available, otherwise session totals."""
+    """Return active-period stats if available, otherwise session totals.
+
+    For sessions with shutdown metrics but no meaningful active-period
+    stats (``has_active_period_stats`` is ``False``), returns zeros
+    rather than the full session totals.  Session totals are only a
+    valid fallback for *pure-active* sessions that have no shutdown data.
+    """
     if has_active_period_stats(session):
         return _EffectiveStats(
             model_calls=session.active_model_calls,
             user_messages=session.active_user_messages,
             output_tokens=session.active_output_tokens,
+        )
+    if session.has_shutdown_metrics:
+        return _EffectiveStats(
+            model_calls=0,
+            user_messages=0,
+            output_tokens=0,
         )
     return _EffectiveStats(
         model_calls=session.model_calls,

--- a/tests/copilot_usage/test_report.py
+++ b/tests/copilot_usage/test_report.py
@@ -3822,6 +3822,36 @@ class TestEffectiveStats:
         # Falls back to total_output_tokens which sums model_metrics
         assert stats.output_tokens == 4200
 
+    def test_returns_zeros_for_resumed_session_without_active_period_stats(
+        self,
+    ) -> None:
+        """Resumed session with shutdown metrics but no active-period stats gets zeros.
+
+        Regression test for issue #1101: a resumed session where
+        ``has_shutdown_metrics=True``, ``is_active=True``, and
+        ``has_active_period_stats=False`` must not fall back to session
+        totals — it should return zeros.
+        """
+        session = SessionSummary(
+            session_id="resumed-no-active-1234",
+            is_active=True,
+            has_shutdown_metrics=True,
+            start_time=datetime.now(tz=UTC) - timedelta(hours=2),
+            model_calls=50,
+            user_messages=25,
+            active_model_calls=0,
+            active_user_messages=0,
+            active_output_tokens=0,
+            model_metrics={
+                "gpt-4": ModelMetrics(usage=TokenUsage(outputTokens=8000)),
+            },
+        )
+        assert not has_active_period_stats(session)
+        stats = _effective_stats(session)
+        assert stats.model_calls == 0
+        assert stats.user_messages == 0
+        assert stats.output_tokens == 0
+
     def test_frozen_dataclass(self) -> None:
         """_EffectiveStats instances are immutable."""
         session = SessionSummary(
@@ -3832,6 +3862,68 @@ class TestEffectiveStats:
         stats = _effective_stats(session)
         with pytest.raises(AttributeError):
             stats.model_calls = 99  # type: ignore[misc]
+
+
+class TestResumedSessionNoActiveStatsRegression:
+    """Issue #1101 — resumed session without active-period stats.
+
+    A resumed session (``is_active=True``, ``has_shutdown_metrics=True``)
+    where ``has_active_period_stats`` returns ``False`` must show zeros
+    (not inflated session totals) in both the active-sessions panel of
+    ``render_full_summary`` and in ``render_live_sessions``.
+    """
+
+    @staticmethod
+    def _make_resumed_session_no_active_stats() -> SessionSummary:
+        """Build a resumed session with shutdown metrics but no active-period stats."""
+        return SessionSummary(
+            session_id="resumed-no-active-9999",
+            name="ResumedNoActive",
+            model="gpt-4",
+            is_active=True,
+            has_shutdown_metrics=True,
+            start_time=datetime.now(tz=UTC) - timedelta(hours=3),
+            model_calls=80,
+            user_messages=40,
+            active_model_calls=0,
+            active_user_messages=0,
+            active_output_tokens=0,
+            model_metrics={
+                "gpt-4": ModelMetrics(usage=TokenUsage(outputTokens=15000)),
+            },
+        )
+
+    def test_render_full_summary_does_not_show_session_totals(self) -> None:
+        """render_full_summary active section must not display session totals."""
+        session = self._make_resumed_session_no_active_stats()
+        output = _capture_full_summary([session])
+        # The active section must not display the session's all-time
+        # model_calls (80) or user_messages (40) as post-shutdown stats.
+        lines = output.splitlines()
+        active_section_lines = []
+        in_active = False
+        for line in lines:
+            if "Active Sessions" in line:
+                in_active = True
+            if in_active:
+                active_section_lines.append(line)
+        active_text = "\n".join(active_section_lines)
+        # Session totals must not appear; zeros (or "0") should be shown.
+        assert " 80 " not in active_text
+        assert " 40 " not in active_text
+        assert "15,000" not in active_text
+
+    def test_render_live_sessions_does_not_show_session_totals(self) -> None:
+        """render_live_sessions must not use session totals for messages/cost."""
+        session = self._make_resumed_session_no_active_stats()
+        buf = StringIO()
+        console = Console(file=buf, force_terminal=False, width=120)
+        render_live_sessions([session], target_console=console)
+        output = buf.getvalue()
+        # Must not display the inflated session-total user_messages (40).
+        assert " 40 " not in output
+        # Must not display session-total output tokens (15,000).
+        assert "15,000" not in output
 
 
 class TestComputeSessionTotals:


### PR DESCRIPTION
Closes #1101

## Problem

`_effective_stats` in `report.py` falls back to **session totals** (all-time `model_calls`, `user_messages`, `total_output_tokens`) when `has_active_period_stats()` returns `False`. For a resumed session (`is_active=True`, `has_shutdown_metrics=True`) with `has_active_period_stats=False`, this means the "Active Sessions (Since Last Shutdown)" panel displays inflated numbers spanning the entire session lifetime — not just post-shutdown activity.

## Fix

Added an explicit guard in `_effective_stats`: when `has_shutdown_metrics=True` and `has_active_period_stats=False`, return zeros instead of falling back to session totals. The session-totals fallback is now only used for pure-active sessions (no shutdown data), which is the only case where it's meaningful.

## Tests

Added regression tests in `test_report.py`:
- `TestEffectiveStats.test_returns_zeros_for_resumed_session_without_active_period_stats` — directly validates `_effective_stats` returns zeros for this edge case.
- `TestResumedSessionNoActiveStatsRegression.test_render_full_summary_does_not_show_session_totals` — verifies the active section of `render_full_summary` does not display session totals.
- `TestResumedSessionNoActiveStatsRegression.test_render_live_sessions_does_not_show_session_totals` — verifies `render_live_sessions` does not use session totals for messages / output tokens.




> [!WARNING]
> <details>
> <summary><strong>⚠️ Firewall blocked 4 domains</strong></summary>
>
> The following domains were blocked by the firewall during workflow execution:
>
> - `astral.sh`
> - `index.crates.io`
> - `pypi.org`
> - `releaseassets.githubusercontent.com`
>
> To allow these domains, add them to the `network.allowed` list in your workflow frontmatter:
>
> ```yaml
> network:
>   allowed:
>     - defaults
>     - "astral.sh"
>     - "index.crates.io"
>     - "pypi.org"
>     - "releaseassets.githubusercontent.com"
> ```
>
> See [Network Configuration](https://github.github.com/gh-aw/reference/network/) for more information.
>
> </details>


> Generated by [Issue Implementer](https://github.com/microsasa/cli-tools/actions/runs/24965800236/agentic_workflow) · ● 13.4M · [◷](https://github.com/search?q=repo%3Amicrosasa%2Fcli-tools+%22gh-aw-workflow-id%3A+issue-implementer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Issue Implementer, engine: copilot, model: claude-opus-4.6, id: 24965800236, workflow_id: issue-implementer, run: https://github.com/microsasa/cli-tools/actions/runs/24965800236 -->

<!-- gh-aw-workflow-id: issue-implementer -->