### PR TITLE
fix: `_effective_stats` returns zeros for resumed sessions without active-period stats (#1108)

### DIFF
--- a/src/copilot_usage/report.py
+++ b/src/copilot_usage/report.py
@@ -71,12 +71,24 @@ class _EffectiveStats:
 
 
 def _effective_stats(session: SessionSummary) -> _EffectiveStats:
-    """Return active-period stats if available, otherwise session totals."""
+    """Return active-period stats if available, otherwise session totals.
+
+    For resumed sessions (``has_shutdown_metrics=True``) where
+    ``has_active_period_stats`` is ``False``, returns zeros rather than the
+    session totals — the totals represent pre-shutdown history and must not
+    be attributed to the post-shutdown active period.
+    """
     if has_active_period_stats(session):
         return _EffectiveStats(
             model_calls=session.active_model_calls,
             user_messages=session.active_user_messages,
             output_tokens=session.active_output_tokens,
+        )
+    if session.has_shutdown_metrics:
+        return _EffectiveStats(
+            model_calls=0,
+            user_messages=0,
+            output_tokens=0,
         )
     return _EffectiveStats(
         model_calls=session.model_calls,

--- a/tests/copilot_usage/test_report.py
+++ b/tests/copilot_usage/test_report.py
@@ -6405,3 +6405,88 @@ class TestRenderCostViewNoRedundantTotalOutputTokens:
             "total_output_tokens should not be called for resumed sessions "
             "with model_metrics"
         )
+
+
+# ---------------------------------------------------------------------------
+# Issue #1108 — render_full_summary and render_live_sessions must not display
+# inflated session totals for resumed sessions with has_active_period_stats=False
+# ---------------------------------------------------------------------------
+
+
+class TestRenderFullSummaryNoInflatedTotals:
+    """Regression #1108: active section must not show pre-shutdown totals
+    when has_active_period_stats is False."""
+
+    def test_active_section_does_not_show_inflated_totals_when_no_active_period_stats(
+        self,
+    ) -> None:
+        """Resumed session with has_active_period_stats=False must not show
+        pre-shutdown totals as active-period stats in the active section."""
+        session = SessionSummary(
+            session_id="resumed-no-activity",
+            name="Stale Resume",
+            model="claude-sonnet-4",
+            start_time=datetime(2025, 3, 1, 12, 0, tzinfo=UTC),
+            is_active=True,
+            has_shutdown_metrics=True,
+            user_messages=50,
+            model_calls=30,
+            model_metrics={
+                "claude-sonnet-4": ModelMetrics(
+                    requests=RequestMetrics(count=30, cost=30),
+                    usage=TokenUsage(outputTokens=50_000),
+                ),
+            },
+            active_model_calls=0,
+            active_user_messages=0,
+            active_output_tokens=0,
+            last_resume_time=None,
+        )
+        output = _capture_full_summary([session])
+        # Strip ANSI escape sequences for clean text matching
+        clean = re.sub(r"\x1b\[[0-9;]*m", "", output)
+        # Split at the Active Sessions heading
+        assert "Active Sessions" in clean
+        active_section = clean.split("Active Sessions", 1)[1]
+        # Historical model_calls (30) and output tokens (50.0K) must NOT appear
+        # in the active section — they are pre-shutdown totals and should not
+        # be shown as "since last shutdown" activity.
+        assert "50.0K" not in active_section
+        assert re.search(r"\b30\b", active_section) is None
+
+
+class TestRenderLiveSessionsNoInflatedTotals:
+    """Regression #1108: render_live_sessions must not display pre-shutdown
+    totals as active-period Messages or Est. Cost."""
+
+    def test_resumed_session_no_active_period_stats_shows_correct_values(
+        self,
+    ) -> None:
+        """render_live_sessions: resumed session with has_active_period_stats=False
+        must not display pre-shutdown user_messages as 'Messages' or inflate
+        Est. Cost."""
+        session = SessionSummary(
+            session_id="resumed-no-activity",
+            name="Stale Resume",
+            model="claude-sonnet-4",
+            start_time=datetime(2025, 3, 1, 12, 0, tzinfo=UTC),
+            is_active=True,
+            has_shutdown_metrics=True,
+            user_messages=50,
+            model_calls=30,
+            model_metrics={
+                "claude-sonnet-4": ModelMetrics(
+                    requests=RequestMetrics(count=30, cost=30),
+                    usage=TokenUsage(outputTokens=50_000),
+                ),
+            },
+            active_model_calls=0,
+            active_user_messages=0,
+            active_output_tokens=0,
+            last_resume_time=None,
+        )
+        output = _capture_output([session])
+        # Strip ANSI escape sequences for clean text matching
+        clean = re.sub(r"\x1b\[[0-9;]*m", "", output)
+        # user_messages=50 is pre-shutdown; must not appear as active messages
+        assert "50" not in clean


### PR DESCRIPTION
Closes #1108

## Problem

`render_full_summary` and `render_live_sessions` both call `_effective_stats(s)`, which falls back to **session totals** (`model_calls`, `user_messages`, `total_output_tokens`) when `has_active_period_stats(s)` is `False`.

A resumed session (`is_active=True`, `has_shutdown_metrics=True`) can have `has_active_period_stats=False` when `last_resume_time` is `None` and all active counters are zero. In that state, the active section silently displays **entire session lifetime totals** under headings that say "Since Last Shutdown" / "Active Sessions", which is factually wrong.

## Fix

`_effective_stats` now has a three-way branch:
1. **`has_active_period_stats` is True** → return active counters (unchanged)
2. **`has_shutdown_metrics` is True** (but no active-period stats) → return zeros
3. **Otherwise** (pure-active session) → return session totals (unchanged)

This is consistent with `render_cost_view`, which already suppresses the "↳ Since last shutdown" row when `has_active_period_stats` is `False`.

## Tests Added

- **`TestRenderFullSummaryNoInflatedTotals`**: verifies the active section does not display historical `model_calls` (30) or output tokens (50.0K) for a resumed session with no post-shutdown activity.
- **`TestRenderLiveSessionsNoInflatedTotals`**: verifies the Messages column does not display pre-shutdown `user_messages` (50).




> [!WARNING]
> <details>
> <summary><strong>⚠️ Firewall blocked 1 domain</strong></summary>
>
> The following domain was blocked by the firewall during workflow execution:
>
> - `pypi.org`
>
> To allow these domains, add them to the `network.allowed` list in your workflow frontmatter:
>
> ```yaml
> network:
>   allowed:
>     - defaults
>     - "pypi.org"
> ```
>
> See [Network Configuration](https://github.github.com/gh-aw/reference/network/) for more information.
>
> </details>


> Generated by [Issue Implementer](https://github.com/microsasa/cli-tools/actions/runs/24981594456/agentic_workflow) · ● 20.9M · [◷](https://github.com/search?q=repo%3Amicrosasa%2Fcli-tools+%22gh-aw-workflow-id%3A+issue-implementer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Issue Implementer, engine: copilot, model: claude-opus-4.6, id: 24981594456, workflow_id: issue-implementer, run: https://github.com/microsasa/cli-tools/actions/runs/24981594456 -->

<!-- gh-aw-workflow-id: issue-implementer -->