### PR TITLE
docs: update architecture.md with active_* counters and shutdown_cycles (#1127)

### DIFF
--- a/src/copilot_usage/docs/architecture.md
+++ b/src/copilot_usage/docs/architecture.md
@@ -36,7 +36,7 @@ Monorepo containing Python CLI utilities that share tooling, CI, and common depe
 | `cli.py` | Click command group — routes commands to parser/report functions, handles CLI options, error display. Contains the interactive loop (invoked when no subcommand is given) which uses helpers from `interactive.py`. |
 | `interactive.py` | Interactive-mode UI helpers — session list rendering, file-watching (watchdog with 2-second debounce), version header, and session index building. Extracted from `cli.py` to separate interactive concerns from CLI routing. |
 | `parser.py` | Discovers sessions, reads events.jsonl line by line, builds SessionSummary per session via focused helpers: `_first_pass()` (extract identity/shutdowns/counters/post-shutdown resume data in a single pass), `_build_completed_summary()`, `_build_active_summary()`. |
-| `models.py` | Pydantic v2 models for all event types + SessionSummary aggregate (includes model_calls and user_messages fields). Runtime validation at parse boundary. |
+| `models.py` | Pydantic v2 models for all event types + SessionSummary aggregate (includes model_calls, user_messages, and post-last-shutdown sub-totals `active_model_calls` / `active_user_messages` / `active_output_tokens`). Also carries `shutdown_cycles` (pre-computed list of shutdown data so renderers never re-scan events), `has_shutdown_metrics` flag, and a `_check_active_counters` model validator enforcing `active_* ≤ total_*` invariants. Runtime validation at parse boundary. |
 | `report.py` | Rich-formatted terminal output — summary tables (with Model Calls and User Msgs columns), live view, premium request breakdown. Shows raw counts and `~`-prefixed premium cost estimates for live/active sessions; historical post-shutdown views display exact API-provided numbers. |
 | `render_detail.py` | Session detail rendering — extracted from report.py. Displays event timeline, per-event metadata, and session-level aggregates. |
 | `_formatting.py` | Shared formatting utilities — `format_duration()` and `format_tokens()` with doctest-verified examples. Used by report.py and render_detail.py. |
@@ -54,7 +54,7 @@ Monorepo containing Python CLI utilities that share tooling, CI, and common depe
 4. **Summarization** — `build_session_summary()` orchestrates focused helpers:
    - `_first_pass()`: single pass over events — extracts session metadata from `session.start`, counts raw events (model calls, user messages, output tokens), collects all shutdown data, and tracks rolling post-shutdown accumulators (reset on each shutdown) for resume detection
    - `_build_completed_summary()`: merges all shutdown cycles (metrics, premium requests, code changes) into a SessionSummary. Sets `is_active=True` if resumed.
-   - `_build_active_summary()`: for sessions with no shutdowns — infers model from `tool.execution_complete` events or `~/.copilot/config.json`, builds synthetic metrics from output tokens
+   - `_build_active_summary()`: for sessions with no shutdowns — infers model from `tool.execution_complete` events or `~/.copilot/config.json`, builds synthetic metrics from output tokens. For these pure-active sessions, `active_*` fields are populated to equal the full-session totals (since there is no pre-shutdown period to split off).
    - Two frozen dataclasses (`_FirstPassResult`, `_ResumeInfo`) carry state between helpers
 5. **Rendering** — Report functions receive `SessionSummary` objects and render Rich output
 
@@ -64,7 +64,7 @@ Monorepo containing Python CLI utilities that share tooling, CI, and common depe
 
 **Shutdown event as source of truth.** The `session.shutdown` event contains pre-aggregated metrics (total tokens, premium requests, model breakdown). We use these directly instead of re-summing individual events — more accurate and faster.
 
-**Resumed session detection.** Sessions can be shut down and resumed. The parser checks for events after the last `session.shutdown` to detect this. Resumed sessions get `is_active = True` with shutdown metrics preserved as historical data.
+**Resumed session detection.** Sessions can be shut down and resumed. The parser checks for events after the last `session.shutdown` to detect this. Resumed sessions get `is_active = True` with shutdown metrics preserved as historical data. The `active_model_calls` / `active_user_messages` / `active_output_tokens` counters track post-resume sub-totals separately from full-session totals, so renderers can split "since last shutdown" from historical data without re-scanning the event list. `shutdown_cycles` is pre-computed by the parser for the same reason — renderers receive the list directly and never walk the raw events. A `_check_active_counters` validator enforces the invariant `active_model_calls ≤ model_calls` (and likewise for user_messages). For pure-active sessions (no shutdowns at all), `active_*` equals the full-session totals.
 
 **Graceful degradation.** Unknown event types still validate as `SessionEvent`, but production code skips them. `GenericEventData(extra="allow")` remains available for optional best-effort payload validation when a caller explicitly chooses to use it. Missing fields get defaults. The tool never crashes on unexpected data.
 
@@ -91,7 +91,7 @@ tests/
     └── test_e2e.py             Full pipeline: CLI → parser → models → report → output
 ```
 
-- **Unit tests**: 99% coverage, test individual functions with synthetic data
+- **Unit tests**: Run `make test` to see current coverage; test individual functions with synthetic data
 - **Doctests**: `_formatting.py` functions have `>>>` examples executed via `--doctest-modules`
 - **E2e tests**: Run actual CLI commands against anonymized fixture sessions, assert on output content
 - Test counts grow regularly — run `make test` to see the current numbers

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -278,6 +278,31 @@ def test_implementation_md_symbols_exist_in_expected_modules() -> None:
             )
 
 
+def test_key_design_decisions_mentions_active_counters_and_shutdown_cycles() -> None:
+    """The Key Design Decisions section in architecture.md must mention
+    active_model_calls (or active_*) and shutdown_cycles so the active-counter
+    architecture description cannot silently regress."""
+    section_match = re.search(
+        r"^###\s+Key Design Decisions\b.*?(?=^#{1,3}\s+|\Z)",
+        _ARCH_MD,
+        re.MULTILINE | re.DOTALL,
+    )
+    assert section_match, (
+        "Could not find '### Key Design Decisions' section in architecture.md"
+    )
+    section = section_match.group(0)
+    assert "active_model_calls" in section, (
+        "Key Design Decisions in architecture.md must mention "
+        "'active_model_calls' — the active-counter architecture "
+        "is a key design decision"
+    )
+    assert "shutdown_cycles" in section, (
+        "Key Design Decisions in architecture.md must mention "
+        "'shutdown_cycles' — the pre-computed shutdown list "
+        "is a key design decision"
+    )
+
+
 def test_active_fields_document_pure_active_semantics() -> None:
     """The active_model_calls / active_user_messages / active_output_tokens
     field descriptions must mention pure-active session semantics — not just


### PR DESCRIPTION
Closes #1127

## Changes

Updates `src/copilot_usage/docs/architecture.md` to document the `active_*` counter architecture and `shutdown_cycles` pre-computation that were missing from several sections:

1. **`models.py` component row** — expanded to mention `active_model_calls` / `active_user_messages` / `active_output_tokens` (post-last-shutdown sub-totals), `shutdown_cycles` (pre-computed shutdown list), `has_shutdown_metrics` flag, and `_check_active_counters` validator.

2. **Key Design Decisions — "Resumed session detection"** — extended with: the `active_*` counters separate post-resume sub-totals from full-session totals so renderers never re-scan events; `shutdown_cycles` is pre-computed for the same reason; `_check_active_counters` enforces the `active_* ≤ total_*` invariant; for pure-active sessions `active_*` equals full-session totals.

3. **`_build_active_summary()` description** — added that for pure-active sessions `active_*` fields equal the full-session totals.

4. **Line 94** — replaced static "99% coverage" claim with a note to run `make test`.

## Tests

Added `test_key_design_decisions_mentions_active_counters_and_shutdown_cycles()` to `tests/test_docs.py` — asserts the Key Design Decisions section contains `active_model_calls` and `shutdown_cycles` to prevent silent regression.

> **Note:** `make check` could not be run in this environment due to network restrictions preventing `uv` installation. Changes were verified with standalone Python assertions against the modified files.




> [!WARNING]
> <details>
> <summary><strong>⚠️ Firewall blocked 3 domains</strong></summary>
>
> The following domains were blocked by the firewall during workflow execution:
>
> - `astral.sh`
> - `pypi.org`
> - `releaseassets.githubusercontent.com`
>
> To allow these domains, add them to the `network.allowed` list in your workflow frontmatter:
>
> ```yaml
> network:
>   allowed:
>     - defaults
>     - "astral.sh"
>     - "pypi.org"
>     - "releaseassets.githubusercontent.com"
> ```
>
> See [Network Configuration](https://github.github.com/gh-aw/reference/network/) for more information.
>
> </details>


> Generated by [Issue Implementer](https://github.com/microsasa/cli-tools/actions/runs/25093617867/agentic_workflow) · ● 8.8M · [◷](https://github.com/search?q=repo%3Amicrosasa%2Fcli-tools+%22gh-aw-workflow-id%3A+issue-implementer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Issue Implementer, engine: copilot, model: claude-opus-4.6, id: 25093617867, workflow_id: issue-implementer, run: https://github.com/microsasa/cli-tools/actions/runs/25093617867 -->

<!-- gh-aw-workflow-id: issue-implementer -->