### PR TITLE
fix: suppress active period panel for pure-active sessions (#1190)

### DIFF
--- a/src/copilot_usage/render_detail.py
+++ b/src/copilot_usage/render_detail.py
@@ -261,10 +261,14 @@ def _render_active_period(
     *,
     target_console: Console | None = None,
 ) -> None:
-    """Show model calls / messages / tokens since last shutdown (if active)."""
+    """Show model calls / messages / tokens since last shutdown (if active).
+
+    Suppressed for pure-active sessions (no shutdown ever occurred) to avoid
+    a misleading title and duplicate stats already shown in Aggregate Stats.
+    """
     out = target_console or Console()
 
-    if not summary.is_active:
+    if not summary.is_active or not summary.has_shutdown_metrics:
         return
 
     content = (

--- a/tests/copilot_usage/test_render_detail.py
+++ b/tests/copilot_usage/test_render_detail.py
@@ -798,10 +798,11 @@ class TestRenderActivePeriod:
     """Direct unit tests for _render_active_period covering active / inactive."""
 
     def test_active_session_renders_panel(self) -> None:
-        """Active session must render an 'Active Period' panel with stats."""
+        """Active resumed session must render an 'Active Period' panel with stats."""
         summary = SessionSummary(
             session_id="active-test",
             is_active=True,
+            has_shutdown_metrics=True,
             model_calls=3,
             user_messages=2,
             active_model_calls=3,
@@ -822,18 +823,35 @@ class TestRenderActivePeriod:
         _render_active_period(summary, target_console=console)
         assert buf.getvalue() == ""
 
+    def test_pure_active_session_suppressed(self) -> None:
+        """Pure-active session (no shutdown) → panel suppressed (issue #1190)."""
+        summary = SessionSummary(
+            session_id="pure-active",
+            is_active=True,
+            has_shutdown_metrics=False,
+            model_calls=4,
+            user_messages=2,
+            active_model_calls=4,
+            active_user_messages=2,
+            active_output_tokens=800,
+        )
+        buf, console = _buf_console()
+        _render_active_period(summary, target_console=console)
+        assert buf.getvalue() == ""
+
 
 class TestRenderSessionDetailActivePeriod:
-    """Integration test: render_session_detail with is_active=True must
-    render the Active Period panel (issue #879)."""
+    """Integration test: render_session_detail with is_active=True and
+    has_shutdown_metrics=True must render the Active Period panel (issue #879)."""
 
     def test_active_session_shows_active_period_panel(self) -> None:
-        """render_session_detail with is_active=True must include the
-        Active Period panel in its output."""
+        """render_session_detail with is_active=True and has_shutdown_metrics=True
+        must include the Active Period panel in its output."""
         summary = SessionSummary(
             session_id="active-e2e",
             start_time=datetime(2026, 4, 1, 10, 0, 0, tzinfo=UTC),
             is_active=True,
+            has_shutdown_metrics=True,
             model_calls=5,
             user_messages=3,
             active_model_calls=5,
@@ -849,6 +867,30 @@ class TestRenderSessionDetailActivePeriod:
         render_session_detail([ev], summary, target_console=console)
         output = _strip_ansi(buf.getvalue())
         assert "Active Period" in output
+
+    def test_pure_active_session_omits_active_period_panel(self) -> None:
+        """render_session_detail on a pure-active session must NOT include
+        'since last shutdown' in its output (issue #1190)."""
+        summary = SessionSummary(
+            session_id="pure-active-e2e",
+            start_time=datetime(2026, 4, 1, 10, 0, 0, tzinfo=UTC),
+            is_active=True,
+            has_shutdown_metrics=False,
+            model_calls=5,
+            user_messages=3,
+            active_model_calls=5,
+            active_user_messages=3,
+            active_output_tokens=2000,
+        )
+        ev = SessionEvent(
+            type=EventType.USER_MESSAGE,
+            timestamp=datetime(2026, 4, 1, 10, 5, 0, tzinfo=UTC),
+            data={"content": "hello"},
+        )
+        buf, console = _buf_console()
+        render_session_detail([ev], summary, target_console=console)
+        output = _strip_ansi(buf.getvalue())
+        assert "since last shutdown" not in output
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #1190

## Problem

`_render_active_period` in `render_detail.py` unconditionally shows the "🟢 Active Period (since last shutdown)" panel for any active session. For pure-active sessions (no shutdown ever occurred, `has_shutdown_metrics=False`), this causes:

1. **Misleading title** — "since last shutdown" implies a prior shutdown that never happened.
2. **Duplicate data** — the panel repeats the same stats already shown in the Aggregate Stats panel above.

## Fix

Added a `has_shutdown_metrics` guard so the panel is only rendered for resumed sessions (where shutdown data exists and the delta is meaningful):

```python
if not summary.is_active or not summary.has_shutdown_metrics:
    return
```

## Tests

- **Unit test** (`test_pure_active_session_suppressed`): Verifies `_render_active_period` produces no output for a pure-active `SessionSummary`.
- **Integration test** (`test_pure_active_session_omits_active_period_panel`): Verifies `render_session_detail` does not include "since last shutdown" for a pure-active session.
- Updated existing tests to explicitly set `has_shutdown_metrics=True` for resumed-session scenarios.




> [!WARNING]
> <details>
> <summary><strong>⚠️ Firewall blocked 2 domains</strong></summary>
>
> The following domains were blocked by the firewall during workflow execution:
>
> - `astral.sh`
> - `pypi.org`
>
> To allow these domains, add them to the `network.allowed` list in your workflow frontmatter:
>
> ```yaml
> network:
>   allowed:
>     - defaults
>     - "astral.sh"
>     - "pypi.org"
> ```
>
> See [Network Configuration](https://github.github.com/gh-aw/reference/network/) for more information.
>
> </details>


> Generated by [Issue Implementer](https://github.com/microsasa/cli-tools/actions/runs/25372621925/agentic_workflow) · ● 6.5M · [◷](https://github.com/search?q=repo%3Amicrosasa%2Fcli-tools+%22gh-aw-workflow-id%3A+issue-implementer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Issue Implementer, engine: copilot, model: claude-opus-4.6, id: 25372621925, workflow_id: issue-implementer, run: https://github.com/microsasa/cli-tools/actions/runs/25372621925 -->

<!-- gh-aw-workflow-id: issue-implementer -->