### PR TITLE
test: add pure-active session output-token double-count coverage (#1155)

### DIFF
--- a/tests/copilot_usage/test_render_detail.py
+++ b/tests/copilot_usage/test_render_detail.py
@@ -850,6 +850,37 @@ class TestRenderSessionDetailActivePeriod:
         output = _strip_ansi(buf.getvalue())
         assert "Active Period" in output
 
+    def test_pure_active_session_aggregate_stats_token_count(self) -> None:
+        """render_session_detail Aggregate Stats panel shows correct (non-doubled) tokens."""
+        summary = SessionSummary(
+            session_id="pure-active-e2e-tok",
+            start_time=datetime(2026, 4, 1, 10, 0, 0, tzinfo=UTC),
+            is_active=True,
+            has_shutdown_metrics=False,
+            model_calls=2,
+            user_messages=1,
+            active_model_calls=2,
+            active_user_messages=1,
+            active_output_tokens=500,
+            model_metrics={
+                "claude-sonnet-4": ModelMetrics(
+                    usage=TokenUsage(outputTokens=500),
+                )
+            },
+        )
+        ev = SessionEvent(
+            type=EventType.USER_MESSAGE,
+            timestamp=datetime(2026, 4, 1, 10, 5, 0, tzinfo=UTC),
+            data={"content": "test"},
+        )
+        buf, console = _buf_console()
+        render_session_detail([ev], summary, target_console=console)
+        output = _strip_ansi(buf.getvalue())
+
+        assert "Aggregate Stats" in output
+        assert "500" in output
+        assert "1000" not in output  # double-count must not appear
+
 
 # ---------------------------------------------------------------------------
 # _event_type_label — parametrized unit tests (issue #879)

--- a/tests/copilot_usage/test_report.py
+++ b/tests/copilot_usage/test_report.py
@@ -939,6 +939,33 @@ class TestRenderAggregateStatsDirect:
         output = _capture_console(_render_aggregate_stats, summary)
         assert "1m" in output
 
+    def test_pure_active_session_output_tokens_not_double_counted(self) -> None:
+        """Pure-active session: Aggregate Stats shows model_metrics tokens, not 2× that value."""
+        summary = SessionSummary(
+            session_id="pure-active-agg",
+            is_active=True,
+            has_shutdown_metrics=False,
+            model_calls=4,
+            user_messages=3,
+            active_model_calls=4,
+            active_user_messages=3,
+            active_output_tokens=800,
+            model_metrics={
+                "gpt-4": ModelMetrics(
+                    usage=TokenUsage(outputTokens=800),
+                )
+            },
+        )
+
+        output = _capture_console(_render_aggregate_stats, summary)
+
+        # Should show 800, NOT 1600 (double-count)
+        assert "800" in output, "Expected 800 output tokens in Aggregate Stats"
+        assert "1600" not in output, "Double-counted token value must not appear"
+        assert (
+            "1.6K" not in output
+        ), "Double-counted token value must not appear as formatted K value"
+
 
 # ---------------------------------------------------------------------------
 # format_tokens tests


### PR DESCRIPTION
Closes #1155

## Summary

Adds two tests covering the missing pure-active session output-token verification in `_render_aggregate_stats` and `render_session_detail`.

### Tests added

1. **`TestRenderAggregateStatsDirect.test_pure_active_session_output_tokens_not_double_counted`** (`test_report.py`)
   - Direct unit test for `_render_aggregate_stats` with a pure-active session (`is_active=True`, `has_shutdown_metrics=False`)
   - Asserts output shows `800` tokens (from `model_metrics`), not `1600` (double-count)

2. **`TestRenderSessionDetailActivePeriod.test_pure_active_session_aggregate_stats_token_count`** (`test_render_detail.py`)
   - Integration test calling `render_session_detail` end-to-end
   - Asserts Aggregate Stats panel shows `500` tokens, not `1000`

### Regression scenario covered

If `total_output_tokens` is refactored to unconditionally add `active_output_tokens` to the baseline, these tests will fail — catching the double-count before it reaches users.




> [!WARNING]
> <details>
> <summary><strong>⚠️ Firewall blocked 3 domains</strong></summary>
>
> The following domains were blocked by the firewall during workflow execution:
>
> - `astral.sh`
> - `index.crates.io`
> - `pypi.org`
>
> To allow these domains, add them to the `network.allowed` list in your workflow frontmatter:
>
> ```yaml
> network:
>   allowed:
>     - defaults
>     - "astral.sh"
>     - "index.crates.io"
>     - "pypi.org"
> ```
>
> See [Network Configuration](https://github.github.com/gh-aw/reference/network/) for more information.
>
> </details>


> Generated by [Issue Implementer](https://github.com/microsasa/cli-tools/actions/runs/25249260997/agentic_workflow) · ● 9.8M · [◷](https://github.com/search?q=repo%3Amicrosasa%2Fcli-tools+%22gh-aw-workflow-id%3A+issue-implementer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Issue Implementer, engine: copilot, model: claude-opus-4.6, id: 25249260997, workflow_id: issue-implementer, run: https://github.com/microsasa/cli-tools/actions/runs/25249260997 -->

<!-- gh-aw-workflow-id: issue-implementer -->