### PR TITLE
fix: remove dead `child_ids` field from `_VSCodeDiscoveryCache` (#1174)

### DIFF
--- a/src/copilot_usage/vscode_parser.py
+++ b/src/copilot_usage/vscode_parser.py
@@ -131,8 +131,7 @@ class _VSCodeDiscoveryCache:
     *newest_child_path* / *newest_child_id* store the most recently
     modified immediate child at population time; re-stat'ing this single
     sentinel on a hit detects new window directories added inside an
-    existing session.  *child_ids* is recorded at population time and
-    retained for diagnostics but is not fully rescanned on cache hits.
+    existing session.
 
     **Limitation:** only changes under the cached newest session directory
     are detected by the sentinel.  If a different (older) session directory
@@ -144,7 +143,6 @@ class _VSCodeDiscoveryCache:
     """
 
     root_id: tuple[int, int]  # (st_mtime_ns, st_size) of the logs root
-    child_ids: _ChildIds
     newest_child_path: Path | None  # most-recently-modified session dir
     newest_child_id: tuple[int, int] | None  # its identity at population
     log_paths: tuple[Path, ...]
@@ -298,7 +296,6 @@ def _cached_discover_vscode_logs(base_path: Path | None) -> list[Path]:
         found = sorted(candidate.glob(_GLOB_PATTERN))
         _VSCODE_DISCOVERY_CACHE[candidate] = _VSCodeDiscoveryCache(
             root_id=root_id,
-            child_ids=child_ids,
             newest_child_path=newest_path,
             newest_child_id=newest_id,
             log_paths=tuple(found),

--- a/tests/copilot_usage/test_vscode_parser.py
+++ b/tests/copilot_usage/test_vscode_parser.py
@@ -2716,7 +2716,6 @@ class TestVscodeDiscoveryCacheSkipsGlob:
         cached = _VSCODE_DISCOVERY_CACHE[tmp_path]
         _VSCODE_DISCOVERY_CACHE[tmp_path] = _VSCodeDiscoveryCache(
             root_id=(cached.root_id[0] + 1_000_000_000, cached.root_id[1]),
-            child_ids=cached.child_ids,
             newest_child_path=cached.newest_child_path,
             newest_child_id=cached.newest_child_id,
             log_paths=cached.log_paths,
@@ -2753,7 +2752,8 @@ class TestVscodeDiscoveryCacheSkipsGlob:
         cached = _VSCODE_DISCOVERY_CACHE[tmp_path]
         assert len(cached.log_paths) == 1
         assert cached.root_id == safe_file_identity(tmp_path)
-        assert cached.child_ids == _scan_child_ids(tmp_path)
+        assert cached.newest_child_path is not None
+        assert cached.newest_child_id is not None
 
     def test_new_window_under_existing_session_triggers_rediscovery(
         self, tmp_path: Path
@@ -3267,7 +3267,6 @@ class TestVSCodeDiscoveryCacheIsFrozen:
         """Assigning to a field after construction raises FrozenInstanceError."""
         cache = _VSCodeDiscoveryCache(
             root_id=(0, 0),
-            child_ids=frozenset(),
             newest_child_path=None,
             newest_child_id=None,
             log_paths=(),


### PR DESCRIPTION
## Summary

Remove the unused `child_ids` field from `_VSCodeDiscoveryCache` which was stored on every cache miss but never consulted on cache hits, causing silent memory overhead proportional to the number of session directories.

## Changes

**`src/copilot_usage/vscode_parser.py`:**
- Removed `child_ids: _ChildIds` from `_VSCodeDiscoveryCache` frozen dataclass
- Removed `child_ids=child_ids` from the cache construction in `_cached_discover_vscode_logs`
- Updated dataclass docstring to remove mention of `child_ids` being retained
- Kept `child_ids` as a local variable where it's used (no semantic change)
- Kept `_ChildIds` type alias (still used by `_scan_child_ids` and `_newest_child_from_ids`)

**`tests/copilot_usage/test_vscode_parser.py`:**
- Removed `child_ids=cached.child_ids` kwarg from `test_cache_invalidated_on_root_mtime_change`
- Replaced `assert cached.child_ids == _scan_child_ids(tmp_path)` with assertions on `newest_child_path` and `newest_child_id` fields
- Removed `child_ids=frozenset()` from `TestVSCodeDiscoveryCacheIsFrozen`

Closes #1174




> [!WARNING]
> <details>
> <summary><strong>⚠️ Firewall blocked 3 domains</strong></summary>
>
> The following domains were blocked by the firewall during workflow execution:
>
> - `astral.sh`
> - `pypi.org`
> - `repo.anaconda.com`
>
> To allow these domains, add them to the `network.allowed` list in your workflow frontmatter:
>
> ```yaml
> network:
>   allowed:
>     - defaults
>     - "astral.sh"
>     - "pypi.org"
>     - "repo.anaconda.com"
> ```
>
> See [Network Configuration](https://github.github.com/gh-aw/reference/network/) for more information.
>
> </details>


> Generated by [Issue Implementer](https://github.com/microsasa/cli-tools/actions/runs/25281948351/agentic_workflow) · ● 9.9M · [◷](https://github.com/search?q=repo%3Amicrosasa%2Fcli-tools+%22gh-aw-workflow-id%3A+issue-implementer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Issue Implementer, engine: copilot, model: claude-opus-4.6, id: 25281948351, workflow_id: issue-implementer, run: https://github.com/microsasa/cli-tools/actions/runs/25281948351 -->

<!-- gh-aw-workflow-id: issue-implementer -->