### PR TITLE
fix: move watchdog Observer import to module level (#1200)

### DIFF
--- a/src/copilot_usage/interactive.py
+++ b/src/copilot_usage/interactive.py
@@ -14,6 +14,7 @@ from loguru import logger
 from rich.console import Console
 from rich.table import Table
 from rich.text import Text
+from watchdog.observers import Observer
 
 from copilot_usage import __version__
 from copilot_usage.models import SessionSummary
@@ -132,8 +133,6 @@ def start_observer(
     treat a ``None`` return as "auto-refresh unavailable" and continue
     without it.
     """
-    from watchdog.observers import Observer
-
     handler: FileChangeEventHandler = FileChangeHandler(change_event)
     observer = Observer()
     observer.schedule(handler, str(session_path), recursive=True)  # pyright: ignore[reportArgumentType]

--- a/tests/copilot_usage/test_interactive.py
+++ b/tests/copilot_usage/test_interactive.py
@@ -1,0 +1,12 @@
+"""Tests for copilot_usage.interactive module."""
+
+import copilot_usage.interactive as _interactive_mod
+from watchdog.observers import Observer
+
+
+def test_watchdog_observer_imported_at_module_level() -> None:
+    """Observer must be importable as a module-level attribute, not deferred."""
+    assert hasattr(_interactive_mod, "Observer"), (
+        "Observer should be imported at module level in interactive.py"
+    )
+    assert _interactive_mod.Observer is Observer


### PR DESCRIPTION
Closes #1200

## Summary

Moves the lazy in-function `from watchdog.observers import Observer` import in `start_observer()` to the module-level import block in `interactive.py`.

## Why

- `watchdog` is a **required** package-level dependency — the lazy import provided no defensive value.
- Violates the coding guideline: "Lazy in-function imports are banned except where already present."
- Import errors now surface at process start rather than at first call to `start_observer()`.

## Changes

- **`src/copilot_usage/interactive.py`** — moved `from watchdog.observers import Observer` to the third-party import section at the top of the module.
- **`tests/copilot_usage/test_interactive.py`** — added test confirming `Observer` is a module-level attribute (not deferred).




> [!WARNING]
> <details>
> <summary><strong>⚠️ Firewall blocked 2 domains</strong></summary>
>
> The following domains were blocked by the firewall during workflow execution:
>
> - `astral.sh`
> - `pypi.org`
>
> To allow these domains, add them to the `network.allowed` list in your workflow frontmatter:
>
> ```yaml
> network:
>   allowed:
>     - defaults
>     - "astral.sh"
>     - "pypi.org"
> ```
>
> See [Network Configuration](https://github.github.com/gh-aw/reference/network/) for more information.
>
> </details>


> Generated by [Issue Implementer](https://github.com/microsasa/cli-tools/actions/runs/25427815943/agentic_workflow) · ● 6.7M · [◷](https://github.com/search?q=repo%3Amicrosasa%2Fcli-tools+%22gh-aw-workflow-id%3A+issue-implementer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Issue Implementer, engine: copilot, model: claude-opus-4.6, id: 25427815943, workflow_id: issue-implementer, run: https://github.com/microsasa/cli-tools/actions/runs/25427815943 -->

<!-- gh-aw-workflow-id: issue-implementer -->