### PR TITLE
docs: add interactive.py and _fs_utils.py to README project structure (#1135)

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,13 +230,15 @@ Add `V=1` for verbose output: `make check V=1`
 cli-tools/
 ├── src/
 │   └── copilot_usage/
-│       ├── cli.py              # Click commands + interactive loop + watchdog auto-refresh
+│       ├── cli.py              # Click command group, _interactive_loop driver; watchdog helpers are in interactive.py
+│       ├── interactive.py      # Interactive-mode UI helpers — session list, file-watching, version header, session index
 │       ├── models.py           # Pydantic data models and session-level helpers
 │       ├── parser.py           # events.jsonl parsing and session summary builder
 │       ├── pricing.py          # Model cost multipliers and lookup helpers
 │       ├── report.py           # Rich terminal output (summary, cost, live views)
 │       ├── render_detail.py    # Session-detail rendering (extracted from report.py)
 │       ├── _formatting.py      # Shared pure formatting utilities (tokens, durations)
+│       ├── _fs_utils.py        # Shared filesystem/caching utilities — lru_insert and safe_file_identity
 │       ├── vscode_parser.py    # VS Code Copilot Chat log parser
 │       ├── vscode_report.py    # Rich rendering for VS Code usage data
 │       ├── logging_config.py   # Loguru configuration


### PR DESCRIPTION
Closes #1135

Updates the "Project Structure" section in `README.md` to reflect the current source layout:

1. **Added `interactive.py`** — Interactive-mode UI helpers (session list, file-watching, version header, session index)
2. **Added `_fs_utils.py`** — Shared filesystem/caching utilities (`lru_insert` and `safe_file_identity`)
3. **Corrected `cli.py` description** — Removed misleading "watchdog auto-refresh" attribution; noted that watchdog helpers live in `interactive.py`

No logic changes. The listing now matches the actual files in `src/copilot_usage/` and aligns with the descriptions already present in `src/copilot_usage/docs/architecture.md`.




> Generated by [Issue Implementer](https://github.com/microsasa/cli-tools/actions/runs/25152805564/agentic_workflow) · ● 1.7M · [◷](https://github.com/search?q=repo%3Amicrosasa%2Fcli-tools+%22gh-aw-workflow-id%3A+issue-implementer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Issue Implementer, engine: copilot, model: claude-opus-4.6, id: 25152805564, workflow_id: issue-implementer, run: https://github.com/microsasa/cli-tools/actions/runs/25152805564 -->

<!-- gh-aw-workflow-id: issue-implementer -->