### PR TITLE
test: add `has_shutdown_metrics` parser coverage (#1113)

### DIFF
--- a/tests/copilot_usage/test_parser.py
+++ b/tests/copilot_usage/test_parser.py
@@ -3575,6 +3575,57 @@ class TestBuildSessionSummaryEdgeCases:
 
 
 # ---------------------------------------------------------------------------
+# has_shutdown_metrics coverage — issue #1113
+# ---------------------------------------------------------------------------
+
+
+class TestHasShutdownMetrics:
+    """Ensure ``has_shutdown_metrics`` is set correctly by the parser."""
+
+    def test_completed_session_with_model_metrics_has_shutdown_metrics_true(
+        self, tmp_path: Path
+    ) -> None:
+        """Shutdown with non-empty modelMetrics → has_shutdown_metrics is True."""
+        shutdown = json.dumps(
+            {
+                "type": "session.shutdown",
+                "data": {
+                    "shutdownType": "routine",
+                    "totalPremiumRequests": 3,
+                    "totalApiDurationMs": 5000,
+                    "sessionStartTime": 1772895600000,
+                    "modelMetrics": {
+                        "gpt-5.1": {
+                            "requests": {"count": 3, "cost": 2},
+                            "usage": {"outputTokens": 200},
+                        }
+                    },
+                },
+                "id": "ev-sd",
+                "timestamp": "2026-03-07T11:00:00.000Z",
+            }
+        )
+        p = tmp_path / "s" / "events.jsonl"
+        _write_events(p, _START_EVENT, _USER_MSG, shutdown)
+        events = parse_events(p)
+        summary = build_session_summary(events)
+        assert summary.has_shutdown_metrics is True
+        assert summary.model_metrics != {}
+        assert summary.is_active is False
+
+    def test_active_session_has_shutdown_metrics_false(
+        self, tmp_path: Path
+    ) -> None:
+        """Active session (no shutdown event) → has_shutdown_metrics is False."""
+        p = tmp_path / "s" / "events.jsonl"
+        _write_events(p, _START_EVENT, _USER_MSG, _ASSISTANT_MSG)
+        events = parse_events(p)
+        summary = build_session_summary(events)
+        assert summary.has_shutdown_metrics is False
+        assert summary.is_active is True
+
+
+# ---------------------------------------------------------------------------
 # Coverage gap tests — parser.py
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Add two missing parser-level tests for `has_shutdown_metrics` to close the coverage gap identified in #1113.

### New tests (`TestHasShutdownMetrics`)

| Test | What it asserts |
|------|----------------|
| `test_completed_session_with_model_metrics_has_shutdown_metrics_true` | Shutdown with non-empty `modelMetrics` → `has_shutdown_metrics is True` |
| `test_active_session_has_shutdown_metrics_false` | No shutdown event → `has_shutdown_metrics is False` and `is_active is True` |

These complement the existing boundary case (`test_shutdown_with_empty_model_metrics_has_shutdown_metrics_false`) which only asserts the `False` path for empty metrics.

### Why this matters

If the `any(sd.modelMetrics ...)` / `bool(merged_metrics)` clause in `_build_completed_summary` were accidentally removed or inverted, `has_shutdown_metrics` would always be `False` — silently hiding shutdown-cycle metrics from the historical table. The new test for the `True` path would catch this regression.

Closes #1113




> [!WARNING]
> <details>
> <summary><strong>⚠️ Firewall blocked 2 domains</strong></summary>
>
> The following domains were blocked by the firewall during workflow execution:
>
> - `astral.sh`
> - `pypi.org`
>
> To allow these domains, add them to the `network.allowed` list in your workflow frontmatter:
>
> ```yaml
> network:
>   allowed:
>     - defaults
>     - "astral.sh"
>     - "pypi.org"
> ```
>
> See [Network Configuration](https://github.github.com/gh-aw/reference/network/) for more information.
>
> </details>


> Generated by [Issue Implementer](https://github.com/microsasa/cli-tools/actions/runs/25009406745/agentic_workflow) · ● 8M · [◷](https://github.com/search?q=repo%3Amicrosasa%2Fcli-tools+%22gh-aw-workflow-id%3A+issue-implementer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Issue Implementer, engine: copilot, model: claude-opus-4.6, id: 25009406745, workflow_id: issue-implementer, run: https://github.com/microsasa/cli-tools/actions/runs/25009406745 -->

<!-- gh-aw-workflow-id: issue-implementer -->