### PR TITLE
test: assert Cache Read column in _render_model_table tests (#1196)

### DIFF
--- a/tests/copilot_usage/test_report.py
+++ b/tests/copilot_usage/test_report.py
@@ -3478,10 +3478,10 @@ class TestFilterSessionsNaiveStartTime:
 
 
 class TestRenderModelTable:
-    """Verify _render_model_table renders the Cache Write column."""
+    """Verify _render_model_table renders both Cache Read and Cache Write columns."""
 
     def test_cache_write_column_present(self) -> None:
-        """Cache Write header and formatted value appear in output."""
+        """Cache Write and Cache Read headers and formatted values appear in output."""
         session = SessionSummary(
             session_id="cw-test",
             model_metrics={
@@ -3502,6 +3502,8 @@ class TestRenderModelTable:
         output = buf.getvalue()
         assert "Cache Write" in output
         assert "5.0K" in output
+        assert "Cache Read" in output
+        assert "8.0K" in output
 
     def test_cache_write_zero_renders(self) -> None:
         """Zero cacheWriteTokens still produces a Cache Write column."""
@@ -3524,6 +3526,52 @@ class TestRenderModelTable:
         _render_model_table(console, [session])
         output = buf.getvalue()
         assert "Cache Write" in output
+
+    def test_cache_read_column_present(self) -> None:
+        """Cache Read header and formatted value appear in output."""
+        session = SessionSummary(
+            session_id="cr-test",
+            model_metrics={
+                "claude-sonnet-4": ModelMetrics(
+                    requests=RequestMetrics(count=3, cost=2),
+                    usage=TokenUsage(
+                        inputTokens=6_000,
+                        outputTokens=1_500,
+                        cacheReadTokens=8_000,
+                        cacheWriteTokens=1_000,
+                    ),
+                )
+            },
+        )
+        buf = StringIO()
+        console = Console(file=buf, force_terminal=True, width=200)
+        _render_model_table(console, [session])
+        output = buf.getvalue()
+        assert "Cache Read" in output
+        assert "8.0K" in output
+
+    def test_cache_read_zero_renders(self) -> None:
+        """Zero cacheReadTokens still produces a Cache Read column header."""
+        session = SessionSummary(
+            session_id="cr-zero",
+            model_metrics={
+                "gpt-5.1": ModelMetrics(
+                    requests=RequestMetrics(count=1, cost=1),
+                    usage=TokenUsage(
+                        inputTokens=100,
+                        outputTokens=50,
+                        cacheReadTokens=0,
+                        cacheWriteTokens=0,
+                    ),
+                )
+            },
+        )
+        buf = StringIO()
+        console = Console(file=buf, force_terminal=True, width=200)
+        _render_model_table(console, [session])
+        output = buf.getvalue()
+        assert "Cache Read" in output
+        assert "0" in output
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

`TestRenderModelTable` only asserted the **Cache Write** column but never verified that the **Cache Read** column header and formatted values appear in `_render_model_table` output.

## Changes

- **`test_cache_write_column_present`** — now also asserts `"Cache Read" in output` and `"8.0K" in output` (the fixture already sets `cacheReadTokens=8_000`)
- **`test_cache_read_column_present`** (new) — dedicated test with `cacheReadTokens=8_000`, asserts header and `"8.0K"`
- **`test_cache_read_zero_renders`** (new) — verifies the column header still appears when `cacheReadTokens=0` and that `"0"` is rendered

These additions ensure any regression that drops or silently zeroes the Cache Read column will be caught.

Closes #1196




> [!WARNING]
> <details>
> <summary><strong>⚠️ Firewall blocked 2 domains</strong></summary>
>
> The following domains were blocked by the firewall during workflow execution:
>
> - `astral.sh`
> - `pypi.org`
>
> To allow these domains, add them to the `network.allowed` list in your workflow frontmatter:
>
> ```yaml
> network:
>   allowed:
>     - defaults
>     - "astral.sh"
>     - "pypi.org"
> ```
>
> See [Network Configuration](https://github.github.com/gh-aw/reference/network/) for more information.
>
> </details>


> Generated by [Issue Implementer](https://github.com/microsasa/cli-tools/actions/runs/25421686616/agentic_workflow) · ● 8.3M · [◷](https://github.com/search?q=repo%3Amicrosasa%2Fcli-tools+%22gh-aw-workflow-id%3A+issue-implementer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Issue Implementer, engine: copilot, model: claude-opus-4.6, id: 25421686616, workflow_id: issue-implementer, run: https://github.com/microsasa/cli-tools/actions/runs/25421686616 -->

<!-- gh-aw-workflow-id: issue-implementer -->