### PR TITLE
fix: set `_ps_resumed` for `ASSISTANT_TURN_START` after shutdown (#1165)

### DIFF
--- a/src/copilot_usage/parser.py
+++ b/src/copilot_usage/parser.py
@@ -854,6 +854,7 @@ def _first_pass(events: list[SessionEvent]) -> _FirstPassResult:
             total_turn_starts += 1
             if _shutdowns:
                 _ps_turn_starts += 1
+                _ps_resumed = True
 
         elif etype == EventType.ASSISTANT_MESSAGE:
             if (tokens := _extract_output_tokens(ev)) is not None:

--- a/tests/copilot_usage/test_parser.py
+++ b/tests/copilot_usage/test_parser.py
@@ -2123,6 +2123,99 @@ class TestBuildSessionSummaryResumed:
         assert summary.active_output_tokens == 120
         assert summary.active_user_messages == 0
 
+    def test_turn_start_alone_marks_resumed(self, tmp_path: Path) -> None:
+        """Shutdown → ASSISTANT_TURN_START (no ASSISTANT_MESSAGE) → is_active=True."""
+        post_turn_start = json.dumps(
+            {
+                "type": "assistant.turn_start",
+                "data": {"turnId": "99", "interactionId": "int-inflight"},
+                "id": "ev-ts-noresume",
+                "timestamp": "2026-03-07T12:01:01.000Z",
+                "parentId": "ev-shutdown",
+            }
+        )
+        p = tmp_path / "s" / "events.jsonl"
+        _write_events(
+            p,
+            _START_EVENT,
+            _USER_MSG,
+            _ASSISTANT_MSG,
+            _SHUTDOWN_EVENT,
+            post_turn_start,
+        )
+        events = parse_events(p)
+        summary = build_session_summary(events)
+        assert summary.is_active is True
+        assert summary.active_model_calls == 1
+        assert summary.active_output_tokens == 0
+        assert summary.last_resume_time is None
+
+    def test_turn_start_then_assistant_message_marks_resumed(
+        self, tmp_path: Path
+    ) -> None:
+        """Shutdown → ASSISTANT_TURN_START + ASSISTANT_MESSAGE → is_active=True."""
+        post_turn_start = json.dumps(
+            {
+                "type": "assistant.turn_start",
+                "data": {"turnId": "99", "interactionId": "int-inflight"},
+                "id": "ev-ts-combined",
+                "timestamp": "2026-03-07T12:01:01.000Z",
+                "parentId": "ev-shutdown",
+            }
+        )
+        post_asst = json.dumps(
+            {
+                "type": "assistant.message",
+                "data": {
+                    "messageId": "m-combined",
+                    "content": "done",
+                    "toolRequests": [],
+                    "interactionId": "int-inflight",
+                    "outputTokens": 200,
+                },
+                "id": "ev-a-combined",
+                "timestamp": "2026-03-07T12:01:05.000Z",
+                "parentId": "ev-ts-combined",
+            }
+        )
+        p = tmp_path / "s" / "events.jsonl"
+        _write_events(
+            p,
+            _START_EVENT,
+            _USER_MSG,
+            _ASSISTANT_MSG,
+            _SHUTDOWN_EVENT,
+            post_turn_start,
+            post_asst,
+        )
+        events = parse_events(p)
+        summary = build_session_summary(events)
+        assert summary.is_active is True
+        assert summary.active_model_calls == 1
+        assert summary.active_output_tokens == 200
+
+    def test_pure_active_session_unaffected_by_turn_start_fix(
+        self, tmp_path: Path
+    ) -> None:
+        """Session with no shutdown → is_active=True with correct totals."""
+        p = tmp_path / "s" / "events.jsonl"
+        _write_events(
+            p,
+            _START_EVENT,
+            _USER_MSG,
+            _TURN_START_1,
+            _ASSISTANT_MSG,
+            _TURN_START_2,
+            _ASSISTANT_MSG_2,
+        )
+        events = parse_events(p)
+        summary = build_session_summary(events)
+        assert summary.is_active is True
+        assert summary.model_calls == 2
+        assert summary.active_model_calls == 2
+        assert summary.user_messages == 1
+        assert summary.active_user_messages == 1
+
     def test_model_inferred_from_highest_request_count(self, tmp_path: Path) -> None:
         """Shutdown with multiple models, no currentModel → picks highest requests.count."""
         shutdown_multi = json.dumps(


### PR DESCRIPTION
Closes #1165

## Problem

In `_first_pass`, the `ASSISTANT_TURN_START` branch incremented `_ps_turn_starts` when occurring after a shutdown but never set `_ps_resumed = True`. This caused in-flight sessions (with an active model turn that hasn't yet produced an `ASSISTANT_MESSAGE`) to be incorrectly reported as `is_active=False` with `active_model_calls=0`, silently discarding the accumulated post-shutdown turn starts.

## Fix

Add `_ps_resumed = True` to the `ASSISTANT_TURN_START` branch when `_shutdowns` is non-empty, making it consistent with the `USER_MESSAGE` and `ASSISTANT_MESSAGE` branches.

## Tests Added

Three regression tests in `TestBuildSessionSummaryResumed`:

1. **`test_turn_start_alone_marks_resumed`** — Shutdown followed by a single `ASSISTANT_TURN_START` (no `ASSISTANT_MESSAGE`) → `is_active=True`, `active_model_calls=1`
2. **`test_turn_start_then_assistant_message_marks_resumed`** — Shutdown followed by `ASSISTANT_TURN_START` + `ASSISTANT_MESSAGE` → `is_active=True`, `active_model_calls=1`, `active_output_tokens=200`
3. **`test_pure_active_session_unaffected_by_turn_start_fix`** — Session with no shutdown → `is_active=True` with correct total counters (no regression)




> [!WARNING]
> <details>
> <summary><strong>⚠️ Firewall blocked 2 domains</strong></summary>
>
> The following domains were blocked by the firewall during workflow execution:
>
> - `astral.sh`
> - `pypi.org`
>
> To allow these domains, add them to the `network.allowed` list in your workflow frontmatter:
>
> ```yaml
> network:
>   allowed:
>     - defaults
>     - "astral.sh"
>     - "pypi.org"
> ```
>
> See [Network Configuration](https://github.github.com/gh-aw/reference/network/) for more information.
>
> </details>


> Generated by [Issue Implementer](https://github.com/microsasa/cli-tools/actions/runs/25262511009/agentic_workflow) · ● 12.6M · [◷](https://github.com/search?q=repo%3Amicrosasa%2Fcli-tools+%22gh-aw-workflow-id%3A+issue-implementer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Issue Implementer, engine: copilot, model: claude-opus-4.6, id: 25262511009, workflow_id: issue-implementer, run: https://github.com/microsasa/cli-tools/actions/runs/25262511009 -->

<!-- gh-aw-workflow-id: issue-implementer -->