### PR TITLE
fix: show '—' for Requests/Premium Cost in model table for pure-active sessions (#1191)

### DIFF
--- a/src/copilot_usage/report.py
+++ b/src/copilot_usage/report.py
@@ -351,10 +351,19 @@ def _render_model_table(
     *,
     title: str = "Per-Model Breakdown",
 ) -> None:
-    """Render the per-model breakdown table."""
+    """Render the per-model breakdown table.
+
+    When all *sessions* are pure-active (no shutdown metrics and still
+    running), Requests and Premium Cost columns display ``"—"`` instead of
+    misleading zeros — mirroring the behaviour of :func:`render_cost_view`.
+    """
     merged = _aggregate_model_metrics(sessions)
     if not merged:
         return
+
+    # Request/cost data is only meaningful when at least one session has
+    # completed shutdown metrics or is no longer active.
+    show_requests = any(s.has_shutdown_metrics or not s.is_active for s in sessions)
 
     table = Table(title=title, border_style="cyan")
     table.add_column("Model", style="bold")
@@ -367,10 +376,12 @@ def _render_model_table(
 
     for model_name in sorted(merged):
         mm = merged[model_name]
+        requests_display = str(mm.requests.count) if show_requests else "—"
+        premium_display = str(mm.requests.cost) if show_requests else "—"
         table.add_row(
             model_name,
-            str(mm.requests.count),
-            str(mm.requests.cost),
+            requests_display,
+            premium_display,
             format_tokens(mm.usage.inputTokens),
             format_tokens(mm.usage.outputTokens),
             format_tokens(mm.usage.cacheReadTokens),

--- a/tests/copilot_usage/test_report.py
+++ b/tests/copilot_usage/test_report.py
@@ -1223,6 +1223,57 @@ class TestRenderSummary:
         # Body should still render the session
         assert "abc123deadbe" in output  # session_display_name truncates to 12 chars
 
+    def test_pure_active_session_shows_dash_for_requests_and_cost(self) -> None:
+        """render_summary shows '—' (not '0') for Requests/Premium Cost on pure-active sessions.
+
+        A pure-active session has is_active=True, has_shutdown_metrics=False,
+        a known model, and non-zero output tokens.  The Requests and Premium
+        Cost values are unknown (not zero) until a shutdown event arrives.
+        """
+        session = SessionSummary(
+            session_id="active-001",
+            start_time=datetime(2026, 4, 10, 12, 0, tzinfo=UTC),
+            name="Active Session",
+            model="claude-sonnet-4",
+            is_active=True,
+            has_shutdown_metrics=False,
+            user_messages=3,
+            model_calls=2,
+            active_user_messages=3,
+            active_model_calls=2,
+            active_output_tokens=2500,
+            model_metrics={
+                "claude-sonnet-4": ModelMetrics(
+                    usage=TokenUsage(outputTokens=2500),
+                )
+            },
+        )
+        output = _capture_summary([session])
+
+        # The model name and output tokens are present.
+        assert "claude-sonnet-4" in output
+        assert "2.5K" in output
+
+        # Requests and Premium Cost must show "—" not "0".
+        # Split output into lines and find the model table row.
+        lines = output.splitlines()
+        model_row = next(
+            (line for line in lines if "claude-sonnet-4" in line), None
+        )
+        assert model_row is not None
+        # The row should contain "—" for the request/cost columns.
+        assert "—" in model_row
+        # The row must NOT show "0" as the requests count (which would be
+        # between the model name and the "—" or the output tokens).
+        # Split by the model name and check the numeric columns that follow.
+        after_model = model_row.split("claude-sonnet-4", 1)[1]
+        # Strip leading/trailing and split by whitespace for column values
+        cols = after_model.split()
+        # cols should be: [Requests, PremiumCost, InputTokens, OutputTokens,
+        #                   CacheRead, CacheWrite]
+        assert cols[0] == "—", f"Requests column should be '—', got '{cols[0]}'"
+        assert cols[1] == "—", f"Premium Cost column should be '—', got '{cols[1]}'"
+
     def test_render_summary_rejects_positional_since(self) -> None:
         """render_summary requires since/until as keyword-only arguments."""
         sessions: list[SessionSummary] = []


### PR DESCRIPTION
Closes #1191

## Problem

`_render_model_table` in `render_summary` displayed `0` for Requests and Premium Cost columns when rendering pure-active sessions (still running, no shutdown event). This is misleading because the data is simply not yet available — not actually zero.

## Fix

Added a `show_requests` guard (mirroring the existing logic in `render_cost_view`) that checks whether any session has shutdown metrics or is no longer active. When all sessions are pure-active, Requests and Premium Cost columns now display `"—"` instead of `"0"`.

The condition used is:
```python
show_requests = any(s.has_shutdown_metrics or not s.is_active for s in sessions)
```

This is consistent with the per-session logic already used in `render_cost_view` (line 686).

## Testing

Added `test_pure_active_session_shows_dash_for_requests_and_cost` to `TestRenderSummary` which:
1. Creates a pure-active session (`is_active=True`, `has_shutdown_metrics=False`, known model, non-zero output tokens)
2. Asserts the model name and output token value appear in the Per-Model Breakdown table
3. Asserts the Requests and Premium Cost cells show `"—"` (not `"0"`)




> [!WARNING]
> <details>
> <summary><strong>⚠️ Firewall blocked 1 domain</strong></summary>
>
> The following domain was blocked by the firewall during workflow execution:
>
> - `pypi.org`
>
> To allow these domains, add them to the `network.allowed` list in your workflow frontmatter:
>
> ```yaml
> network:
>   allowed:
>     - defaults
>     - "pypi.org"
> ```
>
> See [Network Configuration](https://github.github.com/gh-aw/reference/network/) for more information.
>
> </details>


> Generated by [Issue Implementer](https://github.com/microsasa/cli-tools/actions/runs/25372951597/agentic_workflow) · ● 14M · [◷](https://github.com/search?q=repo%3Amicrosasa%2Fcli-tools+%22gh-aw-workflow-id%3A+issue-implementer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Issue Implementer, engine: copilot, model: claude-opus-4.6, id: 25372951597, workflow_id: issue-implementer, run: https://github.com/microsasa/cli-tools/actions/runs/25372951597 -->

<!-- gh-aw-workflow-id: issue-implementer -->