### PR TITLE
fix: show '—' for Requests/Premium Cost in model table for pure-active sessions (#1120)

### DIFF
--- a/src/copilot_usage/report.py
+++ b/src/copilot_usage/report.py
@@ -345,16 +345,44 @@ def _render_totals(console: Console, sessions: list[SessionSummary]) -> None:
     console.print(Panel("\n".join(lines), title="Totals", border_style="cyan"))
 
 
+def _no_request_data_models(sessions: list[SessionSummary]) -> set[str]:
+    """Return model names that appear *only* in pure-active sessions.
+
+    A pure-active session is one where ``is_active`` is ``True`` and
+    ``has_shutdown_metrics`` is ``False`` — request counts are unavailable
+    (default zeros, not real data).  Models that also appear in at least one
+    completed or resumed session retain their real counts.
+    """
+    active_only: set[str] = set()
+    has_real_data: set[str] = set()
+    for s in sessions:
+        bucket = (
+            active_only
+            if s.is_active and not s.has_shutdown_metrics
+            else has_real_data
+        )
+        for model_name in s.model_metrics:
+            bucket.add(model_name)
+    return active_only - has_real_data
+
+
 def _render_model_table(
     console: Console,
     sessions: list[SessionSummary],
     *,
     title: str = "Per-Model Breakdown",
 ) -> None:
-    """Render the per-model breakdown table."""
+    """Render the per-model breakdown table.
+
+    Models that appear exclusively in pure-active sessions (no shutdown
+    metrics) display ``"—"`` for Requests and Premium Cost because those
+    values are unavailable defaults, not real zeros.
+    """
     merged = _aggregate_model_metrics(sessions)
     if not merged:
         return
+
+    no_req_models = _no_request_data_models(sessions)
 
     table = Table(title=title, border_style="cyan")
     table.add_column("Model", style="bold")
@@ -367,10 +395,13 @@ def _render_model_table(
 
     for model_name in sorted(merged):
         mm = merged[model_name]
+        hide_requests = (
+            model_name in no_req_models and mm.requests.count == 0
+        )
         table.add_row(
             model_name,
-            str(mm.requests.count),
-            str(mm.requests.cost),
+            "—" if hide_requests else str(mm.requests.count),
+            "—" if hide_requests else str(mm.requests.cost),
             format_tokens(mm.usage.inputTokens),
             format_tokens(mm.usage.outputTokens),
             format_tokens(mm.usage.cacheReadTokens),

--- a/tests/copilot_usage/test_report.py
+++ b/tests/copilot_usage/test_report.py
@@ -3525,6 +3525,73 @@ class TestRenderModelTable:
         output = buf.getvalue()
         assert "Cache Write" in output
 
+    def test_pure_active_session_shows_dash_for_requests(self) -> None:
+        """Pure-active session renders '—' for Requests and Premium Cost."""
+        session = SessionSummary(
+            session_id="active-only",
+            is_active=True,
+            has_shutdown_metrics=False,
+            model_metrics={
+                "gpt-5": ModelMetrics(
+                    requests=RequestMetrics(count=0, cost=0),
+                    usage=TokenUsage(outputTokens=1200),
+                )
+            },
+        )
+        buf = StringIO()
+        console = Console(file=buf, force_terminal=True, width=200)
+        _render_model_table(console, [session])
+        output = buf.getvalue()
+        # Requests and Premium Cost should show "—", not "0"
+        lines = [
+            line
+            for line in output.splitlines()
+            if "gpt-5" in line
+        ]
+        assert len(lines) == 1
+        model_line = lines[0]
+        # Strip ANSI codes for reliable matching
+        clean = re.sub(r"\x1b\[[0-9;]*m", "", model_line)
+        cells = clean.split("│")
+        # Columns: Model | Requests | Premium Cost | Input | Output | Cache Read | Cache Write
+        requests_cell = cells[2].strip()
+        premium_cell = cells[3].strip()
+        output_tokens_cell = cells[5].strip()
+        assert requests_cell == "—"
+        assert premium_cell == "—"
+        assert output_tokens_cell == "1.2K"
+
+    def test_completed_session_shows_integer_counts(self) -> None:
+        """Completed session renders integer counts, not '—'."""
+        session = SessionSummary(
+            session_id="completed",
+            is_active=False,
+            has_shutdown_metrics=True,
+            model_metrics={
+                "gpt-5": ModelMetrics(
+                    requests=RequestMetrics(count=7, cost=3),
+                    usage=TokenUsage(outputTokens=2500),
+                )
+            },
+        )
+        buf = StringIO()
+        console = Console(file=buf, force_terminal=True, width=200)
+        _render_model_table(console, [session])
+        output = buf.getvalue()
+        lines = [
+            line
+            for line in output.splitlines()
+            if "gpt-5" in line
+        ]
+        assert len(lines) == 1
+        model_line = lines[0]
+        clean = re.sub(r"\x1b\[[0-9;]*m", "", model_line)
+        cells = clean.split("│")
+        requests_cell = cells[2].strip()
+        premium_cell = cells[3].strip()
+        assert requests_cell == "7"
+        assert premium_cell == "3"
+
 
 # ---------------------------------------------------------------------------
 # has_active_period_stats


### PR DESCRIPTION
Closes #1120

## Problem

`_render_model_table` always rendered `str(mm.requests.count)` and `str(mm.requests.cost)` for every model row, showing `0` for pure-active sessions where request data is simply unavailable (not truly zero). This diverged from `render_cost_view` which correctly shows `—` for unavailable data.

## Solution

- Added `_no_request_data_models()` helper that identifies models appearing **only** in pure-active sessions (`is_active=True, has_shutdown_metrics=False`).
- Updated `_render_model_table` to render `—` for Requests and Premium Cost columns when a model is in that set and merged count is `0`, matching the existing `render_cost_view` convention.
- Models appearing in at least one completed/resumed session retain their real integer counts.

## Tests

Added to `TestRenderModelTable`:
- `test_pure_active_session_shows_dash_for_requests` — verifies `—` in Requests and Premium Cost columns + correct `1.2K` output token formatting for a pure-active session.
- `test_completed_session_shows_integer_counts` — regression test confirming completed sessions still render real counts (`7`, `3`).




> [!WARNING]
> <details>
> <summary><strong>⚠️ Firewall blocked 2 domains</strong></summary>
>
> The following domains were blocked by the firewall during workflow execution:
>
> - `astral.sh`
> - `pypi.org`
>
> To allow these domains, add them to the `network.allowed` list in your workflow frontmatter:
>
> ```yaml
> network:
>   allowed:
>     - defaults
>     - "astral.sh"
>     - "pypi.org"
> ```
>
> See [Network Configuration](https://github.github.com/gh-aw/reference/network/) for more information.
>
> </details>


> Generated by [Issue Implementer](https://github.com/microsasa/cli-tools/actions/runs/25037147378/agentic_workflow) · ● 8.7M · [◷](https://github.com/search?q=repo%3Amicrosasa%2Fcli-tools+%22gh-aw-workflow-id%3A+issue-implementer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Issue Implementer, engine: copilot, model: claude-opus-4.6, id: 25037147378, workflow_id: issue-implementer, run: https://github.com/microsasa/cli-tools/actions/runs/25037147378 -->

<!-- gh-aw-workflow-id: issue-implementer -->