### PR TITLE
test: cover all EventType enum string values (#1154)

### DIFF
--- a/tests/copilot_usage/test_models.py
+++ b/tests/copilot_usage/test_models.py
@@ -86,13 +86,47 @@ RAW_USER_MESSAGE = json.loads(
 # ---------------------------------------------------------------------------
 
 
-def test_event_type_values() -> None:
-    assert EventType.SESSION_START == "session.start"
-    assert EventType.SESSION_SHUTDOWN == "session.shutdown"
-    assert EventType.ASSISTANT_MESSAGE == "assistant.message"
-    assert EventType.TOOL_EXECUTION_COMPLETE == "tool.execution_complete"
-    assert EventType.USER_MESSAGE == "user.message"
-    assert EventType.ABORT == "abort"
+@pytest.mark.parametrize(
+    ("member", "expected"),
+    [
+        (EventType.SESSION_START, "session.start"),
+        (EventType.SESSION_SHUTDOWN, "session.shutdown"),
+        (EventType.SESSION_RESUME, "session.resume"),
+        (EventType.SESSION_ERROR, "session.error"),
+        (EventType.SESSION_PLAN_CHANGED, "session.plan_changed"),
+        (EventType.SESSION_WORKSPACE_FILE_CHANGED, "session.workspace_file_changed"),
+        (EventType.ASSISTANT_MESSAGE, "assistant.message"),
+        (EventType.ASSISTANT_TURN_START, "assistant.turn_start"),
+        (EventType.ASSISTANT_TURN_END, "assistant.turn_end"),
+        (EventType.TOOL_EXECUTION_START, "tool.execution_start"),
+        (EventType.TOOL_EXECUTION_COMPLETE, "tool.execution_complete"),
+        (EventType.USER_MESSAGE, "user.message"),
+        (EventType.ABORT, "abort"),
+    ],
+)
+def test_event_type_string_values(member: EventType, expected: str) -> None:
+    """Every EventType member must equal its documented wire-format string."""
+    assert member == expected
+
+
+def test_event_type_all_members_covered() -> None:
+    """Parametrized test above must cover every member (fails if a new one is added without updating)."""
+    documented = {
+        "session.start",
+        "session.shutdown",
+        "session.resume",
+        "session.error",
+        "session.plan_changed",
+        "session.workspace_file_changed",
+        "assistant.message",
+        "assistant.turn_start",
+        "assistant.turn_end",
+        "tool.execution_start",
+        "tool.execution_complete",
+        "user.message",
+        "abort",
+    }
+    assert {str(m) for m in EventType} == documented
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #1154

## Summary

Replace the incomplete `test_event_type_values` test (covering only 6 of 13 `EventType` members) with two robust tests:

1. **`test_event_type_string_values`** — parametrized test that asserts every `EventType` member equals its expected wire-format string literal. Covers all 13 members including the previously untested `SESSION_RESUME`, `ASSISTANT_TURN_START`, `ASSISTANT_TURN_END`, `TOOL_EXECUTION_START`, `SESSION_ERROR`, `SESSION_PLAN_CHANGED`, and `SESSION_WORKSPACE_FILE_CHANGED`.

2. **`test_event_type_all_members_covered`** — membership completeness guard that fails if a new enum member is added without updating the parametrized test.

## Why this matters

- `SESSION_RESUME` is used in `_first_pass` event routing — a wrong string value would silently break active-session detection.
- `ASSISTANT_TURN_START` drives `model_calls` counting — a typo would zero out model call metrics.
- Neither had any test coverage before this change.




> [!WARNING]
> <details>
> <summary><strong>⚠️ Firewall blocked 4 domains</strong></summary>
>
> The following domains were blocked by the firewall during workflow execution:
>
> - `astral.sh`
> - `index.crates.io`
> - `pypi.org`
> - `releaseassets.githubusercontent.com`
>
> To allow these domains, add them to the `network.allowed` list in your workflow frontmatter:
>
> ```yaml
> network:
>   allowed:
>     - defaults
>     - "astral.sh"
>     - "index.crates.io"
>     - "pypi.org"
>     - "releaseassets.githubusercontent.com"
> ```
>
> See [Network Configuration](https://github.github.com/gh-aw/reference/network/) for more information.
>
> </details>


> Generated by [Issue Implementer](https://github.com/microsasa/cli-tools/actions/runs/25249091311/agentic_workflow) · ● 8.6M · [◷](https://github.com/search?q=repo%3Amicrosasa%2Fcli-tools+%22gh-aw-workflow-id%3A+issue-implementer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Issue Implementer, engine: copilot, model: claude-opus-4.6, id: 25249091311, workflow_id: issue-implementer, run: https://github.com/microsasa/cli-tools/actions/runs/25249091311 -->

<!-- gh-aw-workflow-id: issue-implementer -->