### PR TITLE
Add direct unit tests for `draw_home` and `write_prompt` (#1142)

### DIFF
--- a/tests/copilot_usage/test_interactive.py
+++ b/tests/copilot_usage/test_interactive.py
@@ -1,0 +1,74 @@
+"""Tests for copilot_usage.interactive — write_prompt and draw_home contracts."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from copilot_usage.interactive import draw_home, write_prompt
+
+
+# ---------------------------------------------------------------------------
+# write_prompt
+# ---------------------------------------------------------------------------
+
+
+def test_write_prompt_writes_to_stdout_no_newline(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """write_prompt writes the prompt string exactly — no trailing newline."""
+    write_prompt("Enter session #: ")
+    out, _ = capsys.readouterr()
+    assert out == "Enter session #: "
+    assert "\n" not in out
+
+
+def test_write_prompt_flushes(monkeypatch: pytest.MonkeyPatch) -> None:
+    """write_prompt calls sys.stdout.flush() so prompt appears immediately."""
+    flushed: list[bool] = []
+
+    class _FakeStdout:
+        """Fake stdout that records flush() calls."""
+
+        def write(self, s: str) -> None: ...
+
+        def flush(self) -> None:
+            flushed.append(True)
+
+    monkeypatch.setattr(
+        "copilot_usage.interactive.sys.stdout", _FakeStdout()
+    )
+    write_prompt("prompt> ")
+    assert flushed == [True]
+
+
+# ---------------------------------------------------------------------------
+# draw_home
+# ---------------------------------------------------------------------------
+
+
+def test_draw_home_calls_clear_before_any_output() -> None:
+    """console.clear() must be the first call so the previous screen is erased
+    before new content is rendered (prevents flash)."""
+    calls: list[str] = []
+    mock_console = MagicMock()
+    mock_console.clear.side_effect = lambda: calls.append("clear")
+    mock_console.print.side_effect = lambda *a, **kw: calls.append("print")
+
+    with patch(
+        "copilot_usage.interactive.print_version_header",
+        lambda c: calls.append("header"),
+    ):
+        with patch(
+            "copilot_usage.interactive.render_full_summary",
+            lambda s, **kw: calls.append("summary"),
+        ):
+            with patch(
+                "copilot_usage.interactive.render_session_list",
+                lambda c, s: calls.append("list"),
+            ):
+                draw_home(mock_console, [])
+
+    assert calls[0] == "clear", f"Expected clear() first; got {calls}"
+    assert calls == ["clear", "header", "summary", "print", "list"]


### PR DESCRIPTION
Closes #1142

## Problem

`draw_home` and `write_prompt` in `src/copilot_usage/interactive.py` had zero direct unit tests. The only coverage came indirectly through CLI integration tests, which verified the functions were *called* but not *what they do*. Three critical behavioral contracts were unverified:

1. `write_prompt` writes to `sys.stdout` with **no trailing `\n`**
2. `write_prompt` calls `flush()` **immediately** so the prompt appears before user input
3. `draw_home` calls `console.clear()` **before** any content rendering (prevents screen flash)

## Solution

Added `tests/copilot_usage/test_interactive.py` with three focused tests:

| Test | Verifies |
|------|----------|
| `test_write_prompt_writes_to_stdout_no_newline` | Exact output match — no trailing newline |
| `test_write_prompt_flushes` | `flush()` is called via fake stdout |
| `test_draw_home_calls_clear_before_any_output` | Call order: `clear` → `header` → `summary` → `print` → `list` |

## Testing

Tests follow existing conventions (pytest, `monkeypatch`, `MagicMock`/`patch`). No changes to production code.




> [!WARNING]
> <details>
> <summary><strong>⚠️ Firewall blocked 3 domains</strong></summary>
>
> The following domains were blocked by the firewall during workflow execution:
>
> - `astral.sh`
> - `pypi.org`
> - `releaseassets.githubusercontent.com`
>
> To allow these domains, add them to the `network.allowed` list in your workflow frontmatter:
>
> ```yaml
> network:
>   allowed:
>     - defaults
>     - "astral.sh"
>     - "pypi.org"
>     - "releaseassets.githubusercontent.com"
> ```
>
> See [Network Configuration](https://github.github.com/gh-aw/reference/network/) for more information.
>
> </details>


> Generated by [Issue Implementer](https://github.com/microsasa/cli-tools/actions/runs/25203125625/agentic_workflow) · ● 9.4M · [◷](https://github.com/search?q=repo%3Amicrosasa%2Fcli-tools+%22gh-aw-workflow-id%3A+issue-implementer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Issue Implementer, engine: copilot, model: claude-opus-4.6, id: 25203125625, workflow_id: issue-implementer, run: https://github.com/microsasa/cli-tools/actions/runs/25203125625 -->

<!-- gh-aw-workflow-id: issue-implementer -->