### PR TITLE
test: add pure-active empty-metrics coverage for render_summary (#1197)

### DIFF
--- a/tests/copilot_usage/test_report.py
+++ b/tests/copilot_usage/test_report.py
@@ -1229,6 +1229,40 @@ class TestRenderSummary:
         with pytest.raises(TypeError):
             render_summary(sessions, datetime.now(tz=UTC))  # type: ignore[misc]
 
+    def test_pure_active_empty_metrics_shows_active_output_tokens(self) -> None:
+        """Pure-active session with empty model_metrics shows active_output_tokens in Totals."""
+        session = SessionSummary(
+            session_id="pure-actv-abc",
+            name="Pure Active",
+            is_active=True,
+            model_metrics={},
+            active_output_tokens=1_500,
+            active_model_calls=3,
+            active_user_messages=2,
+            model_calls=3,
+            user_messages=2,
+        )
+        output = _capture_summary([session])
+        assert "1.5K" in output  # format_tokens(1500) == "1.5K"
+
+    def test_pure_active_empty_metrics_no_model_table(self) -> None:
+        """Pure-active session with empty model_metrics must not render per-model table."""
+        session = SessionSummary(
+            session_id="pure-actv-abc",
+            name="Pure Active",
+            is_active=True,
+            model_metrics={},
+            active_output_tokens=1_500,
+            active_model_calls=3,
+            active_user_messages=2,
+            model_calls=3,
+            user_messages=2,
+        )
+        output = _capture_summary([session])
+        # _aggregate_model_metrics returns {} for empty model_metrics,
+        # so no per-model breakdown table should appear.
+        assert "claude-" not in output
+
 
 # ---------------------------------------------------------------------------
 # Coverage gap tests — report.py


### PR DESCRIPTION
Closes #1197

## Summary

Adds two tests to `TestRenderSummary` exercising a pure-active session (never shut down) where `model_metrics={}` but `active_output_tokens > 0`.

## Tests Added

1. **`test_pure_active_empty_metrics_shows_active_output_tokens`** — verifies the Totals panel correctly shows `active_output_tokens` (1.5K) via `total_output_tokens` when `model_metrics` is empty. Guards against regressions where `total_output_tokens` might be incorrectly short-circuited to return 0 for empty-metrics sessions.

2. **`test_pure_active_empty_metrics_no_model_table`** — verifies `_aggregate_model_metrics` returns `{}` for empty `model_metrics` and no per-model breakdown table appears in the `render_summary` output. Guards against regressions where a synthetic model row might be incorrectly added.

## Regression Scenarios Covered

- Change `total_output_tokens` to not return `active_output_tokens` when `model_metrics` is empty → test 1 catches it
- Change `_aggregate_model_metrics` to synthesize a fallback model row for empty-metrics sessions → test 2 catches it




> [!WARNING]
> <details>
> <summary><strong>⚠️ Firewall blocked 2 domains</strong></summary>
>
> The following domains were blocked by the firewall during workflow execution:
>
> - `astral.sh`
> - `pypi.org`
>
> To allow these domains, add them to the `network.allowed` list in your workflow frontmatter:
>
> ```yaml
> network:
>   allowed:
>     - defaults
>     - "astral.sh"
>     - "pypi.org"
> ```
>
> See [Network Configuration](https://github.github.com/gh-aw/reference/network/) for more information.
>
> </details>


> Generated by [Issue Implementer](https://github.com/microsasa/cli-tools/actions/runs/25422050208/agentic_workflow) · ● 8.4M · [◷](https://github.com/search?q=repo%3Amicrosasa%2Fcli-tools+%22gh-aw-workflow-id%3A+issue-implementer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Issue Implementer, engine: copilot, model: claude-opus-4.6, id: 25422050208, workflow_id: issue-implementer, run: https://github.com/microsasa/cli-tools/actions/runs/25422050208 -->

<!-- gh-aw-workflow-id: issue-implementer -->