### PR TITLE
fix: surface unknown-model active tokens in model breakdown table (#1152)

### DIFF
--- a/src/copilot_usage/models.py
+++ b/src/copilot_usage/models.py
@@ -482,9 +482,16 @@ def total_output_tokens(session: SessionSummary) -> int:
     When ``model_metrics`` is empty the baseline is zero, so the active
     tokens are the only source and are included unconditionally.
 
-    Pure-active sessions (no shutdown data) already mirror
-    ``active_output_tokens`` inside ``model_metrics``, so adding them again
+    Pure-active sessions (no shutdown data) where model detection succeeded
+    mirror ``active_output_tokens`` inside ``model_metrics``, so
+    ``not model_metrics`` is ``False`` and the function returns only the
+    baseline (the mirrored value) — adding ``active_output_tokens`` again
     would double-count.
+
+    When model detection fails (``model`` is ``None``), however,
+    ``model_metrics`` is ``{}`` and ``not model_metrics`` is ``True``, so
+    the function returns ``baseline + active_output_tokens = 0 + active``.
+    Neither path double-counts.
     """
     baseline = shutdown_output_tokens(session)
     if (

--- a/src/copilot_usage/report.py
+++ b/src/copilot_usage/report.py
@@ -26,6 +26,7 @@ from copilot_usage._formatting import (
 from copilot_usage.models import (
     ModelMetrics,
     SessionSummary,
+    TokenUsage,
     add_to_model_metrics,
     copy_model_metrics,
     ensure_aware,
@@ -257,6 +258,9 @@ def _filter_sessions(
     return filtered
 
 
+_UNKNOWN_MODEL_LABEL: Final[str] = "(unknown)"
+
+
 def _aggregate_model_metrics(
     sessions: list[SessionSummary],
 ) -> dict[str, ModelMetrics]:
@@ -264,6 +268,11 @@ def _aggregate_model_metrics(
 
     Accumulates in-place so each unique model name is copied at most once,
     reducing copy overhead from O(n × m) to O(m).
+
+    Sessions with empty ``model_metrics``, no shutdown metrics, and positive
+    ``active_output_tokens`` contribute their tokens under an ``"(unknown)"``
+    synthetic key so the model breakdown table accounts for all tokens visible
+    in the totals panel.
     """
     result: dict[str, ModelMetrics] = {}
     for s in sessions:
@@ -272,6 +281,20 @@ def _aggregate_model_metrics(
                 add_to_model_metrics(result[model_name], mm)
             else:
                 result[model_name] = copy_model_metrics(mm)
+
+        # Surface unattributed active tokens that would otherwise be invisible.
+        if (
+            not s.model_metrics
+            and not s.has_shutdown_metrics
+            and s.active_output_tokens > 0
+        ):
+            unknown_mm = ModelMetrics(
+                usage=TokenUsage(outputTokens=s.active_output_tokens),
+            )
+            if _UNKNOWN_MODEL_LABEL in result:
+                add_to_model_metrics(result[_UNKNOWN_MODEL_LABEL], unknown_mm)
+            else:
+                result[_UNKNOWN_MODEL_LABEL] = unknown_mm
     return result
 
 

--- a/tests/copilot_usage/test_models.py
+++ b/tests/copilot_usage/test_models.py
@@ -1172,6 +1172,26 @@ class TestTotalOutputTokens:
         )
         assert total_output_tokens(session) == 75
 
+    def test_case_e_unknown_model_active_tokens(self) -> None:
+        """Issue #1152: model=None with active_output_tokens and empty
+        model_metrics falls through the ``not model_metrics`` branch.
+
+        This is the exact state produced by ``_build_active_summary`` when
+        model detection fails.  ``total_output_tokens`` must return the
+        active tokens (250), not zero.
+        """
+        session = SessionSummary(
+            session_id="case-e",
+            model=None,
+            is_active=True,
+            model_calls=3,
+            active_model_calls=3,
+            active_output_tokens=250,
+            model_metrics={},
+            has_shutdown_metrics=False,
+        )
+        assert total_output_tokens(session) == 250
+
 
 # ---------------------------------------------------------------------------
 # has_active_period_stats

--- a/tests/copilot_usage/test_report.py
+++ b/tests/copilot_usage/test_report.py
@@ -61,6 +61,7 @@ from copilot_usage.report import (
     _format_session_running_time,
     _render_model_table,
     _render_session_table,
+    _UNKNOWN_MODEL_LABEL,
     render_cost_view,
     render_full_summary,
     render_live_sessions,
@@ -6405,3 +6406,126 @@ class TestRenderCostViewNoRedundantTotalOutputTokens:
             "total_output_tokens should not be called for resumed sessions "
             "with model_metrics"
         )
+
+
+# ---------------------------------------------------------------------------
+# Issue #1152 — unknown-model active sessions must appear in model breakdown
+# ---------------------------------------------------------------------------
+
+
+class TestRenderSummaryUnknownModelTokens:
+    """Fix #1152: pure-active sessions with model=None and active_output_tokens
+    must surface an ``(unknown)`` row in the model breakdown table so that the
+    totals panel and model table agree."""
+
+    @staticmethod
+    def _unknown_model_session() -> SessionSummary:
+        """Mirror the exact state produced by ``_build_active_summary``
+        when model detection fails entirely."""
+        return SessionSummary(
+            session_id="no-model-active-unk",
+            model=None,
+            is_active=True,
+            model_calls=3,
+            active_model_calls=3,
+            active_output_tokens=250,
+            model_metrics={},
+        )
+
+    def test_totals_panel_shows_output_tokens(self) -> None:
+        """Totals panel must include the 250 active output tokens."""
+        session = self._unknown_model_session()
+        output = _capture_summary([session])
+        expected = format_tokens(250)
+        assert expected in output, (
+            f"Expected totals panel to contain '{expected}', got:\n{output}"
+        )
+
+    def test_model_breakdown_shows_unknown_row(self) -> None:
+        """Model breakdown table must contain an '(unknown)' row with 250 tokens."""
+        session = self._unknown_model_session()
+        output = _capture_summary([session])
+        assert _UNKNOWN_MODEL_LABEL in output, (
+            f"Expected model breakdown to contain '{_UNKNOWN_MODEL_LABEL}', "
+            f"got:\n{output}"
+        )
+        expected = format_tokens(250)
+        clean = re.sub(r"\x1b\[[0-9;]*m", "", output)
+        lines = clean.splitlines()
+        unknown_row = next(
+            (line for line in lines if _UNKNOWN_MODEL_LABEL in line), None
+        )
+        assert unknown_row is not None, (
+            f"No row containing '{_UNKNOWN_MODEL_LABEL}' found"
+        )
+        assert expected in unknown_row, (
+            f"Expected '{expected}' in unknown row, got: {unknown_row}"
+        )
+
+    def test_known_model_session_no_unknown_row(self) -> None:
+        """A completed session with a known model must NOT get an (unknown) row."""
+        session = _make_summary_session()
+        output = _capture_summary([session])
+        assert _UNKNOWN_MODEL_LABEL not in output, (
+            f"Known-model session should not produce '{_UNKNOWN_MODEL_LABEL}' row"
+        )
+        assert "claude-opus-4.6-1m" in output
+
+    def test_aggregate_model_metrics_unknown_bucket(self) -> None:
+        """_aggregate_model_metrics must create an (unknown) entry for
+        sessions with empty model_metrics, no shutdown, and active tokens."""
+        session = self._unknown_model_session()
+        merged = _aggregate_model_metrics([session])
+        assert _UNKNOWN_MODEL_LABEL in merged
+        assert merged[_UNKNOWN_MODEL_LABEL].usage.outputTokens == 250
+
+    def test_aggregate_model_metrics_accumulates_unknown(self) -> None:
+        """Multiple unknown-model sessions accumulate into one (unknown) bucket."""
+        s1 = SessionSummary(
+            session_id="unk-1",
+            model=None,
+            is_active=True,
+            model_calls=1,
+            active_model_calls=1,
+            active_output_tokens=100,
+            model_metrics={},
+        )
+        s2 = SessionSummary(
+            session_id="unk-2",
+            model=None,
+            is_active=True,
+            model_calls=2,
+            active_model_calls=2,
+            active_output_tokens=150,
+            model_metrics={},
+        )
+        merged = _aggregate_model_metrics([s1, s2])
+        assert _UNKNOWN_MODEL_LABEL in merged
+        assert merged[_UNKNOWN_MODEL_LABEL].usage.outputTokens == 250
+
+    def test_aggregate_skips_zero_active_tokens(self) -> None:
+        """Sessions with empty model_metrics but zero active tokens must NOT
+        produce an (unknown) row."""
+        session = SessionSummary(
+            session_id="unk-zero",
+            model=None,
+            is_active=True,
+            model_metrics={},
+            active_output_tokens=0,
+        )
+        merged = _aggregate_model_metrics([session])
+        assert _UNKNOWN_MODEL_LABEL not in merged
+
+    def test_aggregate_skips_session_with_shutdown_metrics(self) -> None:
+        """Sessions with has_shutdown_metrics=True are NOT eligible for
+        the (unknown) bucket even if model_metrics is empty."""
+        session = SessionSummary(
+            session_id="unk-shutdown",
+            model=None,
+            is_active=False,
+            has_shutdown_metrics=True,
+            model_metrics={},
+            active_output_tokens=100,
+        )
+        merged = _aggregate_model_metrics([session])
+        assert _UNKNOWN_MODEL_LABEL not in merged


### PR DESCRIPTION
Closes #1152

## Problem

When model detection fails entirely (`model` is `None`), `_build_active_summary` creates an empty `model_metrics` dict even when `active_output_tokens > 0`. The `_aggregate_model_metrics` function only iterates `s.model_metrics.items()`, so these tokens are completely invisible in the model breakdown table — even though the totals panel correctly shows them via `total_output_tokens()`.

## Changes

### 1. `_aggregate_model_metrics` — `(unknown)` synthetic row (`report.py`)
When a session has:
- Empty `model_metrics`
- No shutdown metrics (`has_shutdown_metrics=False`)
- Positive `active_output_tokens`

its tokens are now accumulated under an `"(unknown)"` key in the model breakdown table, making all token sources visible.

### 2. `total_output_tokens()` docstring fix (`models.py`)
The old docstring falsely claimed that pure-active sessions always mirror `active_output_tokens` inside `model_metrics`. This is only true when model detection succeeds. The updated docstring accurately describes both code paths (model known vs. model unknown).

### 3. Tests
- **`TestRenderSummaryUnknownModelTokens`** (`test_report.py`) — 7 tests covering:
  - Totals panel shows the tokens
  - Model breakdown table shows `(unknown)` row with correct token count
  - Known-model sessions produce no `(unknown)` row
  - `_aggregate_model_metrics` creates/accumulates the `(unknown)` bucket
  - Zero active tokens → no `(unknown)` row
  - Sessions with shutdown metrics → no `(unknown)` row

- **`test_case_e_unknown_model_active_tokens`** (`test_models.py`) — covers the `not model_metrics` branch in `total_output_tokens()` with the exact state from `_build_active_summary` when model is `None`.




> [!WARNING]
> <details>
> <summary><strong>⚠️ Firewall blocked 3 domains</strong></summary>
>
> The following domains were blocked by the firewall during workflow execution:
>
> - `astral.sh`
> - `pypi.org`
> - `releaseassets.githubusercontent.com`
>
> To allow these domains, add them to the `network.allowed` list in your workflow frontmatter:
>
> ```yaml
> network:
>   allowed:
>     - defaults
>     - "astral.sh"
>     - "pypi.org"
>     - "releaseassets.githubusercontent.com"
> ```
>
> See [Network Configuration](https://github.github.com/gh-aw/reference/network/) for more information.
>
> </details>


> Generated by [Issue Implementer](https://github.com/microsasa/cli-tools/actions/runs/25245619840/agentic_workflow) · ● 20.9M · [◷](https://github.com/search?q=repo%3Amicrosasa%2Fcli-tools+%22gh-aw-workflow-id%3A+issue-implementer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Issue Implementer, engine: copilot, model: claude-opus-4.6, id: 25245619840, workflow_id: issue-implementer, run: https://github.com/microsasa/cli-tools/actions/runs/25245619840 -->

<!-- gh-aw-workflow-id: issue-implementer -->