### PR TITLE
fix: resolve candidate paths before vscode discovery cache lookup (#1138)

### DIFF
--- a/src/copilot_usage/vscode_parser.py
+++ b/src/copilot_usage/vscode_parser.py
@@ -263,6 +263,7 @@ def _cached_discover_vscode_logs(base_path: Path | None) -> list[Path]:
     candidates = [base_path] if base_path is not None else _default_log_candidates()
     result: list[Path] = []
     for candidate in candidates:
+        candidate = candidate.resolve()
         try:
             st = candidate.stat()
         except OSError as exc:

--- a/tests/copilot_usage/test_vscode_parser.py
+++ b/tests/copilot_usage/test_vscode_parser.py
@@ -3045,6 +3045,70 @@ class TestScanChildIdsEdgeCases:
         assert "link_window" not in names
 
 
+class TestCachedDiscoverResolvesSymlinks:
+    """Regression: _cached_discover_vscode_logs must resolve paths before cache lookup.
+
+    When a symlink or non-canonical path (containing ``..``) is passed as a
+    candidate, the function must resolve it so that both the symlink and the
+    real path share the same cache entry.
+    """
+
+    def test_symlink_and_real_path_share_cache_entry(self, tmp_path: Path) -> None:
+        """Calling via symlink then real path must produce one cache entry."""
+        real_dir = tmp_path / "real_logs"
+        log_dir = (
+            real_dir
+            / "20260313T211400"
+            / "window1"
+            / "exthost"
+            / "GitHub.copilot-chat"
+        )
+        log_dir.mkdir(parents=True)
+        (log_dir / "GitHub Copilot Chat.log").write_text(_make_log_line(req_idx=0))
+
+        symlink = tmp_path / "link_logs"
+        try:
+            symlink.symlink_to(real_dir)
+        except OSError as exc:
+            pytest.skip(f"Symlinks not supported: {exc}")
+
+        paths_via_symlink = _cached_discover_vscode_logs(symlink)
+        paths_via_real = _cached_discover_vscode_logs(real_dir)
+
+        # Both calls must return identical log paths.
+        assert paths_via_symlink == paths_via_real
+
+        # Only one cache entry should exist (keyed by resolved path).
+        resolved = real_dir.resolve()
+        assert resolved in _VSCODE_DISCOVERY_CACHE
+        assert len(_VSCODE_DISCOVERY_CACHE) == 1
+
+    def test_dotdot_path_shares_cache_entry(self, tmp_path: Path) -> None:
+        """A path containing ``..`` components resolves to the same cache key."""
+        real_dir = tmp_path / "real_logs"
+        log_dir = (
+            real_dir
+            / "20260313T211400"
+            / "window1"
+            / "exthost"
+            / "GitHub.copilot-chat"
+        )
+        log_dir.mkdir(parents=True)
+        (log_dir / "GitHub Copilot Chat.log").write_text(_make_log_line(req_idx=0))
+
+        dotdot_path = tmp_path / "subdir" / ".." / "real_logs"
+        (tmp_path / "subdir").mkdir()
+
+        paths_via_dotdot = _cached_discover_vscode_logs(dotdot_path)
+        paths_via_real = _cached_discover_vscode_logs(real_dir)
+
+        assert paths_via_dotdot == paths_via_real
+
+        resolved = real_dir.resolve()
+        assert resolved in _VSCODE_DISCOVERY_CACHE
+        assert len(_VSCODE_DISCOVERY_CACHE) == 1
+
+
 class TestCachedDiscoverOsErrors:
     """Cover OSError paths in _cached_discover_vscode_logs."""
 


### PR DESCRIPTION
Closes #1138

## Problem

`_cached_discover_vscode_logs` in `vscode_parser.py` used raw, unresolved `candidate` paths as `_VSCODE_DISCOVERY_CACHE` dictionary keys. When a symlinked or non-canonical path (e.g. containing `..`) was passed via `--vscode-logs`, the cache would always miss and duplicate entries would accumulate.

## Fix

Add `candidate = candidate.resolve()` before the stat and cache lookup, matching the existing pattern in `_discover_with_identity` in `parser.py` (line 520).

## Tests

Added `TestCachedDiscoverResolvesSymlinks` with two regression tests:
- **`test_symlink_and_real_path_share_cache_entry`** — calls via symlink then real path, asserts one cache entry and identical results.
- **`test_dotdot_path_shares_cache_entry`** — calls via `../` path then real path, asserts one cache entry and identical results.

Both tests clear caches automatically via the existing `_clear_vscode_caches` autouse fixture.




> [!WARNING]
> <details>
> <summary><strong>⚠️ Firewall blocked 3 domains</strong></summary>
>
> The following domains were blocked by the firewall during workflow execution:
>
> - `astral.sh`
> - `index.crates.io`
> - `pypi.org`
>
> To allow these domains, add them to the `network.allowed` list in your workflow frontmatter:
>
> ```yaml
> network:
>   allowed:
>     - defaults
>     - "astral.sh"
>     - "index.crates.io"
>     - "pypi.org"
> ```
>
> See [Network Configuration](https://github.github.com/gh-aw/reference/network/) for more information.
>
> </details>


> Generated by [Issue Implementer](https://github.com/microsasa/cli-tools/actions/runs/25189015356/agentic_workflow) · ● 8.3M · [◷](https://github.com/search?q=repo%3Amicrosasa%2Fcli-tools+%22gh-aw-workflow-id%3A+issue-implementer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Issue Implementer, engine: copilot, model: claude-opus-4.6, id: 25189015356, workflow_id: issue-implementer, run: https://github.com/microsasa/cli-tools/actions/runs/25189015356 -->

<!-- gh-aw-workflow-id: issue-implementer -->