### PR TITLE
fix: add debug logging for `_first_pass` silent edge cases (#1102)

### DIFF
--- a/src/copilot_usage/docs/architecture.md
+++ b/src/copilot_usage/docs/architecture.md
@@ -91,7 +91,7 @@ tests/
     └── test_e2e.py             Full pipeline: CLI → parser → models → report → output
 ```
 
-- **Unit tests**: 99% coverage, test individual functions with synthetic data
+- **Unit tests**: ≥ 80% coverage (CI-enforced), test individual functions with synthetic data
 - **Doctests**: `_formatting.py` functions have `>>>` examples executed via `--doctest-modules`
 - **E2e tests**: Run actual CLI commands against anonymized fixture sessions, assert on output content
 - Test counts grow regularly — run `make test` to see the current numbers

--- a/src/copilot_usage/parser.py
+++ b/src/copilot_usage/parser.py
@@ -860,6 +860,12 @@ def _first_pass(events: list[SessionEvent]) -> _FirstPassResult:
                 total_output_tokens += tokens
                 if _shutdowns:
                     _ps_output_tokens += tokens
+            elif _shutdowns:
+                logger.debug(
+                    "event {} — post-shutdown assistant.message with zero/missing"
+                    " outputTokens; no token counter incremented",
+                    idx,
+                )
             if _shutdowns:
                 _ps_resumed = True
 
@@ -868,6 +874,12 @@ def _first_pass(events: list[SessionEvent]) -> _FirstPassResult:
                 _ps_resumed = True
                 if ev.timestamp is not None:
                     _ps_last_resume_time = ev.timestamp
+                else:
+                    logger.debug(
+                        "event {} — session.resume after shutdown has no timestamp;"
+                        " last_resume_time remains None",
+                        idx,
+                    )
 
     return _FirstPassResult(
         session_id=session_id,

--- a/tests/copilot_usage/test_parser.py
+++ b/tests/copilot_usage/test_parser.py
@@ -15,6 +15,7 @@ from typing import SupportsIndex, overload
 from unittest.mock import ANY, patch
 
 import pytest
+from loguru import logger
 from pydantic import ValidationError
 
 import copilot_usage.parser as _parser_module
@@ -6505,6 +6506,148 @@ class TestResumeDetectionDirect:
         assert summary.active_user_messages == 0  # must be 0 regardless
         assert summary.active_output_tokens == 0  # must be 0 regardless
         assert not has_active_period_stats(summary)
+
+
+# ---------------------------------------------------------------------------
+# Issue #1102 — _first_pass silent edge-case debug logging
+# ---------------------------------------------------------------------------
+
+
+class TestFirstPassSilentEdgeCases:
+    """Tests for debug logging on missing-timestamp resume and zero-token assistant."""
+
+    def test_resume_with_no_timestamp_logs_debug(
+        self, tmp_path: Path
+    ) -> None:
+        """session.resume with timestamp=None after shutdown emits debug log.
+
+        Asserts post_shutdown_resumed=True and last_resume_time=None (current
+        behaviour) so future changes are caught.
+        """
+        resume_no_ts = json.dumps(
+            {
+                "type": "session.resume",
+                "data": {},
+                "id": "ev-resume-no-ts",
+                "timestamp": None,
+                "parentId": "ev-shutdown",
+            }
+        )
+        p = tmp_path / "s" / "events.jsonl"
+        _write_events(p, _START_EVENT, _USER_MSG, _SHUTDOWN_EVENT, resume_no_ts)
+        events = parse_events(p)
+
+        with patch.object(logger, "debug") as mock_debug:
+            fp = _first_pass(events)
+
+        assert fp.post_shutdown_resumed is True
+        assert fp.last_resume_time is None
+
+        # Verify a debug log was emitted about the missing timestamp
+        assert mock_debug.call_count >= 1
+        messages = [str(c.args[0]) for c in mock_debug.call_args_list]
+        assert any("session.resume" in m and "no timestamp" in m for m in messages)
+
+    def test_zero_token_assistant_message_after_shutdown_logs_debug(
+        self, tmp_path: Path
+    ) -> None:
+        """assistant.message with outputTokens=0 after shutdown emits debug log.
+
+        Asserts post_shutdown_resumed=True and post_shutdown_output_tokens=0
+        (current behaviour preserved).
+        """
+        asst_zero = json.dumps(
+            {
+                "type": "assistant.message",
+                "data": {
+                    "messageId": "m-zero",
+                    "content": "streaming stub",
+                    "toolRequests": [],
+                    "interactionId": "i-zero",
+                    "outputTokens": 0,
+                },
+                "id": "ev-asst-zero",
+                "timestamp": "2026-03-07T12:01:00.000Z",
+            }
+        )
+        p = tmp_path / "s" / "events.jsonl"
+        _write_events(p, _START_EVENT, _USER_MSG, _SHUTDOWN_EVENT, asst_zero)
+        events = parse_events(p)
+
+        with patch.object(logger, "debug") as mock_debug:
+            fp = _first_pass(events)
+
+        assert fp.post_shutdown_resumed is True
+        assert fp.post_shutdown_output_tokens == 0
+
+        # Verify a debug log about the zero-token post-shutdown message
+        assert mock_debug.call_count >= 1
+        messages = [str(c.args[0]) for c in mock_debug.call_args_list]
+        assert any("assistant.message" in m and "zero" in m for m in messages)
+
+    def test_missing_token_assistant_message_after_shutdown_logs_debug(
+        self, tmp_path: Path
+    ) -> None:
+        """assistant.message with no outputTokens key after shutdown emits debug log."""
+        asst_missing = json.dumps(
+            {
+                "type": "assistant.message",
+                "data": {
+                    "messageId": "m-miss",
+                    "content": "hello",
+                    "toolRequests": [],
+                    "interactionId": "i-miss",
+                },
+                "id": "ev-asst-miss",
+                "timestamp": "2026-03-07T12:02:00.000Z",
+            }
+        )
+        p = tmp_path / "s" / "events.jsonl"
+        _write_events(p, _START_EVENT, _USER_MSG, _SHUTDOWN_EVENT, asst_missing)
+        events = parse_events(p)
+
+        with patch.object(logger, "debug") as mock_debug:
+            fp = _first_pass(events)
+
+        assert fp.post_shutdown_resumed is True
+        assert fp.post_shutdown_output_tokens == 0
+
+        # Debug log should fire for missing-token case too
+        assert mock_debug.call_count >= 1
+        messages = [str(c.args[0]) for c in mock_debug.call_args_list]
+        assert any("assistant.message" in m and "zero" in m for m in messages)
+
+    def test_positive_token_assistant_message_after_shutdown_no_warning(
+        self, tmp_path: Path
+    ) -> None:
+        """assistant.message with positive outputTokens after shutdown does NOT log."""
+        asst_ok = json.dumps(
+            {
+                "type": "assistant.message",
+                "data": {
+                    "messageId": "m-ok",
+                    "content": "response",
+                    "toolRequests": [],
+                    "interactionId": "i-ok",
+                    "outputTokens": 42,
+                },
+                "id": "ev-asst-ok",
+                "timestamp": "2026-03-07T12:03:00.000Z",
+            }
+        )
+        p = tmp_path / "s" / "events.jsonl"
+        _write_events(p, _START_EVENT, _USER_MSG, _SHUTDOWN_EVENT, asst_ok)
+        events = parse_events(p)
+
+        with patch.object(logger, "debug") as mock_debug:
+            fp = _first_pass(events)
+
+        assert fp.post_shutdown_resumed is True
+        assert fp.post_shutdown_output_tokens == 42
+
+        # No "zero/missing" log should appear for positive-token case
+        messages = [str(c.args[0]) for c in mock_debug.call_args_list]
+        assert not any("zero" in m for m in messages)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #1102

## Changes

### 1. Debug log for `session.resume` with missing timestamp (parser.py)
When a `session.resume` event arrives after a shutdown with `timestamp=None`, `_ps_resumed` is set but `_ps_last_resume_time` stays `None`. This was previously silent. Now emits `logger.debug(...)` recording the event index.

### 2. Debug log for zero-token `assistant.message` after shutdown (parser.py)
When an `assistant.message` with `outputTokens=0` (or missing) arrives after a shutdown, `_ps_resumed` is set but no token counter is incremented. Now emits `logger.debug(...)` noting the zero-token post-shutdown message.

**Decision on `_ps_turn_starts` increment:** After evaluation, a zero-token `assistant.message` should NOT increment `_ps_turn_starts` because:
- `_ps_turn_starts` mirrors `assistant.turn_start` events specifically
- If a preceding `assistant.turn_start` exists, it's already counted
- Counting assistant messages as turn starts would break the symmetry and double-count when both events are present

### 3. Fix "99% coverage" claim in architecture.md
Updated `architecture.md` to say "≥ 80% coverage (CI-enforced)" to match the actual `--cov-fail-under=80` threshold in the Makefile and CI.

## Tests

Added `TestFirstPassSilentEdgeCases` with 4 tests:
- `test_resume_with_no_timestamp_logs_debug` — verifies debug log emitted + `post_shutdown_resumed=True`, `last_resume_time=None`
- `test_zero_token_assistant_message_after_shutdown_logs_debug` — verifies debug log + `post_shutdown_output_tokens=0`
- `test_missing_token_assistant_message_after_shutdown_logs_debug` — same for missing `outputTokens` key
- `test_positive_token_assistant_message_after_shutdown_no_warning` — negative test: no zero-token log for positive tokens




> [!WARNING]
> <details>
> <summary><strong>⚠️ Firewall blocked 4 domains</strong></summary>
>
> The following domains were blocked by the firewall during workflow execution:
>
> - `astral.sh`
> - `index.crates.io`
> - `pypi.org`
> - `releaseassets.githubusercontent.com`
>
> To allow these domains, add them to the `network.allowed` list in your workflow frontmatter:
>
> ```yaml
> network:
>   allowed:
>     - defaults
>     - "astral.sh"
>     - "index.crates.io"
>     - "pypi.org"
>     - "releaseassets.githubusercontent.com"
> ```
>
> See [Network Configuration](https://github.github.com/gh-aw/reference/network/) for more information.
>
> </details>


> Generated by [Issue Implementer](https://github.com/microsasa/cli-tools/actions/runs/24966021992/agentic_workflow) · ● 33.5M · [◷](https://github.com/search?q=repo%3Amicrosasa%2Fcli-tools+%22gh-aw-workflow-id%3A+issue-implementer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Issue Implementer, engine: copilot, model: claude-opus-4.6, id: 24966021992, workflow_id: issue-implementer, run: https://github.com/microsasa/cli-tools/actions/runs/24966021992 -->

<!-- gh-aw-workflow-id: issue-implementer -->