### PR TITLE
fix: guard `_read_line_nonblocking` against `sys.stdin is None` (#1170)

### DIFF
--- a/src/copilot_usage/cli.py
+++ b/src/copilot_usage/cli.py
@@ -215,13 +215,15 @@ def _read_line_nonblocking(timeout: float = 0.5) -> str | None:
     """Return a line from stdin if available within *timeout*, else ``None``.
 
     Uses ``select.select`` to poll stdin.  Raises :class:`ValueError` or
-    :class:`OSError` when stdin is not selectable (e.g. Windows, or a
-    detached stdin buffer in tests); callers should fall back to a threaded
-    reader in that case.
+    :class:`OSError` when stdin is not selectable (e.g. Windows, detached
+    stdin buffer in tests, or ``sys.stdin is None``); callers should fall
+    back to a threaded reader in that case.
 
     Raises :class:`EOFError` when stdin is closed (``readline()`` returns
     an empty string), preventing an infinite polling loop.
     """
+    if sys.stdin is None:
+        raise ValueError("stdin is None")
     ready, _, _ = select.select([sys.stdin], [], [], timeout)
     if ready:
         line = sys.stdin.readline()

--- a/src/copilot_usage/docs/implementation.md
+++ b/src/copilot_usage/docs/implementation.md
@@ -250,7 +250,7 @@ This is **Unix only** — `select()` on stdin doesn't work on Windows. The 500ms
 
 ### Fallback to threaded `_start_input_reader_thread()`
 
-If `select()` raises `ValueError` or `OSError` (e.g. stdin is not selectable, notably on Windows, or stdin is detached during testing), the loop starts a daemon thread via `_start_input_reader_thread()` (in `cli.py`) that feeds lines into a `queue.SimpleQueue`:
+If `select()` raises `ValueError` or `OSError` (e.g. stdin is not selectable, notably on Windows, stdin is detached during testing, or `sys.stdin is None`), the loop starts a daemon thread via `_start_input_reader_thread()` (in `cli.py`) that feeds lines into a `queue.SimpleQueue`:
 
 ```python
 except (ValueError, OSError):

--- a/tests/copilot_usage/test_cli.py
+++ b/tests/copilot_usage/test_cli.py
@@ -2168,10 +2168,32 @@ class TestReadLineNonblocking:
             r_file.close()
             os.close(w_fd)
 
+    def test_none_stdin_raises_value_error(self) -> None:
+        """When sys.stdin is None, _read_line_nonblocking raises ValueError."""
+        with patch("copilot_usage.cli.sys.stdin", None):
+            with pytest.raises(ValueError, match="stdin is None"):
+                _read_line_nonblocking(timeout=0.05)
+
 
 # ---------------------------------------------------------------------------
 # Gap 3 — _interactive_loop stdin fallback (issue #258)
 # ---------------------------------------------------------------------------
+
+
+def test_interactive_loop_none_stdin_falls_back_to_input(
+    tmp_path: Path, monkeypatch: Any
+) -> None:
+    """When sys.stdin is None, _interactive_loop must fall back to threaded input()."""
+    _write_session(tmp_path, "fb_none0-0000-0000-0000-000000000000", name="NoneStdin")
+
+    import copilot_usage.cli as cli_mod
+
+    monkeypatch.setattr(cli_mod.sys, "stdin", None)
+    monkeypatch.setattr("builtins.input", lambda *_: "q")
+
+    runner = CliRunner()
+    result = runner.invoke(main, ["--path", str(tmp_path)])
+    assert result.exit_code == 0
 
 
 def test_interactive_loop_select_value_error_falls_back_to_input(


### PR DESCRIPTION
Closes #1170

## Problem

When `sys.stdin is None` (e.g. process started with closed stdin, or certain test/CI environments), `select.select([None], [], [], timeout)` raises a `TypeError` that isn't caught by the `except (ValueError, OSError)` handler in `_interactive_loop`. This crashes the interactive session instead of falling back to the threaded reader.

## Fix

Added a `sys.stdin is None` guard at the top of `_read_line_nonblocking` that raises `ValueError("stdin is None")`, which the existing `except (ValueError, OSError)` handler in `_interactive_loop` already catches and handles via the threaded fallback.

### Changes

1. **`src/copilot_usage/cli.py`** — Added `if sys.stdin is None: raise ValueError("stdin is None")` guard and updated docstring to document `sys.stdin is None` as a trigger condition
2. **`src/copilot_usage/docs/implementation.md`** — Updated fallback documentation to include `sys.stdin is None` as a third triggering case
3. **`tests/copilot_usage/test_cli.py`** — Added:
   - `test_none_stdin_raises_value_error` in `TestReadLineNonblocking` class (unit test)
   - `test_interactive_loop_none_stdin_falls_back_to_input` in Gap 3 section (integration test)




> [!WARNING]
> <details>
> <summary><strong>⚠️ Firewall blocked 3 domains</strong></summary>
>
> The following domains were blocked by the firewall during workflow execution:
>
> - `astral.sh`
> - `pypi.org`
> - `releaseassets.githubusercontent.com`
>
> To allow these domains, add them to the `network.allowed` list in your workflow frontmatter:
>
> ```yaml
> network:
>   allowed:
>     - defaults
>     - "astral.sh"
>     - "pypi.org"
>     - "releaseassets.githubusercontent.com"
> ```
>
> See [Network Configuration](https://github.github.com/gh-aw/reference/network/) for more information.
>
> </details>


> Generated by [Issue Implementer](https://github.com/microsasa/cli-tools/actions/runs/25276100450/agentic_workflow) · ● 14.4M · [◷](https://github.com/search?q=repo%3Amicrosasa%2Fcli-tools+%22gh-aw-workflow-id%3A+issue-implementer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Issue Implementer, engine: copilot, model: claude-opus-4.6, id: 25276100450, workflow_id: issue-implementer, run: https://github.com/microsasa/cli-tools/actions/runs/25276100450 -->

<!-- gh-aw-workflow-id: issue-implementer -->