### PR TITLE
fix: advance safe_offset in UnicodeDecodeError handler (#1150)

### DIFF
--- a/src/copilot_usage/parser.py
+++ b/src/copilot_usage/parser.py
@@ -276,6 +276,10 @@ def _parse_events_from_offset(
                         )
                 safe_offset = current_offset
     except UnicodeDecodeError as exc:
+        # Defensive guard: under pydantic>=2.13.2, model_validate_json
+        # wraps UTF-8 failures as ValidationError(type="json_invalid"),
+        # so this branch cannot trigger today.  It remains as insurance
+        # against future pydantic-core changes.
         logger.warning(
             "{} — UTF-8 decode error at offset {}; returning {} new events (partial): {}",
             events_path,
@@ -283,6 +287,7 @@ def _parse_events_from_offset(
             len(new_events),
             exc,
         )
+        safe_offset = current_offset
     return new_events, safe_offset
 
 
@@ -663,9 +668,10 @@ def parse_events(events_path: Path) -> list[SessionEvent]:
     Lines that fail JSON decoding or Pydantic validation are skipped with
     a warning.
 
-    If a ``UnicodeDecodeError`` is raised during parsing (e.g. from a
-    Pydantic validator), parsing stops early and the events parsed so
-    far are returned as a partial session.
+    If a ``UnicodeDecodeError`` is raised during parsing, parsing stops
+    early and the events parsed so far are returned as a partial
+    session.  The offset advances past the offending line so that
+    incremental callers make forward progress.
 
     Raises:
         OSError: If the file cannot be opened or read (e.g., deleted

--- a/tests/copilot_usage/test_parser.py
+++ b/tests/copilot_usage/test_parser.py
@@ -9239,7 +9239,7 @@ class TestParseEventsFromOffset:
         assert safe_end == p.stat().st_size
 
     def test_unicode_decode_error_returns_partial(self, tmp_path: Path) -> None:
-        """A UnicodeDecodeError stops parsing and returns events so far."""
+        """A UnicodeDecodeError stops parsing, returns events so far, and advances offset."""
         p = tmp_path / "events.jsonl"
         line1 = _make_event_line("session.start", "s1") + "\n"
         line2 = _make_event_line("assistant.message", "m1") + "\n"
@@ -9262,7 +9262,68 @@ class TestParseEventsFromOffset:
         with patch.object(_SE, "model_validate_json", _boom):
             events, safe_end = _parse_events_from_offset(p, 0)
             assert len(events) == 1
-            assert safe_end == len(line1.encode("utf-8"))
+            # safe_end must advance *past* the bad line so callers don't
+            # retry the same offset indefinitely.
+            assert safe_end == p.stat().st_size
+
+    def test_unicode_decode_error_offset_advances_past_bad_line(
+        self, tmp_path: Path
+    ) -> None:
+        """Regression: UnicodeDecodeError handler must not stall the cursor.
+
+        A file has three valid lines; ``model_validate_json`` raises
+        ``UnicodeDecodeError`` on line 2.  After the fix:
+
+        * Events parsed before the error are returned.
+        * ``safe_offset`` advances past the bad line.
+        * A warning is emitted.
+        * A subsequent call starting at the returned offset picks up
+          line 3 without re-encountering line 2.
+        """
+        p = tmp_path / "events.jsonl"
+        line1 = _make_event_line("session.start", "s1") + "\n"
+        line2 = _make_event_line("assistant.message", "m1") + "\n"
+        line3 = _make_event_line("assistant.message", "m2") + "\n"
+        p.write_text(line1 + line2 + line3, encoding="utf-8")
+
+        from copilot_usage.models import SessionEvent as _SE
+
+        real_validate = _SE.model_validate_json
+        call_count = [0]
+
+        @classmethod  # type: ignore[misc]
+        def _boom(
+            cls: type[object], *args: str | bytes | bytearray, **kwargs: object
+        ) -> object:
+            call_count[0] += 1
+            if call_count[0] == 2:
+                raise UnicodeDecodeError("utf-8", b"", 0, 1, "simulated")
+            return real_validate(args[0], **kwargs)  # type: ignore[arg-type]
+
+        line1_len = len(line1.encode("utf-8"))
+        line2_len = len(line2.encode("utf-8"))
+
+        with patch.object(_parser_module.logger, "warning") as warning_spy:
+            with patch.object(_SE, "model_validate_json", _boom):
+                events, safe_end = _parse_events_from_offset(p, 0)
+
+        # Only line 1 was successfully parsed.
+        assert len(events) == 1
+        assert events[0].type == "session.start"
+
+        # Cursor must have advanced past line 2.
+        assert safe_end == line1_len + line2_len
+
+        # A warning was emitted about the decode error.
+        warning_spy.assert_called_once()
+        assert "UTF-8 decode error" in warning_spy.call_args.args[0]
+
+        # A second call from the returned offset must parse line 3
+        # without revisiting line 2.
+        events2, safe_end2 = _parse_events_from_offset(p, safe_end)
+        assert len(events2) == 1
+        assert events2[0].type == "assistant.message"
+        assert safe_end2 == p.stat().st_size
 
 
 class TestParseEventsPartialTailParity:


### PR DESCRIPTION
Closes #1150

## Problem

The `except UnicodeDecodeError` handler in `_parse_events_from_offset` did not advance `safe_offset` past the offending line. If `model_validate_json` ever raises a bare `UnicodeDecodeError` (e.g. after a future pydantic-core change), the incremental cursor would stall at the same byte position, causing an infinite retry loop with a stream of warning logs and no forward progress.

Additionally, the `parse_events` docstring incorrectly stated that Pydantic validators raise `UnicodeDecodeError`.

## Changes

**`src/copilot_usage/parser.py`**
- Add `safe_offset = current_offset` in the `except UnicodeDecodeError` handler so the cursor always advances past a bad line (matching the existing `ValidationError` skip-and-advance behavior)
- Add a defensive-guard comment noting this handler cannot trigger under `pydantic>=2.13.2` but remains as insurance against future pydantic-core changes
- Update `parse_events` docstring to remove incorrect claim that pydantic validators raise `UnicodeDecodeError`

**`tests/copilot_usage/test_parser.py`**
- Update existing `test_unicode_decode_error_returns_partial` assertion to verify offset advances past the bad line
- Add `test_unicode_decode_error_offset_advances_past_bad_line` regression test that:
  - Patches `model_validate_json` to raise `UnicodeDecodeError` on a specific line
  - Verifies events before the error are returned
  - Verifies `safe_offset` advances past the bad line
  - Verifies a warning is emitted
  - Verifies a subsequent call from the returned offset parses the next line without re-encountering the bad one




> [!WARNING]
> <details>
> <summary><strong>⚠️ Firewall blocked 2 domains</strong></summary>
>
> The following domains were blocked by the firewall during workflow execution:
>
> - `astral.sh`
> - `pypi.org`
>
> To allow these domains, add them to the `network.allowed` list in your workflow frontmatter:
>
> ```yaml
> network:
>   allowed:
>     - defaults
>     - "astral.sh"
>     - "pypi.org"
> ```
>
> See [Network Configuration](https://github.github.com/gh-aw/reference/network/) for more information.
>
> </details>


> Generated by [Issue Implementer](https://github.com/microsasa/cli-tools/actions/runs/25231723976/agentic_workflow) · ● 17.5M · [◷](https://github.com/search?q=repo%3Amicrosasa%2Fcli-tools+%22gh-aw-workflow-id%3A+issue-implementer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Issue Implementer, engine: copilot, model: claude-opus-4.6, id: 25231723976, workflow_id: issue-implementer, run: https://github.com/microsasa/cli-tools/actions/runs/25231723976 -->

<!-- gh-aw-workflow-id: issue-implementer -->