### PR TITLE
fix: add `active_output_tokens` invariant to `SessionSummary` validator (#1109)

### DIFF
--- a/src/copilot_usage/models.py
+++ b/src/copilot_usage/models.py
@@ -454,6 +454,11 @@ class SessionSummary(BaseModel):
                 f"active_user_messages ({self.active_user_messages}) must be <= "
                 f"user_messages ({self.user_messages})"
             )
+        if not self.is_active and self.active_output_tokens != 0:
+            raise ValueError(
+                f"active_output_tokens ({self.active_output_tokens}) must be 0 "
+                f"for non-active sessions"
+            )
         return self
 
 

--- a/tests/copilot_usage/test_models.py
+++ b/tests/copilot_usage/test_models.py
@@ -1049,6 +1049,74 @@ class TestSessionSummaryUserMessageInvariant:
 
 
 # ---------------------------------------------------------------------------
+# Issue #1109 — Validate active_output_tokens == 0 for non-active sessions
+# ---------------------------------------------------------------------------
+
+
+class TestSessionSummaryOutputTokenInvariant:
+    """Tests for the active_output_tokens invariant on non-active sessions."""
+
+    def test_rejects_nonzero_active_output_tokens_when_not_active(self) -> None:
+        """SessionSummary must reject active_output_tokens != 0 when is_active=False."""
+        with pytest.raises(ValidationError):
+            SessionSummary(
+                session_id="inv",
+                active_output_tokens=100,
+                is_active=False,
+            )
+
+    def test_accepts_positive_active_output_tokens_when_active(self) -> None:
+        """SessionSummary allows active_output_tokens > 0 when is_active=True."""
+        s = SessionSummary(
+            session_id="act",
+            active_output_tokens=500,
+            is_active=True,
+        )
+        assert s.active_output_tokens == 500
+
+    def test_accepts_zero_active_output_tokens_when_not_active(self) -> None:
+        """SessionSummary allows active_output_tokens=0 for non-active sessions."""
+        s = SessionSummary(
+            session_id="zero-inactive",
+            active_output_tokens=0,
+            is_active=False,
+        )
+        assert s.active_output_tokens == 0
+
+    def test_accepts_zero_active_output_tokens_when_active(self) -> None:
+        """SessionSummary allows active_output_tokens=0 for active sessions."""
+        s = SessionSummary(
+            session_id="zero-active",
+            active_output_tokens=0,
+            is_active=True,
+        )
+        assert s.active_output_tokens == 0
+
+    def test_double_count_regression(self) -> None:
+        """Regression: completed session with positive active_output_tokens must raise.
+
+        Previously, constructing a non-active SessionSummary with
+        active_output_tokens > 0 and has_shutdown_metrics=True silently
+        caused total_output_tokens() to double-count tokens.  The
+        validator now rejects this at construction time.
+        """
+        with pytest.raises(ValidationError):
+            SessionSummary(
+                session_id="double-count",
+                model_metrics={
+                    "m": ModelMetrics(
+                        usage=TokenUsage(outputTokens=100),
+                        requests=RequestMetrics(count=1),
+                    ),
+                },
+                has_shutdown_metrics=True,
+                active_output_tokens=100,
+                is_active=False,
+                model_calls=1,
+            )
+
+
+# ---------------------------------------------------------------------------
 # shutdown_output_tokens
 # ---------------------------------------------------------------------------
 
@@ -1068,6 +1136,7 @@ class TestShutdownOutputTokens:
             },
             active_output_tokens=999,
             model_calls=1,
+            is_active=True,
         )
         assert shutdown_output_tokens(session) == 100
 
@@ -1077,6 +1146,7 @@ class TestShutdownOutputTokens:
             session_id="s2",
             model_metrics={},
             active_output_tokens=50,
+            is_active=True,
         )
         assert shutdown_output_tokens(session) == 0
 
@@ -1169,6 +1239,7 @@ class TestTotalOutputTokens:
             model_metrics={},
             has_shutdown_metrics=False,
             active_output_tokens=75,
+            is_active=True,
         )
         assert total_output_tokens(session) == 75
 
@@ -1211,6 +1282,9 @@ class TestHasActivePeriodStats:
             kwargs["model_calls"] = value
         if field == "active_user_messages":
             kwargs["user_messages"] = value
+        # non-zero active_output_tokens requires is_active=True
+        if field == "active_output_tokens":
+            kwargs["is_active"] = True
         session = SessionSummary(**kwargs)  # type: ignore[arg-type]
         assert has_active_period_stats(session) is True
 


### PR DESCRIPTION
Closes #1109

## Problem

`SessionSummary._check_active_counters` guarded `active_model_calls` and `active_user_messages` but left `active_output_tokens` unvalidated. A non-active session with `active_output_tokens > 0` silently caused `total_output_tokens()` to double-count tokens via `has_active_period_stats()`.

## Fix

Added a guard in `_check_active_counters`: non-active sessions (`is_active=False`) must have `active_output_tokens == 0`. This mirrors the parser's own guarantee in `_build_completed_summary`.

### Changes

**`src/copilot_usage/models.py`**
- Added validator: `if not self.is_active and self.active_output_tokens != 0: raise ValueError(...)`

**`tests/copilot_usage/test_models.py`**
- Added `TestSessionSummaryOutputTokenInvariant` class with 5 tests:
  - Rejects `active_output_tokens != 0` when `is_active=False`
  - Accepts `active_output_tokens > 0` when `is_active=True`
  - Accepts `active_output_tokens=0` for both active and non-active sessions
  - Regression test for the double-count scenario
- Fixed 4 existing tests that set `active_output_tokens > 0` without `is_active=True`




> [!WARNING]
> <details>
> <summary><strong>⚠️ Firewall blocked 3 domains</strong></summary>
>
> The following domains were blocked by the firewall during workflow execution:
>
> - `astral.sh`
> - `index.crates.io`
> - `pypi.org`
>
> To allow these domains, add them to the `network.allowed` list in your workflow frontmatter:
>
> ```yaml
> network:
>   allowed:
>     - defaults
>     - "astral.sh"
>     - "index.crates.io"
>     - "pypi.org"
> ```
>
> See [Network Configuration](https://github.github.com/gh-aw/reference/network/) for more information.
>
> </details>


> Generated by [Issue Implementer](https://github.com/microsasa/cli-tools/actions/runs/24982024070/agentic_workflow) · ● 12.6M · [◷](https://github.com/search?q=repo%3Amicrosasa%2Fcli-tools+%22gh-aw-workflow-id%3A+issue-implementer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Issue Implementer, engine: copilot, model: claude-opus-4.6, id: 24982024070, workflow_id: issue-implementer, run: https://github.com/microsasa/cli-tools/actions/runs/24982024070 -->

<!-- gh-aw-workflow-id: issue-implementer -->