### PR TITLE
test: add partial-tail coverage for `parse_vscode_log` public API (#1173)

### DIFF
--- a/tests/copilot_usage/test_vscode_parser.py
+++ b/tests/copilot_usage/test_vscode_parser.py
@@ -210,6 +210,39 @@ class TestParseVscodeLog:
         result = parse_vscode_log(log_path)
         assert result == []
 
+    def test_parse_vscode_log_includes_partial_tail_single_line(
+        self, tmp_path: Path
+    ) -> None:
+        """parse_vscode_log returns the request even when the only line lacks '\\n'."""
+        log_file = tmp_path / "chat.log"
+        log_file.write_text(_make_log_line(req_idx=0).rstrip("\n"))
+        result = parse_vscode_log(log_file)
+        assert len(result) == 1
+        assert result[0].request_id == "req00000"
+
+    def test_parse_vscode_log_includes_partial_tail_after_complete_lines(
+        self, tmp_path: Path
+    ) -> None:
+        """parse_vscode_log returns all lines including a final unterminated ccreq line."""
+        log_file = tmp_path / "chat.log"
+        content = (
+            _make_log_line(req_idx=0)
+            + _make_log_line(req_idx=1)
+            + _make_log_line(req_idx=2).rstrip("\n")  # partial tail
+        )
+        log_file.write_text(content)
+        result = parse_vscode_log(log_file)
+        assert len(result) == 3
+        assert result[-1].request_id == "req00002"
+
+    def test_private_default_excludes_partial_tail(self, tmp_path: Path) -> None:
+        """_parse_vscode_log_from_offset with default include_partial_tail=False
+        drops the unterminated final line — confirming the public API adds value."""
+        log_file = tmp_path / "chat.log"
+        log_file.write_text(_make_log_line(req_idx=0).rstrip("\n"))
+        reqs, _ = _parse_vscode_log_from_offset(log_file, 0)
+        assert len(reqs) == 0  # private default excludes partial tail
+
 
 # ---------------------------------------------------------------------------
 # build_vscode_summary


### PR DESCRIPTION
Closes #1173

## Summary

Adds three tests to `TestParseVscodeLog` in `tests/copilot_usage/test_vscode_parser.py` that exercise the documented `include_partial_tail=True` contract through the public `parse_vscode_log` API.

## Tests Added

1. **`test_parse_vscode_log_includes_partial_tail_single_line`** — verifies the request is returned when the only line in the file lacks a trailing `\n`.
2. **`test_parse_vscode_log_includes_partial_tail_after_complete_lines`** — verifies all three lines are returned when the final ccreq line is unterminated.
3. **`test_private_default_excludes_partial_tail`** — regression contrast confirming `_parse_vscode_log_from_offset` with default `include_partial_tail=False` drops the unterminated line, pinning the semantic difference between the public and private APIs.

## Regression Guard

Changing `include_partial_tail=True` → `False` on line 322 of `vscode_parser.py` now causes tests 1 and 2 to fail.

## Notes

- Test-only change — no production code modified.
- Uses the existing `_make_log_line` helper for consistency.




> [!WARNING]
> <details>
> <summary><strong>⚠️ Firewall blocked 2 domains</strong></summary>
>
> The following domains were blocked by the firewall during workflow execution:
>
> - `astral.sh`
> - `pypi.org`
>
> To allow these domains, add them to the `network.allowed` list in your workflow frontmatter:
>
> ```yaml
> network:
>   allowed:
>     - defaults
>     - "astral.sh"
>     - "pypi.org"
> ```
>
> See [Network Configuration](https://github.github.com/gh-aw/reference/network/) for more information.
>
> </details>


> Generated by [Issue Implementer](https://github.com/microsasa/cli-tools/actions/runs/25281783480/agentic_workflow) · ● 5.4M · [◷](https://github.com/search?q=repo%3Amicrosasa%2Fcli-tools+%22gh-aw-workflow-id%3A+issue-implementer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Issue Implementer, engine: copilot, model: claude-opus-4.6, id: 25281783480, workflow_id: issue-implementer, run: https://github.com/microsasa/cli-tools/actions/runs/25281783480 -->

<!-- gh-aw-workflow-id: issue-implementer -->