### PR TITLE
fix: derive fallback session_id from directory name when session.start is missing (#1139)

### DIFF
--- a/src/copilot_usage/parser.py
+++ b/src/copilot_usage/parser.py
@@ -1036,6 +1036,18 @@ def _build_session_summary_with_meta(
 ) -> _BuildMeta:
     """Build a summary and report whether the config fallback was used."""
     fp = _first_pass(events)
+
+    # Derive a fallback session_id from the directory name when the events
+    # file lacks a session.start event (avoids build_session_index collisions).
+    if not fp.session_id:
+        fallback_id = ""
+        if session_dir is not None:
+            fallback_id = session_dir.name
+        elif events_path is not None:
+            fallback_id = events_path.parent.name
+        if fallback_id:
+            fp = dataclasses.replace(fp, session_id=fallback_id)
+
     name = (
         _extract_session_name(session_dir, plan_exists=plan_exists)
         if session_dir

--- a/tests/copilot_usage/test_parser.py
+++ b/tests/copilot_usage/test_parser.py
@@ -2922,6 +2922,65 @@ class TestGetAllSessions:
 
 
 # ---------------------------------------------------------------------------
+# Fallback session_id for sessions lacking session.start (issue #1139)
+# ---------------------------------------------------------------------------
+
+
+class TestNoSessionStartFallbackId:
+    """Sessions without a session.start event get a fallback session_id.
+
+    Verifies that the directory name is used as a stable fallback so that
+    build_session_index does not collapse multiple such sessions into a
+    single key.
+    """
+
+    def test_single_session_gets_directory_name_as_id(self, tmp_path: Path) -> None:
+        """A session with no session.start derives session_id from its dir name."""
+        session_dir = tmp_path / "abc-uuid-1234"
+        events_path = session_dir / "events.jsonl"
+        _write_events(events_path, _USER_MSG, _ASSISTANT_MSG)
+        result = get_all_sessions(tmp_path)
+        assert len(result) == 1
+        assert result[0].session_id == "abc-uuid-1234"
+
+    def test_two_no_start_sessions_have_distinct_ids(self, tmp_path: Path) -> None:
+        """Two sessions without session.start produce distinct session_ids."""
+        dir_a = tmp_path / "dir-aaa"
+        dir_b = tmp_path / "dir-bbb"
+        _write_events(dir_a / "events.jsonl", _USER_MSG, _ASSISTANT_MSG)
+        _write_events(dir_b / "events.jsonl", _USER_MSG, _ASSISTANT_MSG)
+        result = get_all_sessions(tmp_path)
+        assert len(result) == 2
+        ids = {s.session_id for s in result}
+        assert ids == {"dir-aaa", "dir-bbb"}
+
+    def test_no_start_sessions_no_index_collision(self, tmp_path: Path) -> None:
+        """build_session_index contains distinct keys for no-start sessions."""
+        from copilot_usage.interactive import build_session_index
+
+        dir_a = tmp_path / "session-x"
+        dir_b = tmp_path / "session-y"
+        _write_events(dir_a / "events.jsonl", _USER_MSG)
+        _write_events(dir_b / "events.jsonl", _USER_MSG)
+        sessions = get_all_sessions(tmp_path)
+        assert len(sessions) == 2
+        index = build_session_index(sessions)
+        assert len(index) == 2
+        assert "session-x" in index
+        assert "session-y" in index
+
+    def test_normal_session_start_not_overridden(self, tmp_path: Path) -> None:
+        """Sessions with a session.start event still use the event's sessionId."""
+        session_dir = tmp_path / "some-dir-name"
+        _write_events(
+            session_dir / "events.jsonl", _START_EVENT, _USER_MSG, _ASSISTANT_MSG
+        )
+        result = get_all_sessions(tmp_path)
+        assert len(result) == 1
+        assert result[0].session_id == "test-session-001"
+
+
+# ---------------------------------------------------------------------------
 # Real data smoke test (against ~/.copilot/session-state/)
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Sessions without a `session.start` event previously produced `session_id=""`, causing `build_session_index` collisions when multiple such sessions existed. This led to the wrong session being displayed on auto-refresh in interactive mode.

## Changes

**`src/copilot_usage/parser.py`** — In `_build_session_summary_with_meta`, after calling `_first_pass`, if `fp.session_id` is empty, derive a fallback ID from the session directory name (or `events_path.parent.name`). Uses `dataclasses.replace` since `_FirstPassResult` is frozen.

**`tests/copilot_usage/test_parser.py`** — Added `TestNoSessionStartFallbackId` class with four tests:
1. Single no-start session gets directory name as ID
2. Two no-start sessions get distinct IDs
3. `build_session_index` contains no collisions for such sessions
4. Normal sessions with `session.start` are not affected

## Why Option A

Per the issue spec, Option A (fallback to directory name) is preferred over Option B (skip sessions) because it retains session data in aggregate views rather than silently discarding it.

Closes #1139




> [!WARNING]
> <details>
> <summary><strong>⚠️ Firewall blocked 3 domains</strong></summary>
>
> The following domains were blocked by the firewall during workflow execution:
>
> - `astral.sh`
> - `index.crates.io`
> - `pypi.org`
>
> To allow these domains, add them to the `network.allowed` list in your workflow frontmatter:
>
> ```yaml
> network:
>   allowed:
>     - defaults
>     - "astral.sh"
>     - "index.crates.io"
>     - "pypi.org"
> ```
>
> See [Network Configuration](https://github.github.com/gh-aw/reference/network/) for more information.
>
> </details>


> Generated by [Issue Implementer](https://github.com/microsasa/cli-tools/actions/runs/25189385673/agentic_workflow) · ● 14.1M · [◷](https://github.com/search?q=repo%3Amicrosasa%2Fcli-tools+%22gh-aw-workflow-id%3A+issue-implementer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Issue Implementer, engine: copilot, model: claude-opus-4.6, id: 25189385673, workflow_id: issue-implementer, run: https://github.com/microsasa/cli-tools/actions/runs/25189385673 -->

<!-- gh-aw-workflow-id: issue-implementer -->