### PR TITLE
fix(report): accumulate grand total premium for empty model_metrics sessions (#1131)

### DIFF
--- a/src/copilot_usage/report.py
+++ b/src/copilot_usage/report.py
@@ -716,6 +716,10 @@ def render_cost_view(
                 str(s.model_calls),
                 format_tokens(session_output) if session_output else "—",
             )
+            # Accumulate premium totals so the Grand Total row is correct
+            # even when model_metrics is empty but premium requests exist.
+            if not s.is_active or s.has_shutdown_metrics:
+                grand_premium += s.total_premium_requests
 
         grand_output += session_output
         grand_model_calls += s.model_calls

--- a/tests/copilot_usage/test_report.py
+++ b/tests/copilot_usage/test_report.py
@@ -6405,3 +6405,83 @@ class TestRenderCostViewNoRedundantTotalOutputTokens:
             "total_output_tokens should not be called for resumed sessions "
             "with model_metrics"
         )
+
+
+# ---------------------------------------------------------------------------
+# Issue #1131 — render_cost_view Grand Total undercounts Premium Cost for
+# sessions with total_premium_requests > 0 but empty model_metrics
+# ---------------------------------------------------------------------------
+
+
+class TestCostViewGrandTotalEmptyMetricsPremium:
+    """Issue #1131 — Grand Total Premium Cost must include sessions with
+    total_premium_requests > 0 and empty model_metrics."""
+
+    def test_grand_total_premium_includes_empty_metrics_session(self) -> None:
+        """Grand Total 'Premium Cost' cell equals total_premium_requests
+        for a completed session with empty model_metrics."""
+        session = SessionSummary(
+            session_id="premium-no-metrics-1131",
+            name="Premium No Metrics",
+            model="gpt-4",
+            start_time=datetime(2025, 5, 1, 10, 0, tzinfo=UTC),
+            is_active=False,
+            has_shutdown_metrics=False,
+            total_premium_requests=9,
+            model_metrics={},
+            model_calls=4,
+            user_messages=2,
+        )
+        output = _capture_cost_view([session])
+        clean = re.sub(r"\x1b\[[0-9;]*m", "", output)
+        lines = clean.splitlines()
+
+        grand_row = next(line for line in lines if "Grand Total" in line)
+        grand_cols = [c.strip() for c in grand_row.split("│")]
+        # Column 4 is "Premium Cost" (1-indexed: Session, Model, Requests, Premium Cost)
+        assert grand_cols[4] == "9", (
+            f"Grand Total Premium Cost: expected '9', got '{grand_cols[4]}'"
+        )
+
+    def test_grand_total_premium_combines_metrics_and_empty_metrics(self) -> None:
+        """Grand Total accumulates premium from both metric-rich and
+        empty-metrics sessions."""
+        session_with_metrics = SessionSummary(
+            session_id="with-metrics-1131",
+            name="With Metrics",
+            model="gpt-4",
+            start_time=datetime(2025, 5, 2, 10, 0, tzinfo=UTC),
+            is_active=False,
+            has_shutdown_metrics=True,
+            total_premium_requests=10,
+            model_metrics={
+                "gpt-4": ModelMetrics(
+                    requests=RequestMetrics(count=5, cost=10),
+                    usage=TokenUsage(outputTokens=200),
+                ),
+            },
+            model_calls=5,
+            user_messages=3,
+        )
+        session_empty_metrics = SessionSummary(
+            session_id="empty-metrics-1131",
+            name="Empty Metrics",
+            model="gpt-4",
+            start_time=datetime(2025, 5, 1, 10, 0, tzinfo=UTC),
+            is_active=False,
+            has_shutdown_metrics=False,
+            total_premium_requests=7,
+            model_metrics={},
+            model_calls=3,
+            user_messages=1,
+        )
+        output = _capture_cost_view([session_with_metrics, session_empty_metrics])
+        clean = re.sub(r"\x1b\[[0-9;]*m", "", output)
+        lines = clean.splitlines()
+
+        grand_row = next(line for line in lines if "Grand Total" in line)
+        grand_cols = [c.strip() for c in grand_row.split("│")]
+        # 10 (from model_metrics cost) + 7 (from empty-metrics session) = 17
+        assert grand_cols[4] == "17", (
+            f"Grand Total Premium Cost: expected '17', got '{grand_cols[4]}'"
+        )


### PR DESCRIPTION
Closes #1131

## Problem

`render_cost_view` accumulated `grand_premium` only inside the per-model `model_metrics` loop. Sessions with `total_premium_requests > 0` but empty `model_metrics` (e.g., older Copilot CLI versions emitting `totalPremiumRequests` without `modelMetrics`) were silently excluded from the Grand Total "Premium Cost" cell.

## Fix

In the `else` branch (empty `model_metrics`), accumulate `grand_premium += s.total_premium_requests` when the session is completed (`not s.is_active`) or has shutdown metrics (`s.has_shutdown_metrics`). This mirrors the `show_requests` guard used in the model_metrics branch.

## Testing

Added `TestCostViewGrandTotalEmptyMetricsPremium` with two tests:
- A single completed session with empty `model_metrics` and `total_premium_requests=9` → Grand Total Premium Cost = "9"
- A mixed scenario combining a metrics-rich session (cost=10) with an empty-metrics session (premium=7) → Grand Total = "17"




> [!WARNING]
> <details>
> <summary><strong>⚠️ Firewall blocked 2 domains</strong></summary>
>
> The following domains were blocked by the firewall during workflow execution:
>
> - `astral.sh`
> - `pypi.org`
>
> To allow these domains, add them to the `network.allowed` list in your workflow frontmatter:
>
> ```yaml
> network:
>   allowed:
>     - defaults
>     - "astral.sh"
>     - "pypi.org"
> ```
>
> See [Network Configuration](https://github.github.com/gh-aw/reference/network/) for more information.
>
> </details>


> Generated by [Issue Implementer](https://github.com/microsasa/cli-tools/actions/runs/25133174647/agentic_workflow) · ● 9.8M · [◷](https://github.com/search?q=repo%3Amicrosasa%2Fcli-tools+%22gh-aw-workflow-id%3A+issue-implementer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Issue Implementer, engine: copilot, model: claude-opus-4.6, id: 25133174647, workflow_id: issue-implementer, run: https://github.com/microsasa/cli-tools/actions/runs/25133174647 -->

<!-- gh-aw-workflow-id: issue-implementer -->