### PR TITLE
test: add direct tests for `_build_event_details` TOOL_EXECUTION_COMPLETE branch (#1180)

### DIFF
--- a/tests/copilot_usage/test_render_detail.py
+++ b/tests/copilot_usage/test_render_detail.py
@@ -999,6 +999,92 @@ class TestBuildEventDetailsSessionShutdown:
 
 
 # ---------------------------------------------------------------------------
+# _build_event_details — TOOL_EXECUTION_COMPLETE arm (issue #1180)
+# ---------------------------------------------------------------------------
+
+
+class TestBuildEventDetailsToolExecutionComplete:
+    """Tests for the TOOL_EXECUTION_COMPLETE branch of _build_event_details."""
+
+    def test_success_with_tool_name_and_model(self) -> None:
+        """success=True, tool_name='bash', model='claude-sonnet-4' → joined output."""
+        ev = SessionEvent(
+            type=EventType.TOOL_EXECUTION_COMPLETE,
+            data={
+                "toolCallId": "tc1",
+                "model": "claude-sonnet-4",
+                "interactionId": "int1",
+                "success": True,
+                "toolTelemetry": {"properties": {"tool_name": "bash"}},
+            },
+        )
+        assert _build_event_details(ev) == "bash  ✓  model=claude-sonnet-4"
+
+    def test_failure_indicator(self) -> None:
+        """success=False, no telemetry → output contains '✗' and no '✓'."""
+        ev = SessionEvent(
+            type=EventType.TOOL_EXECUTION_COMPLETE,
+            data={
+                "toolCallId": "tc2",
+                "success": False,
+            },
+        )
+        detail = _build_event_details(ev)
+        assert "✗" in detail
+        assert "✓" not in detail
+
+    def test_model_absent(self) -> None:
+        """model=None → output does NOT contain 'model='."""
+        ev = SessionEvent(
+            type=EventType.TOOL_EXECUTION_COMPLETE,
+            data={
+                "toolCallId": "tc3",
+                "model": None,
+                "success": True,
+            },
+        )
+        detail = _build_event_details(ev)
+        assert "model=" not in detail
+        assert "✓" in detail
+
+    def test_model_empty_string(self) -> None:
+        """model='' (empty string) → output does NOT contain 'model='."""
+        ev = SessionEvent(
+            type=EventType.TOOL_EXECUTION_COMPLETE,
+            data={
+                "toolCallId": "tc3b",
+                "model": "",
+                "success": True,
+            },
+        )
+        detail = _build_event_details(ev)
+        assert "model=" not in detail
+        assert "✓" in detail
+
+    def test_tool_name_absent_no_telemetry(self) -> None:
+        """toolTelemetry=None → detail starts with '✓' (or '✗'), no leading '  '."""
+        ev = SessionEvent(
+            type=EventType.TOOL_EXECUTION_COMPLETE,
+            data={
+                "toolCallId": "tc4",
+                "success": True,
+                "toolTelemetry": None,
+            },
+        )
+        detail = _build_event_details(ev)
+        assert detail.startswith("✓")
+        assert not detail.startswith("  ")
+
+    def test_malformed_data_returns_empty(self) -> None:
+        """Invalid data triggers ValidationError → returns ''."""
+        ev = SessionEvent(
+            type=EventType.TOOL_EXECUTION_COMPLETE,
+            data={"toolTelemetry": "not_a_dict"},
+        )
+        assert _build_event_details(ev) == ""
+
+
+# ---------------------------------------------------------------------------
 # _render_shutdown_cycles — None timestamp path (issue #1058)
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Closes #1180

## Summary

Adds `TestBuildEventDetailsToolExecutionComplete` in `tests/copilot_usage/test_render_detail.py` with direct tests for the `TOOL_EXECUTION_COMPLETE` branch of `_build_event_details`.

## Tests Added

| Test | Coverage |
|------|----------|
| `test_success_with_tool_name_and_model` | `success=True`, tool_name from telemetry, model present → exact joined output `"bash  ✓  model=claude-sonnet-4"` |
| `test_failure_indicator` | `success=False`, no telemetry → `✗` present, `✓` absent |
| `test_model_absent` | `model=None` → no `model=` in output |
| `test_model_empty_string` | `model=""` → no `model=` in output |
| `test_tool_name_absent_no_telemetry` | `toolTelemetry=None` → detail starts with indicator, no leading separator |
| `test_malformed_data_returns_empty` | Invalid event data triggers `ValidationError` → returns `""` |

Each test calls `_build_event_details(ev)` directly with precise string assertions, following the same pattern used by `TestBuildEventDetailsSessionShutdown` and `TestBuildEventDetailsUserMessage`.




> [!WARNING]
> <details>
> <summary><strong>⚠️ Firewall blocked 3 domains</strong></summary>
>
> The following domains were blocked by the firewall during workflow execution:
>
> - `astral.sh`
> - `pypi.org`
> - `releaseassets.githubusercontent.com`
>
> To allow these domains, add them to the `network.allowed` list in your workflow frontmatter:
>
> ```yaml
> network:
>   allowed:
>     - defaults
>     - "astral.sh"
>     - "pypi.org"
>     - "releaseassets.githubusercontent.com"
> ```
>
> See [Network Configuration](https://github.github.com/gh-aw/reference/network/) for more information.
>
> </details>


> Generated by [Issue Implementer](https://github.com/microsasa/cli-tools/actions/runs/25303916614/agentic_workflow) · ● 20.7M · [◷](https://github.com/search?q=repo%3Amicrosasa%2Fcli-tools+%22gh-aw-workflow-id%3A+issue-implementer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Issue Implementer, engine: copilot, model: claude-opus-4.6, id: 25303916614, workflow_id: issue-implementer, run: https://github.com/microsasa/cli-tools/actions/runs/25303916614 -->

<!-- gh-aw-workflow-id: issue-implementer -->