### PR TITLE
fix: split aggregate stats panel for resumed sessions (#1126)

### DIFF
--- a/src/copilot_usage/render_detail.py
+++ b/src/copilot_usage/render_detail.py
@@ -33,6 +33,8 @@ from copilot_usage.models import (
     SessionSummary,
     ToolExecutionData,
     ensure_aware,
+    has_active_period_stats,
+    shutdown_output_tokens,
     total_output_tokens,
 )
 
@@ -204,18 +206,58 @@ def _render_aggregate_stats(
     *,
     target_console: Console | None = None,
 ) -> None:
-    """Print aggregate stats panel (model calls, user msgs, tokens, premium)."""
+    """Print aggregate stats panel (model calls, user msgs, tokens, premium).
+
+    For resumed sessions (``has_active_period_stats`` is ``True`` **and**
+    ``has_shutdown_metrics`` is ``True``), renders two labelled sections —
+    "Since last shutdown" and "Historical (shutdown)" — so that
+    shutdown-only premium/duration metrics are not misleadingly placed
+    beside full-session totals.
+
+    For pure-active sessions (no shutdown data), the premium/duration
+    line is omitted entirely since no shutdown metrics exist.
+    """
     out = target_console or Console()
 
-    total_output = total_output_tokens(summary)
+    active = has_active_period_stats(summary)
 
-    lines = [
-        f"[green]{summary.model_calls}[/green] model calls   "
-        f"[green]{summary.user_messages}[/green] user messages   "
-        f"[green]{format_tokens(total_output)}[/green] output tokens",
-        f"[green]{summary.total_premium_requests}[/green] premium requests   "
-        f"[green]{format_duration(summary.total_api_duration_ms)}[/green] API duration",
-    ]
+    if active and summary.has_shutdown_metrics:
+        # Resumed session — split into active vs. historical sections.
+        active_tokens = format_tokens(summary.active_output_tokens)
+        hist_calls = summary.model_calls - summary.active_model_calls
+        hist_msgs = summary.user_messages - summary.active_user_messages
+        hist_tokens = format_tokens(shutdown_output_tokens(summary))
+        lines = [
+            f"[bold]Since last shutdown:[/bold]  "
+            f"[green]{summary.active_model_calls}[/green] model calls   "
+            f"[green]{summary.active_user_messages}[/green] user messages   "
+            f"[green]{active_tokens}[/green] output tokens",
+            f"[bold]Historical (shutdown):[/bold]  "
+            f"[green]{hist_calls}[/green] model calls   "
+            f"[green]{hist_msgs}[/green] user messages   "
+            f"[green]{hist_tokens}[/green] output tokens",
+            f"  [green]{summary.total_premium_requests}[/green] premium requests   "
+            f"[green]{format_duration(summary.total_api_duration_ms)}[/green] API duration",
+        ]
+    elif active:
+        # Pure-active session — no shutdown metrics; suppress premium/duration.
+        total_output = total_output_tokens(summary)
+        lines = [
+            f"[green]{summary.model_calls}[/green] model calls   "
+            f"[green]{summary.user_messages}[/green] user messages   "
+            f"[green]{format_tokens(total_output)}[/green] output tokens",
+        ]
+    else:
+        # Completed session — both scopes coincide; show everything flat.
+        total_output = total_output_tokens(summary)
+        lines = [
+            f"[green]{summary.model_calls}[/green] model calls   "
+            f"[green]{summary.user_messages}[/green] user messages   "
+            f"[green]{format_tokens(total_output)}[/green] output tokens",
+            f"[green]{summary.total_premium_requests}[/green] premium requests   "
+            f"[green]{format_duration(summary.total_api_duration_ms)}[/green] API duration",
+        ]
+
     out.print(Panel("\n".join(lines), title="Aggregate Stats", border_style="cyan"))
 
 

--- a/tests/copilot_usage/test_report.py
+++ b/tests/copilot_usage/test_report.py
@@ -940,6 +940,103 @@ class TestRenderAggregateStatsDirect:
         assert "1m" in output
 
 
+class TestRenderAggregateStats:
+    """Issue #1126 — _render_aggregate_stats scope-mismatch for resumed sessions."""
+
+    def test_resumed_session_shows_split_sections(self) -> None:
+        """Resumed session with active_model_calls < model_calls shows labelled sections."""
+        session = SessionSummary(
+            session_id="resumed-split-1234",
+            model_calls=140,
+            user_messages=93,
+            total_premium_requests=48,
+            total_api_duration_ms=8_040_000,
+            is_active=True,
+            has_shutdown_metrics=True,
+            last_resume_time=datetime.now(tz=UTC),
+            active_model_calls=60,
+            active_user_messages=40,
+            active_output_tokens=1_200_000,
+            model_metrics={
+                "gpt-4": ModelMetrics(
+                    requests=RequestMetrics(count=80, cost=160),
+                    usage=TokenUsage(outputTokens=3_000_000),
+                ),
+            },
+        )
+        output = _capture_console(_render_aggregate_stats, session)
+
+        # Active section is labelled and shows active-period stats
+        assert "Since last shutdown" in output
+        assert "60 model calls" in output
+        assert "40 user messages" in output
+        assert format_tokens(1_200_000) in output
+
+        # Historical section is labelled and shows shutdown-period stats
+        assert "Historical" in output
+        assert "80 model calls" in output  # 140 - 60
+        assert "53 user messages" in output  # 93 - 40
+        assert format_tokens(3_000_000) in output
+
+        # Premium / API duration appear under historical section
+        assert "48 premium requests" in output
+        assert format_duration(8_040_000) in output
+
+    def test_pure_active_session_omits_premium_line(self) -> None:
+        """Pure-active session (no shutdown) does not show misleading premium line."""
+        session = SessionSummary(
+            session_id="pure-active-5678",
+            model_calls=25,
+            user_messages=12,
+            total_premium_requests=0,
+            total_api_duration_ms=0,
+            is_active=True,
+            has_shutdown_metrics=False,
+            active_model_calls=25,
+            active_user_messages=12,
+            active_output_tokens=50_000,
+        )
+        output = _capture_console(_render_aggregate_stats, session)
+
+        # Counts are shown
+        assert "25 model calls" in output
+        assert "12 user messages" in output
+        assert format_tokens(50_000) in output
+
+        # Premium/duration line is absent — no shutdown data exists
+        assert "premium requests" not in output
+        assert "API duration" not in output
+
+    def test_completed_session_unchanged(self) -> None:
+        """Completed session still shows flat totals and premium/duration."""
+        session = SessionSummary(
+            session_id="completed-9999",
+            model_calls=50,
+            user_messages=30,
+            total_premium_requests=20,
+            total_api_duration_ms=120_000,
+            is_active=False,
+            has_shutdown_metrics=True,
+            model_metrics={
+                "gpt-4": ModelMetrics(
+                    requests=RequestMetrics(count=50, cost=100),
+                    usage=TokenUsage(outputTokens=500_000),
+                ),
+            },
+        )
+        output = _capture_console(_render_aggregate_stats, session)
+
+        # Flat totals (no section labels)
+        assert "50 model calls" in output
+        assert "30 user messages" in output
+        assert format_tokens(500_000) in output
+        assert "20 premium requests" in output
+        assert format_duration(120_000) in output
+        # No split labels
+        assert "Since last shutdown" not in output
+        assert "Historical" not in output
+
+
 # ---------------------------------------------------------------------------
 # format_tokens tests
 # ---------------------------------------------------------------------------
@@ -4524,14 +4621,12 @@ class TestTotalOutputTokens:
 
 
 class TestRenderAggregateStatsResumedTokens:
-    """Issue #290 — _render_aggregate_stats includes active tokens for resumed sessions."""
+    """Issue #290 / #1126 — _render_aggregate_stats splits sections for resumed sessions."""
 
-    def test_aggregate_stats_shows_total_output_tokens_for_resumed_session(
+    def test_aggregate_stats_shows_split_sections_for_resumed_session(
         self,
     ) -> None:
-        """Output tokens in Aggregate Stats panel include active_output_tokens for resumed sessions."""
-        from copilot_usage.render_detail import _render_aggregate_stats
-
+        """Resumed session shows active and historical sections with labelled rows."""
         session = SessionSummary(
             session_id="agg-resumed-1234",
             model_calls=5,
@@ -4550,15 +4645,14 @@ class TestRenderAggregateStatsResumedTokens:
             },
         )
 
-        expected_total = total_output_tokens(session)  # 350 + 250 = 600
-        assert expected_total == 600
-
         output = _capture_console(_render_aggregate_stats, session)
-        assert format_tokens(expected_total) in output
-        # Ensure the shutdown-only baseline is NOT shown
-        shutdown_only = format_tokens(350)
-        if shutdown_only != format_tokens(expected_total):
-            assert shutdown_only not in output
+        # Active section shows active_output_tokens
+        assert "Since last shutdown" in output
+        assert format_tokens(250) in output
+        # Historical section shows shutdown-only tokens and premium
+        assert "Historical" in output
+        assert format_tokens(350) in output
+        assert "2 premium requests" in output
 
 
 class TestComputeSessionTotalsResumed:


### PR DESCRIPTION
Closes #1126

## Problem

`_render_aggregate_stats` in `render_detail.py` mixed two different time scopes without labelling the difference:
- **Line 1** showed full-session totals (model_calls, user_messages, total_output_tokens)
- **Line 2** showed shutdown-period-only totals (premium_requests, api_duration)

For resumed sessions these scopes diverge, making the display misleading (e.g. "48 premium requests" beside "140 model calls" when the 48 only covers the pre-shutdown period).

## Solution (Option A from the issue)

When `has_active_period_stats(session)` is `True` **and** `has_shutdown_metrics` is `True` (resumed session), the panel now renders two labelled sections:

1. **"Since last shutdown"** — `active_model_calls`, `active_user_messages`, `active_output_tokens`
2. **"Historical (shutdown)"** — historical calls/messages/tokens, `total_premium_requests`, `total_api_duration_ms`

For **pure-active sessions** (no shutdown data), the premium/duration line is omitted entirely since no shutdown metrics exist.

For **completed sessions**, the flat layout is unchanged.

## Tests

Added `TestRenderAggregateStats` class with three tests:
- `test_resumed_session_shows_split_sections` — verifies labelled split for resumed sessions
- `test_pure_active_session_omits_premium_line` — verifies no misleading "0 premium requests"
- `test_completed_session_unchanged` — regression test for completed sessions

Updated `TestRenderAggregateStatsResumedTokens` to match the new split-panel behavior.




> [!WARNING]
> <details>
> <summary><strong>⚠️ Firewall blocked 2 domains</strong></summary>
>
> The following domains were blocked by the firewall during workflow execution:
>
> - `astral.sh`
> - `pypi.org`
>
> To allow these domains, add them to the `network.allowed` list in your workflow frontmatter:
>
> ```yaml
> network:
>   allowed:
>     - defaults
>     - "astral.sh"
>     - "pypi.org"
> ```
>
> See [Network Configuration](https://github.github.com/gh-aw/reference/network/) for more information.
>
> </details>


> Generated by [Issue Implementer](https://github.com/microsasa/cli-tools/actions/runs/25093187666/agentic_workflow) · ● 19.8M · [◷](https://github.com/search?q=repo%3Amicrosasa%2Fcli-tools+%22gh-aw-workflow-id%3A+issue-implementer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Issue Implementer, engine: copilot, model: claude-opus-4.6, id: 25093187666, workflow_id: issue-implementer, run: https://github.com/microsasa/cli-tools/actions/runs/25093187666 -->

<!-- gh-aw-workflow-id: issue-implementer -->