### PR TITLE
fix: update stale interactive-loop snippets in implementation.md (#1167)

### DIFF
--- a/src/copilot_usage/docs/implementation.md
+++ b/src/copilot_usage/docs/implementation.md
@@ -242,18 +242,24 @@ The loop uses `select.select()` on stdin (in `cli.py`) with a 500ms timeout:
 def _read_line_nonblocking(timeout: float = 0.5) -> str | None:
     ready, _, _ = select.select([sys.stdin], [], [], timeout)
     if ready:
-        return sys.stdin.readline().strip()
+        line = sys.stdin.readline()
+        if not line:
+            raise EOFError("stdin closed")
+        return line.strip()
     return None
 ```
 
-This is **Unix only** — `select()` on stdin doesn't work on Windows. The 500ms timeout allows the main loop to check for file-change events between input polls.
+This is **Unix only** — `select()` on stdin doesn't work on Windows. The 500ms timeout allows the main loop to check for file-change events between input polls. When `readline()` returns an empty string (stdin closed), `_read_line_nonblocking` raises `EOFError` to prevent an infinite polling loop.
 
 ### Fallback to threaded `_start_input_reader_thread()`
 
-If `select()` raises `ValueError` or `OSError` (e.g. stdin is not selectable, notably on Windows, or stdin is detached during testing), the loop starts a daemon thread via `_start_input_reader_thread()` (in `cli.py`) that feeds lines into a `queue.SimpleQueue`:
+If `_read_line_nonblocking` raises `EOFError` (stdin closed), the main loop breaks immediately — no fallback reader is started. If it raises `ValueError` or `OSError` (e.g. stdin is not selectable, notably on Windows, or stdin is detached during testing), the loop starts a daemon thread via `_start_input_reader_thread()` (in `cli.py`) that feeds lines into a `queue.SimpleQueue`:
 
 ```python
+except EOFError:
+    break
 except (ValueError, OSError):
+    # stdin not selectable — start a threaded input() reader
     fallback_queue = _start_input_reader_thread()
     line = None
 ```

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -1,4 +1,5 @@
 import importlib
+import inspect
 import re
 from pathlib import Path
 
@@ -305,3 +306,31 @@ def test_active_fields_document_pure_active_semantics() -> None:
             f"'resumed sessions only' — the field is also populated "
             f"for pure-active sessions"
         )
+
+
+def test_read_line_nonblocking_doc_snippet_matches_implementation() -> None:
+    """The _read_line_nonblocking and fallback-reader snippets in
+    implementation.md must reflect the EOFError handling present in the
+    actual implementation."""
+    from copilot_usage import cli as cli_mod
+
+    # _read_line_nonblocking must mention EOFError (source or docstring)
+    read_src = inspect.getsource(cli_mod._read_line_nonblocking)
+    assert "EOFError" in read_src, (
+        "_read_line_nonblocking source must reference EOFError — "
+        "the function raises EOFError when stdin is closed"
+    )
+
+    # _interactive_loop must have 'except EOFError' near the
+    # ValueError/OSError fallback logic
+    loop_src = inspect.getsource(cli_mod._interactive_loop)
+    assert "except EOFError" in loop_src, (
+        "_interactive_loop source must contain 'except EOFError' — "
+        "the loop breaks immediately when stdin is closed"
+    )
+
+    # implementation.md must also mention EOFError in both snippets
+    assert "EOFError" in _IMPL_MD, (
+        "implementation.md must mention EOFError in the interactive "
+        "loop architecture section"
+    )


### PR DESCRIPTION
Closes #1167

## Changes

### Documentation (`src/copilot_usage/docs/implementation.md`)

1. **`_read_line_nonblocking` snippet** — Updated to match the actual implementation that checks for empty `readline()` and raises `EOFError("stdin closed")` to prevent infinite polling.

2. **Fallback reader snippet** — Added the `except EOFError: break` clause before `except (ValueError, OSError):` to reflect the actual control flow in `_interactive_loop`.

3. **Prose updates** — Updated the "Non-blocking input with `select()`" subsection to mention that `_read_line_nonblocking` raises `EOFError` when stdin is closed, and updated the fallback section to explain that `EOFError` causes an immediate loop break rather than starting the fallback reader.

### Tests (`tests/test_docs.py`)

Added `test_read_line_nonblocking_doc_snippet_matches_implementation` which:
- Asserts `EOFError` appears in `_read_line_nonblocking`'s source via `inspect.getsource`
- Asserts `except EOFError` appears in `_interactive_loop`'s source
- Asserts `EOFError` appears in `implementation.md`

This prevents the docs from silently diverging from the implementation again.




> [!WARNING]
> <details>
> <summary><strong>⚠️ Firewall blocked 2 domains</strong></summary>
>
> The following domains were blocked by the firewall during workflow execution:
>
> - `astral.sh`
> - `pypi.org`
>
> To allow these domains, add them to the `network.allowed` list in your workflow frontmatter:
>
> ```yaml
> network:
>   allowed:
>     - defaults
>     - "astral.sh"
>     - "pypi.org"
> ```
>
> See [Network Configuration](https://github.github.com/gh-aw/reference/network/) for more information.
>
> </details>


> Generated by [Issue Implementer](https://github.com/microsasa/cli-tools/actions/runs/25271384297/agentic_workflow) · ● 7.4M · [◷](https://github.com/search?q=repo%3Amicrosasa%2Fcli-tools+%22gh-aw-workflow-id%3A+issue-implementer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Issue Implementer, engine: copilot, model: claude-opus-4.6, id: 25271384297, workflow_id: issue-implementer, run: https://github.com/microsasa/cli-tools/actions/runs/25271384297 -->

<!-- gh-aw-workflow-id: issue-implementer -->