### PR TITLE
fix: replace bare `except Exception` with specific types in `_reader` (#1157)

### DIFF
--- a/src/copilot_usage/cli.py
+++ b/src/copilot_usage/cli.py
@@ -199,7 +199,7 @@ def _start_input_reader_thread() -> queue.SimpleQueue[str]:
             except (EOFError, KeyboardInterrupt):
                 q.put(_FALLBACK_EOF)
                 break
-            except Exception as exc:
+            except (ValueError, OSError) as exc:
                 logger.warning(
                     "Unexpected stdin error in fallback reader thread: {}", exc
                 )

--- a/tests/copilot_usage/test_cli.py
+++ b/tests/copilot_usage/test_cli.py
@@ -24,11 +24,13 @@ from copilot_usage import __version__
 from copilot_usage.cli import (
     _build_session_index,
     _DateTimeOrDate,
+    _FALLBACK_EOF,
     _normalize_until,
     _ParsedDateArg,
     _print_version_header,
     _read_line_nonblocking,
     _show_session_by_index,
+    _start_input_reader_thread,
     _start_observer,
     _stop_observer,
     _validate_since_until,
@@ -4064,3 +4066,22 @@ class TestSingleConsolePerCommand:
         assert "Copilot Usage" in output
         assert f"v{__version__}" in output
         assert "VS Code Copilot Chat" in output
+
+
+# ---------------------------------------------------------------------------
+# _start_input_reader_thread
+# ---------------------------------------------------------------------------
+
+
+class TestStartInputReaderThread:
+    """Tests for _start_input_reader_thread."""
+
+    def test_value_error_puts_fallback_eof(self) -> None:
+        """ValueError from input() (closed stdin) enqueues _FALLBACK_EOF."""
+        with patch(
+            "builtins.input",
+            side_effect=ValueError("I/O operation on closed file"),
+        ):
+            q = _start_input_reader_thread()
+            result = q.get(timeout=2)
+        assert result == _FALLBACK_EOF


### PR DESCRIPTION
Closes #1157

## Changes

**`src/copilot_usage/cli.py`** — Replace the catch-all `except Exception` in `_start_input_reader_thread._reader` with `except (ValueError, OSError)`, the two specific exception types that `input()` can raise beyond `EOFError`/`KeyboardInterrupt`:

- `ValueError` — raised when the underlying `sys.stdin` buffer is closed
- `OSError` — raised for underlying I/O failures on the file descriptor

This brings the code into compliance with the error handling guideline: *"Catch specific exception types. Never use bare `except:` or `except Exception:` unless re-raising."*

**`tests/copilot_usage/test_cli.py`** — Add `TestStartInputReaderThread.test_value_error_puts_fallback_eof` which patches `input()` to raise `ValueError`, calls `_start_input_reader_thread()`, and asserts that `_FALLBACK_EOF` is enqueued.




> [!WARNING]
> <details>
> <summary><strong>⚠️ Firewall blocked 4 domains</strong></summary>
>
> The following domains were blocked by the firewall during workflow execution:
>
> - `astral.sh`
> - `index.crates.io`
> - `pypi.org`
> - `releaseassets.githubusercontent.com`
>
> To allow these domains, add them to the `network.allowed` list in your workflow frontmatter:
>
> ```yaml
> network:
>   allowed:
>     - defaults
>     - "astral.sh"
>     - "index.crates.io"
>     - "pypi.org"
>     - "releaseassets.githubusercontent.com"
> ```
>
> See [Network Configuration](https://github.github.com/gh-aw/reference/network/) for more information.
>
> </details>


> Generated by [Issue Implementer](https://github.com/microsasa/cli-tools/actions/runs/25249637006/agentic_workflow) · ● 9.5M · [◷](https://github.com/search?q=repo%3Amicrosasa%2Fcli-tools+%22gh-aw-workflow-id%3A+issue-implementer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Issue Implementer, engine: copilot, model: claude-opus-4.6, id: 25249637006, workflow_id: issue-implementer, run: https://github.com/microsasa/cli-tools/actions/runs/25249637006 -->

<!-- gh-aw-workflow-id: issue-implementer -->