### PR TITLE
test: add 6× ultra-premium multiplier tests (#1186)

### DIFF
--- a/tests/copilot_usage/test_report.py
+++ b/tests/copilot_usage/test_report.py
@@ -494,6 +494,27 @@ class TestRenderLiveSessions:
         output = _capture_output([session])
         assert "~0" in output
 
+    def test_est_cost_ultra_premium_model(self) -> None:
+        """Live session with claude-opus-4.6-1m (6× multiplier) shows correct estimate."""
+        now = datetime.now(tz=UTC)
+        session = SessionSummary(
+            session_id="live-ultraprem-1234",
+            name="Ultra Premium",
+            model="claude-opus-4.6-1m",
+            is_active=True,
+            start_time=now - timedelta(minutes=10),
+            user_messages=5,
+            model_calls=5,
+            model_metrics={
+                "claude-opus-4.6-1m": ModelMetrics(
+                    usage=TokenUsage(outputTokens=2000),
+                )
+            },
+        )
+        output = _capture_output([session])
+        assert "~30" in output  # 5 calls × 6.0 = ~30
+        assert "~15" not in output  # must not be capped at 3×
+
 
 # ---------------------------------------------------------------------------
 # Helpers for session detail tests
@@ -2804,6 +2825,12 @@ class TestEstimatePremiumCost:
         """
         result = _estimate_premium_cost("Claude-Opus-4.6", 10)
         assert result == "~30"
+
+    def test_ultra_premium_tier_model_uses_6x_multiplier(self) -> None:
+        """claude-opus-4.6-1m has a 6× multiplier — must not be capped at 3×."""
+        assert _estimate_premium_cost("claude-opus-4.6-1m", 5) == "~30"  # round(5 * 6.0)
+        assert _estimate_premium_cost("claude-opus-4.6-1m", 1) == "~6"  # round(1 * 6.0)
+        assert _estimate_premium_cost("claude-opus-4.6-1m", 0) == "~0"  # round(0 * 6.0)
 
 
 class TestRenderFullSummaryHelperReuse:


### PR DESCRIPTION
Closes #1186

## Changes

Adds two missing tests that exercise the `claude-opus-4.6-1m` model's **6× multiplier** through the cost-estimation pipeline:

1. **`TestEstimatePremiumCost::test_ultra_premium_tier_model_uses_6x_multiplier`** — verifies `_estimate_premium_cost` correctly applies the 6.0× multiplier (not capped at 3×) for multiple call counts.

2. **`TestRenderLiveSessions::test_est_cost_ultra_premium_model`** — integration test confirming `render_live_sessions` displays `~30` (5 calls × 6.0) and does **not** show `~15` (which would indicate a 3× cap).

These tests guard against the regression scenario described in the issue where refactoring `_estimate_premium_cost` to use `pricing.tier` instead of `pricing.multiplier` would silently underestimate costs for ultra-premium models.




> [!WARNING]
> <details>
> <summary><strong>⚠️ Firewall blocked 2 domains</strong></summary>
>
> The following domains were blocked by the firewall during workflow execution:
>
> - `astral.sh`
> - `pypi.org`
>
> To allow these domains, add them to the `network.allowed` list in your workflow frontmatter:
>
> ```yaml
> network:
>   allowed:
>     - defaults
>     - "astral.sh"
>     - "pypi.org"
> ```
>
> See [Network Configuration](https://github.github.com/gh-aw/reference/network/) for more information.
>
> </details>


> Generated by [Issue Implementer](https://github.com/microsasa/cli-tools/actions/runs/25360922470/agentic_workflow) · ● 6M · [◷](https://github.com/search?q=repo%3Amicrosasa%2Fcli-tools+%22gh-aw-workflow-id%3A+issue-implementer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Issue Implementer, engine: copilot, model: claude-opus-4.6, id: 25360922470, workflow_id: issue-implementer, run: https://github.com/microsasa/cli-tools/actions/runs/25360922470 -->

<!-- gh-aw-workflow-id: issue-implementer -->