### PR TITLE
fix: move vscode lazy imports to module level (#1183)

### DIFF
--- a/src/copilot_usage/cli.py
+++ b/src/copilot_usage/cli.py
@@ -39,6 +39,8 @@ from copilot_usage.report import (
     render_session_detail,
     render_summary,
 )
+from copilot_usage.vscode_parser import get_vscode_summary
+from copilot_usage.vscode_report import render_vscode_summary
 
 __all__: Final[list[str]] = [
     "main",
@@ -592,9 +594,6 @@ def live(ctx: click.Context, path: Path | None) -> None:
 )
 def vscode(vscode_logs: Path | None) -> None:
     """Show usage from VS Code Copilot Chat logs."""
-    from copilot_usage.vscode_parser import get_vscode_summary
-    from copilot_usage.vscode_report import render_vscode_summary
-
     c = Console()
     _print_version_header(target=c)
     summary = get_vscode_summary(vscode_logs)

--- a/tests/copilot_usage/test_cli.py
+++ b/tests/copilot_usage/test_cli.py
@@ -4064,3 +4064,21 @@ class TestSingleConsolePerCommand:
         assert "Copilot Usage" in output
         assert f"v{__version__}" in output
         assert "VS Code Copilot Chat" in output
+
+
+# ---------------------------------------------------------------------------
+# Regression: vscode imports are module-level (not deferred)
+# ---------------------------------------------------------------------------
+
+
+def test_vscode_imports_are_module_level() -> None:
+    """``get_vscode_summary`` and ``render_vscode_summary`` are module-level imports.
+
+    Regression test for GitHub issue #1183: the ``vscode`` command previously
+    used lazy in-function imports, which deferred ``ImportError`` discovery to
+    invocation time instead of failing fast at process start.
+    """
+    import copilot_usage.cli as cli_module
+
+    assert hasattr(cli_module, "get_vscode_summary")
+    assert hasattr(cli_module, "render_vscode_summary")


### PR DESCRIPTION
## Summary

Move `get_vscode_summary` and `render_vscode_summary` imports from inside the `vscode()` function body to the module-level import block in `cli.py`, consistent with every other subcommand (`summary`, `cost`, `live`, `session`).

## Changes

- **`src/copilot_usage/cli.py`** — Moved two `from copilot_usage.*` imports from inside `vscode()` to the top-level import section. Removed the now-redundant in-function import lines.
- **`tests/copilot_usage/test_cli.py`** — Added `test_vscode_imports_are_module_level()` regression test that verifies both symbols are available as module-level attributes of `copilot_usage.cli` (i.e., no longer deferred).

## Why

1. Import errors now surface at process start instead of only when the `vscode` command is invoked.
2. Aligns with the CODING_GUIDELINES.md import convention (standard → third-party → local at module level).
3. Makes the module dependency graph visible to static analysis and readers auditing imports.

Closes #1183




> [!WARNING]
> <details>
> <summary><strong>⚠️ Firewall blocked 4 domains</strong></summary>
>
> The following domains were blocked by the firewall during workflow execution:
>
> - `astral.sh`
> - `index.crates.io`
> - `pypi.org`
> - `releaseassets.githubusercontent.com`
>
> To allow these domains, add them to the `network.allowed` list in your workflow frontmatter:
>
> ```yaml
> network:
>   allowed:
>     - defaults
>     - "astral.sh"
>     - "index.crates.io"
>     - "pypi.org"
>     - "releaseassets.githubusercontent.com"
> ```
>
> See [Network Configuration](https://github.github.com/gh-aw/reference/network/) for more information.
>
> </details>


> Generated by [Issue Implementer](https://github.com/microsasa/cli-tools/actions/runs/25316467857/agentic_workflow) · ● 7.3M · [◷](https://github.com/search?q=repo%3Amicrosasa%2Fcli-tools+%22gh-aw-workflow-id%3A+issue-implementer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Issue Implementer, engine: copilot, model: claude-opus-4.6, id: 25316467857, workflow_id: issue-implementer, run: https://github.com/microsasa/cli-tools/actions/runs/25316467857 -->

<!-- gh-aw-workflow-id: issue-implementer -->