### PR TITLE
fix: scan all events for first non-None timestamp in `session_start` fallback (#1182)

### DIFF
--- a/src/copilot_usage/render_detail.py
+++ b/src/copilot_usage/render_detail.py
@@ -387,10 +387,9 @@ def render_session_detail(
     session_start = (
         ensure_aware(summary.start_time)
         if summary.start_time is not None
-        else (
-            ensure_aware(events[0].timestamp)
-            if events and events[0].timestamp is not None
-            else datetime.now(tz=UTC)
+        else next(
+            (ensure_aware(ev.timestamp) for ev in events if ev.timestamp is not None),
+            datetime.now(tz=UTC),
         )
     )
     _render_recent_events(events, session_start, target_console=out)

--- a/tests/copilot_usage/test_render_detail.py
+++ b/tests/copilot_usage/test_render_detail.py
@@ -234,6 +234,46 @@ class TestRenderSessionDetailBothTimestampsNone:
 
 
 # ---------------------------------------------------------------------------
+# session_start fallback scans all events for first non-None timestamp (#1182)
+# ---------------------------------------------------------------------------
+
+
+class TestRenderSessionDetailFirstNoneTimestampFallback:
+    """When start_time is None and events[0].timestamp is None, the renderer
+    must scan forward to the first event with a non-None timestamp rather
+    than falling back to datetime.now(tz=UTC), which would clamp every
+    relative-time column to +0:00.
+    """
+
+    def test_relative_times_correct_when_first_event_has_no_timestamp(self) -> None:
+        """events[1] anchors at +0:00, events[2] shows +5:00."""
+        t = datetime(2026, 3, 15, 12, 0, 0, tzinfo=UTC)
+        ev0 = SessionEvent(
+            type=EventType.SESSION_START,
+            timestamp=None,
+            data={},
+        )
+        ev1 = SessionEvent(
+            type=EventType.USER_MESSAGE,
+            timestamp=t,
+            data={"content": "first"},
+        )
+        ev2 = SessionEvent(
+            type=EventType.USER_MESSAGE,
+            timestamp=t + timedelta(minutes=5),
+            data={"content": "second"},
+        )
+        summary = SessionSummary(session_id="null-head-test", start_time=None)
+
+        buf, console = _buf_console()
+        render_session_detail([ev0, ev1, ev2], summary, target_console=console)
+        output = _strip_ansi(buf.getvalue())
+
+        assert "+5:00" in output
+        assert "+0:00" in output
+
+
+# ---------------------------------------------------------------------------
 # Gap — render_session_detail start_time fallback from events (#954)
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Closes #1182

## Problem

In `render_session_detail`, when `summary.start_time` is `None` and `events[0].timestamp` is `None`, the fallback was `datetime.now(tz=UTC)`. This caused all past event timestamps to display `+0:00` in the relative-time column — a silent data-loss bug.

## Fix

Replace the `events[0]`-only check with `next()` to scan **all** events for the first non-`None` timestamp:

```python
session_start = (
    ensure_aware(summary.start_time)
    if summary.start_time is not None
    else next(
        (ensure_aware(ev.timestamp) for ev in events if ev.timestamp is not None),
        datetime.now(tz=UTC),
    )
)
```

`datetime.now(tz=UTC)` remains the final fallback only when **no** event has a timestamp.

## Test

Adds `TestRenderSessionDetailFirstNoneTimestampFallback` with a 3-event scenario:
- `events[0].timestamp = None`
- `events[1].timestamp = T`
- `events[2].timestamp = T + 5min`

Asserts `+5:00` and `+0:00` appear in the rendered output, confirming `events[1]` anchors the timeline.




> [!WARNING]
> <details>
> <summary><strong>⚠️ Firewall blocked 3 domains</strong></summary>
>
> The following domains were blocked by the firewall during workflow execution:
>
> - `astral.sh`
> - `pypi.org`
> - `releaseassets.githubusercontent.com`
>
> To allow these domains, add them to the `network.allowed` list in your workflow frontmatter:
>
> ```yaml
> network:
>   allowed:
>     - defaults
>     - "astral.sh"
>     - "pypi.org"
>     - "releaseassets.githubusercontent.com"
> ```
>
> See [Network Configuration](https://github.github.com/gh-aw/reference/network/) for more information.
>
> </details>


> Generated by [Issue Implementer](https://github.com/microsasa/cli-tools/actions/runs/25316106476/agentic_workflow) · ● 9.5M · [◷](https://github.com/search?q=repo%3Amicrosasa%2Fcli-tools+%22gh-aw-workflow-id%3A+issue-implementer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Issue Implementer, engine: copilot, model: claude-opus-4.6, id: 25316106476, workflow_id: issue-implementer, run: https://github.com/microsasa/cli-tools/actions/runs/25316106476 -->

<!-- gh-aw-workflow-id: issue-implementer -->