### PR TITLE
test: assert LRU eviction target after key update (#1116)

### DIFF
--- a/tests/copilot_usage/test_fs_utils.py
+++ b/tests/copilot_usage/test_fs_utils.py
@@ -98,6 +98,52 @@ class TestLruInsert:
         # "a" should now be at the end (most recently used)
         assert list(cache.keys()) == ["b", "a"]
 
+    @pytest.mark.parametrize(
+        ("max_size", "initial_keys", "update_key", "new_key", "expected_keys"),
+        [
+            pytest.param(
+                2,
+                [("a", 1), ("b", 2)],
+                ("a", 10),
+                ("c", 3),
+                ["a", "c"],
+                id="size-2",
+            ),
+            pytest.param(
+                3,
+                [("a", 1), ("b", 2), ("c", 3)],
+                ("a", 10),
+                ("d", 4),
+                ["c", "a", "d"],
+                id="size-3",
+            ),
+        ],
+    )
+    def test_eviction_after_update_targets_correct_lru(
+        self,
+        max_size: int,
+        initial_keys: list[tuple[str, int]],
+        update_key: tuple[str, int],
+        new_key: tuple[str, int],
+        expected_keys: list[str],
+    ) -> None:
+        """After an update moves a key to MRU, the next new-key insert evicts the LRU."""
+        cache: OrderedDict[str, int] = OrderedDict()
+        for k, v in initial_keys:
+            lru_insert(cache, k, v, max_size=max_size)
+
+        # Update an existing key — moves it to MRU position.
+        lru_insert(cache, update_key[0], update_key[1], max_size=max_size)
+
+        # Insert a brand-new key — must evict the current LRU, not the updated key.
+        lru_insert(cache, new_key[0], new_key[1], max_size=max_size)
+
+        assert list(cache.keys()) == expected_keys
+        assert cache[update_key[0]] == update_key[1]
+        assert cache[new_key[0]] == new_key[1]
+        # The second entry in initial_keys is now LRU and must have been evicted.
+        assert initial_keys[1][0] not in cache
+
     def test_max_size_one(self) -> None:
         cache: OrderedDict[str, int] = OrderedDict()
         lru_insert(cache, "x", 1, max_size=1)


### PR DESCRIPTION
Adds `test_eviction_after_update_targets_correct_lru` to `TestLruInsert` in `tests/copilot_usage/test_fs_utils.py`.

## What

The existing `test_replacement_of_stale_entry` verifies that updating a key moves it to MRU position without evicting other entries, but never asserts that the **next** new-key insertion evicts the correct LRU entry. This test fills that gap.

## Test details

Parametrized with two cache sizes:
- **size-2**: Fill with A, B → update A (MRU) → insert C → assert B evicted, order is `[A, C]`
- **size-3**: Fill with A, B, C → update A (MRU) → insert D → assert B evicted, order is `[C, A, D]`

Both variants assert:
- The updated key survives with its new value
- The newly inserted key is present
- The former LRU (second initial key) has been evicted
- MRU ordering is correct via `list(cache.keys())`

## Regression scenario

Any refactoring that changes when `popitem` is called (e.g., checking `len(cache) >= max_size` unconditionally, or computing size before the `del`) would incorrectly evict the just-updated entry. This test directly guards against that failure mode.

Closes #1116




> [!WARNING]
> <details>
> <summary><strong>⚠️ Firewall blocked 2 domains</strong></summary>
>
> The following domains were blocked by the firewall during workflow execution:
>
> - `astral.sh`
> - `pypi.org`
>
> To allow these domains, add them to the `network.allowed` list in your workflow frontmatter:
>
> ```yaml
> network:
>   allowed:
>     - defaults
>     - "astral.sh"
>     - "pypi.org"
> ```
>
> See [Network Configuration](https://github.github.com/gh-aw/reference/network/) for more information.
>
> </details>


> Generated by [Issue Implementer](https://github.com/microsasa/cli-tools/actions/runs/25017250573/agentic_workflow) · ● 6.1M · [◷](https://github.com/search?q=repo%3Amicrosasa%2Fcli-tools+%22gh-aw-workflow-id%3A+issue-implementer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Issue Implementer, engine: copilot, model: claude-opus-4.6, id: 25017250573, workflow_id: issue-implementer, run: https://github.com/microsasa/cli-tools/actions/runs/25017250573 -->

<!-- gh-aw-workflow-id: issue-implementer -->