### PR TITLE
fix: dynamic active section title based on shutdown history (#1146)

### DIFF
--- a/src/copilot_usage/report.py
+++ b/src/copilot_usage/report.py
@@ -545,6 +545,11 @@ def _render_active_section_from(
 
     *active* must already contain only sessions where ``is_active`` is
     ``True``.  No filtering is performed here.
+
+    The table title includes "(Since Last Shutdown)" only when at least one
+    session in *active* has shutdown history (non-empty ``shutdown_cycles``).
+    Pure-active sessions (never shut down) get the neutral title
+    "🟢 Active Sessions".
     """
     if not active:
         console.print(
@@ -554,9 +559,13 @@ def _render_active_section_from(
         )
         return
 
-    table = Table(
-        title="🟢 Active Sessions (Since Last Shutdown)", border_style="green"
+    has_shutdown_history = any(s.shutdown_cycles for s in active)
+    title = (
+        "🟢 Active Sessions (Since Last Shutdown)"
+        if has_shutdown_history
+        else "🟢 Active Sessions"
     )
+    table = Table(title=title, border_style="green")
     table.add_column("Name", style="bold", max_width=40)
     table.add_column("Model")
     table.add_column("Model Calls", justify="right")

--- a/tests/copilot_usage/test_report.py
+++ b/tests/copilot_usage/test_report.py
@@ -59,6 +59,7 @@ from copilot_usage.report import (
     _filter_sessions,
     _format_elapsed_since,
     _format_session_running_time,
+    _render_active_section_from,
     _render_model_table,
     _render_session_table,
     render_cost_view,
@@ -2094,6 +2095,146 @@ class TestRenderFullSummary:
             "Active row must NOT display shutdown output tokens"
         )
 
+    def test_active_title_no_since_last_shutdown_for_pure_active(self) -> None:
+        """Pure-active sessions (no shutdown history) omit 'Since Last Shutdown'.
+
+        Regression test for issue #1146: the title should not claim a temporal
+        scope that does not exist for sessions that have never been shut down.
+        """
+        now = datetime.now(tz=UTC)
+        session = SessionSummary(
+            session_id="pure-active-title-abcdef",
+            name="PureActive",
+            model="claude-sonnet-4",
+            start_time=now - timedelta(minutes=5),
+            is_active=True,
+            has_shutdown_metrics=False,
+            user_messages=2,
+            model_calls=1,
+            active_model_calls=1,
+            active_user_messages=2,
+            active_output_tokens=100,
+            shutdown_cycles=[],
+        )
+        output = _capture_full_summary([session])
+        clean = re.sub(r"\x1b\[[0-9;]*m", "", output)
+
+        assert "Active Sessions" in clean
+        assert "Since Last Shutdown" not in clean
+
+    def test_active_title_since_last_shutdown_for_resumed(self) -> None:
+        """Resumed sessions (non-empty shutdown_cycles) show 'Since Last Shutdown'.
+
+        Regression test for issue #1146: when at least one active session has
+        shutdown history, the title should clarify the temporal scope.
+        """
+        now = datetime.now(tz=UTC)
+        sd = SessionShutdownData(
+            shutdownType="explicit",
+            totalPremiumRequests=5,
+            totalApiDurationMs=1000,
+        )
+        session = SessionSummary(
+            session_id="resumed-title-abcdef",
+            name="Resumed",
+            model="claude-sonnet-4",
+            start_time=now - timedelta(hours=1),
+            last_resume_time=now - timedelta(minutes=10),
+            is_active=True,
+            has_shutdown_metrics=True,
+            total_premium_requests=5,
+            user_messages=8,
+            model_calls=6,
+            active_model_calls=2,
+            active_user_messages=3,
+            active_output_tokens=200,
+            shutdown_cycles=[(now - timedelta(minutes=30), sd)],
+            model_metrics={
+                "claude-sonnet-4": ModelMetrics(
+                    requests=RequestMetrics(count=3, cost=5),
+                    usage=TokenUsage(outputTokens=500),
+                )
+            },
+        )
+        output = _capture_full_summary([session])
+        clean = re.sub(r"\x1b\[[0-9;]*m", "", output)
+
+        assert "Since Last Shutdown" in clean
+
+
+# ---------------------------------------------------------------------------
+# _render_active_section_from direct tests (issue #1146)
+# ---------------------------------------------------------------------------
+
+
+class TestRenderActiveSectionFromTitle:
+    """Verify _render_active_section_from title depends on shutdown_cycles."""
+
+    def _capture(self, active: list[SessionSummary]) -> str:
+        """Capture Rich output from _render_active_section_from."""
+        buf = StringIO()
+        console = Console(file=buf, force_terminal=True, width=120)
+        _render_active_section_from(console, active)
+        return buf.getvalue()
+
+    def test_pure_active_no_since_last_shutdown(self) -> None:
+        """Title omits 'Since Last Shutdown' for pure-active sessions."""
+        now = datetime.now(tz=UTC)
+        session = SessionSummary(
+            session_id="direct-pure-abcdef",
+            name="DirectPure",
+            model="claude-sonnet-4",
+            start_time=now - timedelta(minutes=5),
+            is_active=True,
+            has_shutdown_metrics=False,
+            user_messages=1,
+            model_calls=1,
+            active_model_calls=1,
+            active_user_messages=1,
+            active_output_tokens=50,
+            shutdown_cycles=[],
+        )
+        output = self._capture([session])
+        clean = re.sub(r"\x1b\[[0-9;]*m", "", output)
+
+        assert "Active Sessions" in clean
+        assert "Since Last Shutdown" not in clean
+
+    def test_resumed_session_shows_since_last_shutdown(self) -> None:
+        """Title includes 'Since Last Shutdown' when shutdown_cycles is non-empty."""
+        now = datetime.now(tz=UTC)
+        sd = SessionShutdownData(
+            shutdownType="explicit",
+            totalPremiumRequests=3,
+            totalApiDurationMs=500,
+        )
+        session = SessionSummary(
+            session_id="direct-resumed-abcdef",
+            name="DirectResumed",
+            model="claude-sonnet-4",
+            start_time=now - timedelta(hours=1),
+            last_resume_time=now - timedelta(minutes=5),
+            is_active=True,
+            has_shutdown_metrics=True,
+            total_premium_requests=3,
+            user_messages=5,
+            model_calls=4,
+            active_model_calls=2,
+            active_user_messages=1,
+            active_output_tokens=100,
+            shutdown_cycles=[(now - timedelta(minutes=30), sd)],
+            model_metrics={
+                "claude-sonnet-4": ModelMetrics(
+                    requests=RequestMetrics(count=2, cost=3),
+                    usage=TokenUsage(outputTokens=300),
+                )
+            },
+        )
+        output = self._capture([session])
+        clean = re.sub(r"\x1b\[[0-9;]*m", "", output)
+
+        assert "Since Last Shutdown" in clean
+
 
 # ---------------------------------------------------------------------------
 # render_cost_view capture helper
@@ -3636,6 +3777,17 @@ class TestHistoricalSectionResumedFreeSessions:
 
     def test_resumed_free_session_appears_in_active_section(self) -> None:
         """Same resumed session must also appear in the active section."""
+        sd = SessionShutdownData(
+            shutdownType="routine",
+            totalPremiumRequests=0,
+            totalApiDurationMs=1000,
+            modelMetrics={
+                "gpt-5-mini": ModelMetrics(
+                    requests=RequestMetrics(count=17, cost=0),
+                    usage=TokenUsage(outputTokens=8000),
+                )
+            },
+        )
         session = SessionSummary(
             session_id="resumed-free-model-1234",
             name="ResumedFreeSession",
@@ -3648,6 +3800,7 @@ class TestHistoricalSectionResumedFreeSessions:
             model_calls=20,
             active_model_calls=3,
             active_output_tokens=500,
+            shutdown_cycles=[(datetime(2025, 1, 15, 10, 30, tzinfo=UTC), sd)],
             model_metrics={
                 "gpt-5-mini": ModelMetrics(
                     requests=RequestMetrics(count=17, cost=0),


### PR DESCRIPTION
## Summary

`_render_active_section_from` in `report.py` hardcoded the table title as `"🟢 Active Sessions (Since Last Shutdown)"` unconditionally. For pure-active sessions (never shut down, `shutdown_cycles=[]`), this title is factually incorrect — there is no "last shutdown" to refer to.

## Changes

**`src/copilot_usage/report.py`**
- Compute title dynamically: `"🟢 Active Sessions (Since Last Shutdown)"` when any session has `shutdown_cycles`, otherwise `"🟢 Active Sessions"`
- Updated docstring to document the new behavior

**`tests/copilot_usage/test_report.py`**
- Added `test_active_title_no_since_last_shutdown_for_pure_active` — verifies pure-active sessions omit "Since Last Shutdown"
- Added `test_active_title_since_last_shutdown_for_resumed` — verifies resumed sessions show "Since Last Shutdown"
- Added `TestRenderActiveSectionFromTitle` class with direct tests of `_render_active_section_from`
- Fixed existing `test_resumed_free_session_appears_in_active_section` to include `shutdown_cycles` for realistic resumed session construction

## Testing

Regression tests cover both scenarios per the issue spec:
1. Pure-active sessions (`shutdown_cycles=[]`) → title does NOT contain "Since Last Shutdown"
2. Resumed sessions (`shutdown_cycles` non-empty) → title DOES contain "Since Last Shutdown"

Closes #1146




> [!WARNING]
> <details>
> <summary><strong>⚠️ Firewall blocked 2 domains</strong></summary>
>
> The following domains were blocked by the firewall during workflow execution:
>
> - `astral.sh`
> - `pypi.org`
>
> To allow these domains, add them to the `network.allowed` list in your workflow frontmatter:
>
> ```yaml
> network:
>   allowed:
>     - defaults
>     - "astral.sh"
>     - "pypi.org"
> ```
>
> See [Network Configuration](https://github.github.com/gh-aw/reference/network/) for more information.
>
> </details>


> Generated by [Issue Implementer](https://github.com/microsasa/cli-tools/actions/runs/25219355719/agentic_workflow) · ● 26.5M · [◷](https://github.com/search?q=repo%3Amicrosasa%2Fcli-tools+%22gh-aw-workflow-id%3A+issue-implementer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Issue Implementer, engine: copilot, model: claude-opus-4.6, id: 25219355719, workflow_id: issue-implementer, run: https://github.com/microsasa/cli-tools/actions/runs/25219355719 -->

<!-- gh-aw-workflow-id: issue-implementer -->