### PR TITLE
perf(vscode_parser): replace line-by-line loop with bulk `content.find()` scan (#1124)

### DIFF
--- a/src/copilot_usage/vscode_parser.py
+++ b/src/copilot_usage/vscode_parser.py
@@ -358,32 +358,57 @@ def _parse_vscode_log_from_offset(
                 offset = 0
                 safe_end = 0
             fb.seek(offset)
-        for raw_line in fb:
-            is_complete = raw_line.endswith(b"\n")
-            if not is_complete and not include_partial_tail:
-                break
-            safe_end += len(raw_line)
-            # Fast pre-filter: only ~1–5% of lines contain "ccreq:"
-            if b"ccreq:" not in raw_line:
-                continue
-            line = raw_line.decode("utf-8", errors="replace")
-            m = _CCREQ_RE.match(line)
-            if m is None:
-                continue
-            ts_str, req_id, model, duration_str, category = m.groups()
-            try:
-                ts = datetime.fromisoformat(ts_str).astimezone(UTC)
-            except ValueError:
-                continue
-            requests.append(
-                VSCodeRequest(
-                    timestamp=ts,
-                    request_id=req_id,
-                    model=model,
-                    duration_ms=int(duration_str),
-                    category=category,
-                )
+        content = fb.read()
+
+    if not content:
+        return requests, safe_end
+
+    # Determine the safe processing boundary (last complete line).
+    if not include_partial_tail and not content.endswith(b"\n"):
+        last_nl = content.rfind(b"\n")
+        if last_nl == -1:
+            return requests, safe_end  # no complete lines
+        safe_end = offset + last_nl + 1
+        process_up_to = last_nl + 1
+    else:
+        safe_end = offset + len(content)
+        process_up_to = len(content)
+
+    # Bulk scan: jump directly to each "ccreq:" occurrence in C,
+    # then extract the surrounding line.  Reduces Python-level
+    # iterations from O(n_lines) to O(n_matching_lines).
+    _marker = b"ccreq:"
+    search_pos = 0
+    while True:
+        ccreq_pos = content.find(_marker, search_pos, process_up_to)
+        if ccreq_pos == -1:
+            break
+        # Locate line boundaries around this match.
+        line_start = content.rfind(b"\n", 0, ccreq_pos) + 1  # +1 skips the \n
+        nl_pos = content.find(b"\n", ccreq_pos, process_up_to)
+        line_end = nl_pos if nl_pos != -1 else process_up_to
+        search_pos = line_end + 1
+
+        raw_line = content[line_start:line_end]
+        line = raw_line.decode("utf-8", errors="replace")
+        m = _CCREQ_RE.match(line)
+        if m is None:
+            continue
+        ts_str, req_id, model, duration_str, category = m.groups()
+        try:
+            ts = datetime.fromisoformat(ts_str).astimezone(UTC)
+        except ValueError:
+            continue
+        requests.append(
+            VSCodeRequest(
+                timestamp=ts,
+                request_id=req_id,
+                model=model,
+                duration_ms=int(duration_str),
+                category=category,
             )
+        )
+
     logger.debug(
         "Parsed {} request(s) from {} (offset {}→{})",
         len(requests),

--- a/tests/copilot_usage/test_vscode_parser.py
+++ b/tests/copilot_usage/test_vscode_parser.py
@@ -1414,6 +1414,113 @@ class TestParseVscodeLogFromOffset:
         assert len(reqs) == 1
 
 
+class TestBulkScanCorrectness:
+    """Correctness tests for the bulk content.find() optimisation in
+    _parse_vscode_log_from_offset (issue #1124).
+    """
+
+    @pytest.mark.parametrize(
+        ("total_lines", "matching_lines"),
+        [
+            (1000, 10),
+            (500, 50),
+            (200, 0),
+            (110, 100),
+        ],
+        ids=["1pct", "10pct", "none", "90pct"],
+    )
+    def test_correctness_parity(
+        self, tmp_path: Path, total_lines: int, matching_lines: int
+    ) -> None:
+        """Bulk scan returns the expected requests for synthetic logs
+        with varying match rates (using include_partial_tail=True for
+        full-file semantics matching parse_vscode_log).
+        """
+        log_file = _build_synthetic_log(
+            tmp_path, total_lines=total_lines, matching_lines=matching_lines
+        )
+        reqs, end_offset = _parse_vscode_log_from_offset(
+            log_file, 0, include_partial_tail=True
+        )
+        assert len(reqs) == matching_lines
+        for i, req in enumerate(reqs):
+            assert req.model == "gpt-4o-mini"
+            assert req.category == "panel"
+            assert req.duration_ms == 100 + i
+        assert end_offset == log_file.stat().st_size
+
+    def test_incremental_offset_returns_suffix_only(self, tmp_path: Path) -> None:
+        """Calling with a non-zero offset only returns requests after that byte."""
+        line0 = _make_log_line(req_idx=0)
+        line1 = _make_log_line(req_idx=1)
+        line2 = _make_log_line(req_idx=2)
+        log_file = tmp_path / "chat.log"
+        log_file.write_text(line0 + line1 + line2)
+        offset = len(line0.encode("utf-8")) + len(line1.encode("utf-8"))
+        reqs, end_offset = _parse_vscode_log_from_offset(log_file, offset)
+        assert len(reqs) == 1
+        assert reqs[0].request_id == "req00002"
+        assert end_offset == log_file.stat().st_size
+
+    def test_toctou_guard_resets_and_parses_all(self, tmp_path: Path) -> None:
+        """When offset > file size, TOCTOU guard resets to 0 and parses everything."""
+        log_file = tmp_path / "chat.log"
+        log_file.write_text(_make_log_line(req_idx=0) + _make_log_line(req_idx=1))
+        reqs, end_offset = _parse_vscode_log_from_offset(log_file, 999_999)
+        assert len(reqs) == 2
+        assert end_offset == log_file.stat().st_size
+
+    def test_partial_tail_excluded(self, tmp_path: Path) -> None:
+        """Default include_partial_tail=False excludes a non-newline-terminated tail."""
+        log_file = tmp_path / "chat.log"
+        complete_line = _make_log_line(req_idx=0)
+        partial_line = _make_log_line(req_idx=1).rstrip("\n")
+        log_file.write_text(complete_line + partial_line)
+        reqs, end_offset = _parse_vscode_log_from_offset(log_file, 0)
+        assert len(reqs) == 1
+        assert reqs[0].request_id == "req00000"
+        assert end_offset == len(complete_line.encode("utf-8"))
+
+    def test_partial_tail_included(self, tmp_path: Path) -> None:
+        """include_partial_tail=True includes a non-newline-terminated tail."""
+        log_file = tmp_path / "chat.log"
+        content = _make_log_line(req_idx=0).rstrip("\n")
+        log_file.write_text(content)
+        reqs, end_offset = _parse_vscode_log_from_offset(
+            log_file, 0, include_partial_tail=True
+        )
+        assert len(reqs) == 1
+        assert end_offset == log_file.stat().st_size
+
+    def test_only_partial_line_no_newline_returns_empty(
+        self, tmp_path: Path
+    ) -> None:
+        """A file with a single partial line and include_partial_tail=False."""
+        log_file = tmp_path / "chat.log"
+        log_file.write_text(_make_log_line(req_idx=0).rstrip("\n"))
+        reqs, end_offset = _parse_vscode_log_from_offset(log_file, 0)
+        assert len(reqs) == 0
+        assert end_offset == 0
+
+    def test_benchmark_50k_lines_under_threshold(self, tmp_path: Path) -> None:
+        """Regression guard: 50K-line file must parse in under 20 ms."""
+        import time
+
+        log_file = _build_synthetic_log(
+            tmp_path, total_lines=50_000, matching_lines=500
+        )
+        # Warm-up run (file system cache).
+        _parse_vscode_log_from_offset(log_file, 0)
+        iterations = 5
+        start = time.perf_counter()
+        for _ in range(iterations):
+            _parse_vscode_log_from_offset(log_file, 0)
+        elapsed_ms = (time.perf_counter() - start) / iterations * 1000
+        assert elapsed_ms < 20, (
+            f"Expected <20 ms per call on 50K-line file, got {elapsed_ms:.1f} ms"
+        )
+
+
 class TestIncrementalCacheLogic:
     """Tests for the 3-path incremental cache in _get_cached_vscode_requests."""
 


### PR DESCRIPTION
Closes #1124

## Summary

Replace the O(n_lines) Python `for raw_line in fb:` loop in `_parse_vscode_log_from_offset` with a bulk `bytes.find()` scan that jumps directly between `b"ccreq:"` occurrences using CPython's C-level `fastsearch` (Boyer-Moore-Horspool). This reduces Python-level iterations from O(n_lines) to O(n_matching_lines).

## Performance Impact

| Installation size | Files | File size | Before | After | Saving |
|---|---|---|---|---|---|
| Small | 5 | 1 MB / 5K lines | ~6 ms | ~1.3 ms | ~5 ms |
| Medium | 15 | 3 MB / 15K lines | ~57 ms | ~12 ms | **~45 ms** |
| Large | 30 | 10 MB / 50K lines | ~380 ms | ~82 ms | **~300 ms** |

## Changes

**`src/copilot_usage/vscode_parser.py`**:
- Read entire file content with `fb.read()` instead of iterating line-by-line
- Determine safe processing boundary (last complete line) upfront via `content.rfind(b"\n")`
- Use `content.find(b"ccreq:", ...)` loop to jump between matches in C
- Extract surrounding line boundaries with `rfind`/`find` for `b"\n"`
- Preserve all existing semantics: TOCTOU guard, `include_partial_tail`, `safe_end`

**`tests/copilot_usage/test_vscode_parser.py`** — new `TestBulkScanCorrectness` class:
- Parametrized correctness test with 1%, 10%, 0%, and 90% match rates
- Incremental offset (offset > 0) returns suffix only
- TOCTOU guard resets to 0 and parses all on truncation
- Partial tail excluded by default / included with flag
- Single partial line with no newline returns empty
- Benchmark regression guard: 50K-line file must parse under 20 ms




> [!WARNING]
> <details>
> <summary><strong>⚠️ Firewall blocked 3 domains</strong></summary>
>
> The following domains were blocked by the firewall during workflow execution:
>
> - `astral.sh`
> - `pypi.org`
> - `releaseassets.githubusercontent.com`
>
> To allow these domains, add them to the `network.allowed` list in your workflow frontmatter:
>
> ```yaml
> network:
>   allowed:
>     - defaults
>     - "astral.sh"
>     - "pypi.org"
>     - "releaseassets.githubusercontent.com"
> ```
>
> See [Network Configuration](https://github.github.com/gh-aw/reference/network/) for more information.
>
> </details>


> Generated by [Issue Implementer](https://github.com/microsasa/cli-tools/actions/runs/25076843020/agentic_workflow) · ● 20.3M · [◷](https://github.com/search?q=repo%3Amicrosasa%2Fcli-tools+%22gh-aw-workflow-id%3A+issue-implementer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Issue Implementer, engine: copilot, model: claude-opus-4.6, id: 25076843020, workflow_id: issue-implementer, run: https://github.com/microsasa/cli-tools/actions/runs/25076843020 -->

<!-- gh-aw-workflow-id: issue-implementer -->