### PR TITLE
test: add coverage for idle-resumed sessions (#1115)

### DIFF
--- a/tests/copilot_usage/test_models.py
+++ b/tests/copilot_usage/test_models.py
@@ -1125,6 +1125,34 @@ class TestTotalOutputTokens:
         )
         assert total_output_tokens(session) == 150
 
+    def test_case_a2_idle_resumed_with_shutdown_metrics(self) -> None:
+        """Idle-resumed session: last_resume_time set, active_output_tokens=0.
+
+        Same branch as case A (has_active_period_stats=True AND
+        has_shutdown_metrics=True), but the zero active-token addition is an
+        independent invariant: baseline + 0 must equal baseline exactly.
+        """
+        session = SessionSummary(
+            session_id="case-a2",
+            model_metrics={
+                "m": ModelMetrics(
+                    usage=TokenUsage(outputTokens=5000),
+                    requests=RequestMetrics(count=10),
+                ),
+            },
+            has_shutdown_metrics=True,
+            active_output_tokens=0,
+            last_resume_time=datetime(2026, 1, 1, 12, 0, tzinfo=UTC),
+            model_calls=10,
+            active_model_calls=0,
+            active_user_messages=0,
+            user_messages=10,
+        )
+        # has_active_period_stats is True (via last_resume_time)
+        assert has_active_period_stats(session) is True
+        # baseline + 0 == baseline; no double-counting
+        assert total_output_tokens(session) == 5000
+
     def test_case_b_active_no_shutdown_metrics(self) -> None:
         """Active-period stats True but no shutdown metrics: only baseline."""
         session = SessionSummary(

--- a/tests/copilot_usage/test_report.py
+++ b/tests/copilot_usage/test_report.py
@@ -6131,6 +6131,84 @@ class TestCostViewActiveNoActivePeriodStats:
 
 
 # ---------------------------------------------------------------------------
+# Issue #1115 — idle-resumed session shows "↳ Since last shutdown" row
+# ---------------------------------------------------------------------------
+
+
+class TestCostViewIdleResumedSession:
+    """Issue #1115: when is_active=True, has_shutdown_metrics=True, and
+    last_resume_time is set (but all active counters are 0), the
+    '↳ Since last shutdown' row must still appear with zero counts."""
+
+    def test_idle_resumed_session_shows_since_last_shutdown_row_with_zeros(
+        self,
+    ) -> None:
+        """Idle-resumed session triggers the '↳ Since last shutdown' row.
+
+        has_active_period_stats returns True via last_resume_time alone, so
+        the active sub-row must render — but with zero cost and zero counters.
+        """
+        session = SessionSummary(
+            session_id="idle-resumed-1115",
+            model="claude-sonnet-4",
+            start_time=datetime(2025, 1, 1, 12, 0, tzinfo=UTC),
+            is_active=True,
+            has_shutdown_metrics=True,
+            last_resume_time=datetime(2025, 1, 1, 18, 0, tzinfo=UTC),
+            model_calls=10,
+            user_messages=10,
+            active_model_calls=0,
+            active_user_messages=0,
+            active_output_tokens=0,
+            model_metrics={
+                "claude-sonnet-4": ModelMetrics(
+                    requests=RequestMetrics(count=10, cost=10),
+                    usage=TokenUsage(outputTokens=5000),
+                ),
+            },
+        )
+        output = _capture_cost_view([session])
+        clean = re.sub(r"\x1b\[[0-9;]*m", "", output)
+
+        # The ↳ row MUST appear (idle-resumed triggers has_active_period_stats)
+        assert "Since last shutdown" in clean
+
+        lines = clean.splitlines()
+        active_row = next(
+            (ln for ln in lines if "Since last shutdown" in ln), None
+        )
+        assert active_row is not None, "Expected '↳ Since last shutdown' row"
+        cols = [c.strip() for c in active_row.split("│")]
+
+        # Model calls on the active row = 0
+        assert cols[5] == "0", (
+            f"Active model calls should be 0, got '{cols[5]}'"
+        )
+        # Output tokens on the active row = 0
+        assert cols[6] == "0", (
+            f"Active output tokens should be 0, got '{cols[6]}'"
+        )
+
+        # Parent per-model row still shows historical totals
+        expected_label = session_display_name(session)
+        model_row = next(
+            (
+                ln
+                for ln in lines
+                if "claude-sonnet-4" in ln
+                and expected_label in ln
+                and "Since last shutdown" not in ln
+            ),
+            None,
+        )
+        assert model_row is not None, "Expected a per-model parent row"
+        model_cols = [c.strip() for c in model_row.split("│")]
+        assert model_cols[5] == "10", (
+            f"Parent model calls should be 10, got '{model_cols[5]}'"
+        )
+
+
+# ---------------------------------------------------------------------------
 # Issue #703 — historical session table shows total model_calls/user_messages
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Closes #1115

## Summary

Adds two tests covering the boundary scenario where `last_resume_time` is set (session was resumed) but all active counters remain zero (user hasn't interacted since the resume).

### Tests Added

**`tests/copilot_usage/test_models.py` — `TestTotalOutputTokens`**

- `test_case_a2_idle_resumed_with_shutdown_metrics`: Verifies that `total_output_tokens()` returns exactly the baseline when `has_active_period_stats=True` (via `last_resume_time`) and `active_output_tokens=0`. Exercises the same branch as case A but asserts the zero-addition invariant independently.

**`tests/copilot_usage/test_report.py` — `TestCostViewIdleResumedSession`**

- `test_idle_resumed_session_shows_since_last_shutdown_row_with_zeros`: Verifies that `render_cost_view()` renders the "↳ Since last shutdown" row when `has_active_period_stats` returns `True` solely via a non-None `last_resume_time`, and that all active counters on that row are `0` while the parent row retains the full historical totals.

### Regression Scenario

These tests lock in correct semantics so that if `has_active_period_stats` is refactored to drop the `last_resume_time is not None` arm, both tests will catch the regression.




> [!WARNING]
> <details>
> <summary><strong>⚠️ Firewall blocked 1 domain</strong></summary>
>
> The following domain was blocked by the firewall during workflow execution:
>
> - `pypi.org`
>
> To allow these domains, add them to the `network.allowed` list in your workflow frontmatter:
>
> ```yaml
> network:
>   allowed:
>     - defaults
>     - "pypi.org"
> ```
>
> See [Network Configuration](https://github.github.com/gh-aw/reference/network/) for more information.
>
> </details>


> Generated by [Issue Implementer](https://github.com/microsasa/cli-tools/actions/runs/25016845323/agentic_workflow) · ● 9.8M · [◷](https://github.com/search?q=repo%3Amicrosasa%2Fcli-tools+%22gh-aw-workflow-id%3A+issue-implementer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Issue Implementer, engine: copilot, model: claude-opus-4.6, id: 25016845323, workflow_id: issue-implementer, run: https://github.com/microsasa/cli-tools/actions/runs/25016845323 -->

<!-- gh-aw-workflow-id: issue-implementer -->